### PR TITLE
fix: resolve release workflow failure (fetch-tags) + Node.js 20 deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   create-release:
@@ -26,6 +27,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        fetch-tags: true
 
     - name: Generate release notes
       id: release_notes


### PR DESCRIPTION
## Summary
- Fix `gh release create` exiting with code 1 — `fetch-tags: false` default caused gh CLI to see the tag as local-only even though it was pushed
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to suppress Node.js 20 deprecation warning for `actions/checkout@v4`

## Root Cause
`actions/checkout@v4` with `fetch-tags: false` (the default) creates a local ref for the triggering tag but `gh release create` validates the tag against the remote, causing: _"tag exists locally but has not been pushed"_ and exit 1.

## Fix
- `fetch-tags: true` on the `create-release` job checkout step
- Workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var

## Test plan
- [ ] Push a new version tag and confirm the Release workflow completes successfully
- [ ] Confirm no Node.js 20 deprecation warning in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)