### PR TITLE
Fix: Add missing ENV to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - PGID=${PGID:-1000}
 
       # Redis Configuration
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/1


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updated the Docker Compose file to include additional Redis ENV variables for non-default deployments.