### PR TITLE
fix: security sweep 2026-05-07 — 3 CVEs + broken dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Development, testing, documentation, and code quality tools
 
 # Include production dependencies
--r requirements-prod.txt
+-r requirements.txt
 
 # Development and Testing
 pytest==9.0.3  # Security: CVE-2025-71176 tmpdir vuln fix

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -24,7 +24,7 @@ httpx==0.25.2
 sqlalchemy[asyncio]>=2.0.23
 aiomysql>=0.2.0
 cryptography>=3.4.8
-python-multipart>=0.0.26  # Security: CVE-2026-24486, CVE-2026-40347 DoS fix
+python-multipart>=0.0.27  # Security: CVE-2026-24486, CVE-2026-40347 DoS fix, CVE-2026-42561 header parsing DoS fix
 
 # Keep pymysql for Flask compatibility during migration
 pymysql>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 fastapi==0.123.0
 starlette>=0.50.0  # Security: Fix GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 uvicorn[standard]==0.24.0
-python-multipart==0.0.26  # Security: CVE-2026-24486 path traversal fix, CVE-2026-40347 DoS fix
+python-multipart==0.0.27  # Security: CVE-2026-24486 path traversal fix, CVE-2026-40347 DoS fix, CVE-2026-42561 header parsing DoS fix
 jinja2==3.1.6
 
 # Flask - Optional backwards compatibility (to be fully removed in future release)
@@ -33,7 +33,7 @@ moviepy==1.0.3
 
 # Data Processing
 python-dateutil==2.8.2
-python-dotenv==1.0.0
+python-dotenv==1.2.2  # Security: CVE-2026-28684 symlink following arbitrary file overwrite fix
 pydantic==2.5.0
 pydantic-settings==2.1.0
 marshmallow==3.26.2
@@ -41,7 +41,7 @@ PyYAML==6.0.1
 
 # HTML Parsing (for AllMusic web scraping)
 beautifulsoup4==4.12.2
-lxml==4.9.3
+lxml==6.1.0  # Security: CVE-2026-41066 XXE local file read fix
 
 # Background Tasks
 celery==5.3.4

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"

--- a/src/api/fastapi/admin.py
+++ b/src/api/fastapi/admin.py
@@ -16,7 +16,6 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import get_current_user as _get_current_user
 from src.database.connection import get_db_session
 from src.database.models import SessionStatus, User, UserRole, UserSession

--- a/src/api/fastapi/advanced_image_processing.py
+++ b/src/api/fastapi/advanced_image_processing.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Body, HTTPException
 from pydantic import BaseModel, Field
-
 from src.jobs.advanced_image_tasks import (
     ImageFormat,
     analyze_large_image_collection,
@@ -445,7 +444,6 @@ async def analyze_image_quality_only(
         import cv2
         import numpy as np
         from PIL import Image
-
         from src.services.image_quality_enhancer import ImageQualityAnalyzer
 
         # Validate paths

--- a/src/api/fastapi/advanced_jobs.py
+++ b/src/api/fastapi/advanced_jobs.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.services.job_queue import (
     BackgroundJob,

--- a/src/api/fastapi/advanced_search.py
+++ b/src/api/fastapi/advanced_search.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.search_models import SearchPresetType

--- a/src/api/fastapi/analytics_reporting.py
+++ b/src/api/fastapi/analytics_reporting.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import FileResponse, HTMLResponse
 from pydantic import BaseModel, Field
-
 from src.services.analytics_service import get_analytics_service
 from src.services.content_analytics_engine import (
     ContentType,

--- a/src/api/fastapi/api_gateway_management.py
+++ b/src/api/fastapi/api_gateway_management.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.services.api_gateway import (
     RouteRule,
     RoutingStrategy,

--- a/src/api/fastapi/artists.py
+++ b/src/api/fastapi/artists.py
@@ -14,7 +14,6 @@ Refactored into: 5 specialized modules for better maintainability
 """
 
 from fastapi import APIRouter
-
 from src.api.fastapi.artists_bulk import router as bulk_router
 from src.api.fastapi.artists_crud import router as crud_router
 from src.api.fastapi.artists_discovery import router as discovery_router

--- a/src/api/fastapi/artists_bulk.py
+++ b/src/api/fastapi/artists_bulk.py
@@ -18,7 +18,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.artists_models import (
     BulkDeleteRequest,
     BulkEditRequest,

--- a/src/api/fastapi/artists_crud.py
+++ b/src/api/fastapi/artists_crud.py
@@ -28,7 +28,6 @@ from fastapi import (
 )
 from sqlalchemy import and_, desc, func, or_
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.artists_models import (
     ArtistCreateRequest,
     ArtistResponse,

--- a/src/api/fastapi/artists_discovery.py
+++ b/src/api/fastapi/artists_discovery.py
@@ -18,7 +18,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.artists_models import ArtistResponse, IMVDbImportRequest
 from src.api.fastapi.auth_dependencies import (
     get_current_user,

--- a/src/api/fastapi/artists_scheduling.py
+++ b/src/api/fastapi/artists_scheduling.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db
 from src.database.models import Artist, ScheduledJob

--- a/src/api/fastapi/artists_thumbnails.py
+++ b/src/api/fastapi/artists_thumbnails.py
@@ -28,7 +28,6 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.artists_models import ThumbnailSearchRequest
 from src.api.fastapi.auth_dependencies import (
     get_current_user,

--- a/src/api/fastapi/auth.py
+++ b/src/api/fastapi/auth.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.services.audit_service import (
     AuditEventType,
@@ -556,7 +555,6 @@ async def auth_health():
     """Check authentication system health"""
     try:
         from sqlalchemy import text
-
         from src.database.connection import get_db
 
         with get_db() as db_session:

--- a/src/api/fastapi/backup_integration.py
+++ b/src/api/fastapi/backup_integration.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-
 from src.integrations.youtube_importer import get_youtube_importer
 from src.services.local_network_share import get_local_network_share
 from src.services.personal_backup import (

--- a/src/api/fastapi/backups.py
+++ b/src/api/fastapi/backups.py
@@ -9,7 +9,6 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.services.backup_service import BackupService, BackupType
 

--- a/src/api/fastapi/bulk_operations.py
+++ b/src/api/fastapi/bulk_operations.py
@@ -18,7 +18,6 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from pydantic import BaseModel, Field, validator
-
 from src.jobs.bulk_media_tasks import (
     BulkMediaProcessor,
     BulkOperationStatus,

--- a/src/api/fastapi/client_generation.py
+++ b/src/api/fastapi/client_generation.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
-
 from src.api.fastapi.client_javascript_generator import generate_javascript_client
 from src.api.fastapi.client_models import (
     ClientConfig,

--- a/src/api/fastapi/collection_management.py
+++ b/src/api/fastapi/collection_management.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-
 from src.services.collection_organizer import (
     OrganizationRule,
     OrganizationStrategy,

--- a/src/api/fastapi/dependency_injection.py
+++ b/src/api/fastapi/dependency_injection.py
@@ -14,7 +14,6 @@ from functools import wraps
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
 from fastapi import Depends, HTTPException, Request
-
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/discogs.py
+++ b/src/api/fastapi/discogs.py
@@ -7,7 +7,6 @@ import asyncio
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/enhanced_artist_discovery.py
+++ b/src/api/fastapi/enhanced_artist_discovery.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.models import Artist

--- a/src/api/fastapi/enhanced_auth.py
+++ b/src/api/fastapi/enhanced_auth.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr, Field, validator
-
 from src.middleware.jwt_auth_middleware import (
     JWTManager,
     TokenConfig,

--- a/src/api/fastapi/filesystem.py
+++ b/src/api/fastapi/filesystem.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/frontend_router.py
+++ b/src/api/fastapi/frontend_router.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-
 from src.api.fastapi.template_system import (
     require_admin,
     require_authentication,

--- a/src/api/fastapi/genres.py
+++ b/src/api/fastapi/genres.py
@@ -5,7 +5,6 @@ Provides genre-related endpoints for video and artist genre management
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db_session
 from src.database.models import Artist, Video
 from src.utils.logger import get_logger

--- a/src/api/fastapi/health.py
+++ b/src/api/fastapi/health.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Optional
 import psutil
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-
 from src.database.connection import get_db_session
 from src.utils.async_subprocess import get_git_branch, get_git_version
 from src.utils.logger import get_logger

--- a/src/api/fastapi/image_processing.py
+++ b/src/api/fastapi/image_processing.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.jobs.image_processing_tasks import (
     ThumbnailSpec,
     submit_bulk_thumbnail_generation,

--- a/src/api/fastapi/imvdb.py
+++ b/src/api/fastapi/imvdb.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/job_management.py
+++ b/src/api/fastapi/job_management.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-
 from src.auth.dependencies import get_current_user_optional
 from src.jobs.base_task import (
     cancel_task,

--- a/src/api/fastapi/jobs.py
+++ b/src/api/fastapi/jobs.py
@@ -6,7 +6,6 @@ This module provides compatibility endpoints and redirects to the new system.
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import RedirectResponse
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.fastapi.jobs")

--- a/src/api/fastapi/lastfm.py
+++ b/src/api/fastapi/lastfm.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/lidarr.py
+++ b/src/api/fastapi/lidarr.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 import requests
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/logging_middleware.py
+++ b/src/api/fastapi/logging_middleware.py
@@ -9,9 +9,8 @@ from typing import Callable
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.utils.structured_logger import CorrelationContext, get_structured_logger
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_structured_logger("mvidarr.api.middleware")
 

--- a/src/api/fastapi/maintenance.py
+++ b/src/api/fastapi/maintenance.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
-
 from src.api.fastapi.template_system import template_system
 from src.services.maintenance_tasks import (
     cleanup_old_job_history,

--- a/src/api/fastapi/media_processing.py
+++ b/src/api/fastapi/media_processing.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
-
 from src.jobs.ffmpeg_processing_tasks import (
     submit_bulk_metadata_task,
     submit_metadata_extraction_task,

--- a/src/api/fastapi/metadata_enrichment.py
+++ b/src/api/fastapi/metadata_enrichment.py
@@ -15,7 +15,6 @@ Original: 1,433 lines → Refactored: 5 files (~200-400 lines each)
 """
 
 from fastapi import APIRouter
-
 from src.utils.logger import get_logger
 
 from .metadata_enrichment_analytics import router as analytics_router

--- a/src/api/fastapi/metadata_enrichment_analytics.py
+++ b/src/api/fastapi/metadata_enrichment_analytics.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db_session
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger

--- a/src/api/fastapi/metadata_enrichment_jobs.py
+++ b/src/api/fastapi/metadata_enrichment_jobs.py
@@ -6,7 +6,6 @@ Job management endpoints (job status, cancel, celery health, celery inspect)
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger
 
@@ -196,7 +195,6 @@ async def clear_completed_jobs(current_user: dict = Depends(require_authenticati
     """Clear completed job history from Redis result backend"""
     try:
         import redis
-
         from src.jobs.celery_app import CELERY_RESULT_BACKEND
 
         # Create Redis connection with timeout
@@ -245,7 +243,6 @@ async def get_celery_inspect(current_user: dict = Depends(require_authentication
         import json
 
         import redis
-
         from src.jobs.celery_app import CELERY_RESULT_BACKEND, celery_app
 
         inspect = celery_app.control.inspect()

--- a/src/api/fastapi/metadata_enrichment_operations.py
+++ b/src/api/fastapi/metadata_enrichment_operations.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy.orm import Session, attributes
-
 from src.database.connection import get_db_session
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger

--- a/src/api/fastapi/metadata_enrichment_search.py
+++ b/src/api/fastapi/metadata_enrichment_search.py
@@ -7,7 +7,6 @@ import asyncio
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/metube.py
+++ b/src/api/fastapi/metube.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.ytdlp_service import ytdlp_service

--- a/src/api/fastapi/mobile_access.py
+++ b/src/api/fastapi/mobile_access.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
-
 from src.services.local_network_share import get_local_network_share
 from src.services.performance_monitor import get_performance_monitor
 from src.utils.logger import get_logger

--- a/src/api/fastapi/monitoring_dashboard.py
+++ b/src/api/fastapi/monitoring_dashboard.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
-
 from src.middleware.auto_scaling_middleware import get_scaling_status
 from src.services.analytics_service import AlertRule, get_analytics_service
 from src.utils.logger import get_logger

--- a/src/api/fastapi/music_recommendations.py
+++ b/src/api/fastapi/music_recommendations.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.services.imvdb_service import imvdb_service
 from src.services.lastfm_service import lastfm_service
 from src.services.music_recommendations import (

--- a/src/api/fastapi/musicbrainz.py
+++ b/src/api/fastapi/musicbrainz.py
@@ -7,7 +7,6 @@ import asyncio
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-
 from src.middleware.fastapi_auth_middleware import require_authentication
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/optimization.py
+++ b/src/api/fastapi/optimization.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.search_optimization_service import search_optimization_service

--- a/src/api/fastapi/performance.py
+++ b/src/api/fastapi/performance.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 import psutil
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.services.performance_monitor import get_performance_monitor
 from src.utils.logger import get_logger

--- a/src/api/fastapi/personal_insights.py
+++ b/src/api/fastapi/personal_insights.py
@@ -10,7 +10,6 @@ from typing import Dict
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
-
 from src.api.fastapi.template_system import template_system
 from src.services.personal_analytics import (
     export_collection_csv,

--- a/src/api/fastapi/playlists.py
+++ b/src/api/fastapi/playlists.py
@@ -13,7 +13,6 @@ Original: 1,480 lines → Refactored: 5 files (~300 lines each)
 """
 
 from fastapi import APIRouter
-
 from src.utils.logger import get_logger
 
 # Import all routers from modular components

--- a/src/api/fastapi/playlists_auth.py
+++ b/src/api/fastapi/playlists_auth.py
@@ -7,7 +7,6 @@ from typing import Dict
 
 from fastapi import HTTPException, Request
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Playlist, User, UserRole
 from src.utils.logger import get_logger

--- a/src/api/fastapi/playlists_crud.py
+++ b/src/api/fastapi/playlists_crud.py
@@ -10,7 +10,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query, Request
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.playlists_auth import UserInfo, get_current_user_from_session
 from src.api.fastapi.playlists_models import (

--- a/src/api/fastapi/playlists_features.py
+++ b/src/api/fastapi/playlists_features.py
@@ -21,7 +21,6 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, RedirectResponse
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.playlists_auth import UserInfo, get_current_user_from_session
 from src.api.fastapi.playlists_models import (
     DynamicPlaylistPreviewRequest,

--- a/src/api/fastapi/playlists_models.py
+++ b/src/api/fastapi/playlists_models.py
@@ -6,7 +6,6 @@ Pydantic models and utility functions for playlist operations
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
-
 from src.database.models import Playlist
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/plex.py
+++ b/src/api/fastapi/plex.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/production_monitoring.py
+++ b/src/api/fastapi/production_monitoring.py
@@ -13,7 +13,6 @@ import psutil
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-
 from src.database.async_connection import get_async_db_manager
 from src.middleware.auto_scaling_middleware import get_scaling_status
 from src.services.media_cache_manager import MediaCacheManager

--- a/src/api/fastapi/request_logging.py
+++ b/src/api/fastapi/request_logging.py
@@ -14,10 +14,9 @@ from typing import Any, Dict, List, Optional
 
 import aiofiles
 from fastapi import FastAPI, Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 logger = get_logger("mvidarr.api.logging")
 

--- a/src/api/fastapi/scheduled_jobs.py
+++ b/src/api/fastapi/scheduled_jobs.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import func
-
 from src.database.connection import get_db
 from src.database.models import Artist, ScheduledJob
 from src.services.scheduler_service_v2 import scheduler_v2

--- a/src/api/fastapi/scheduler_v2.py
+++ b/src/api/fastapi/scheduler_v2.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from pydantic import BaseModel, Field
-
 from src.database.connection import get_db
 from src.database.models import ScheduledJob
 from src.services.scheduler_service_v2 import scheduler_v2

--- a/src/api/fastapi/security.py
+++ b/src/api/fastapi/security.py
@@ -16,7 +16,6 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 

--- a/src/api/fastapi/settings.py
+++ b/src/api/fastapi/settings.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-
 from src.services.settings_service import SettingsService, settings
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/spotify_enhanced.py
+++ b/src/api/fastapi/spotify_enhanced.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import or_
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/system_health.py
+++ b/src/api/fastapi/system_health.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
-
 from src.api.fastapi.template_system import template_system
 from src.services.health_monitoring import (
     get_celery_status,

--- a/src/api/fastapi/template_performance.py
+++ b/src/api/fastapi/template_performance.py
@@ -14,7 +14,6 @@ from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import Request, Response
 from fastapi.responses import HTMLResponse
-
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/template_system.py
+++ b/src/api/fastapi/template_system.py
@@ -14,7 +14,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 
@@ -250,7 +249,6 @@ class AsyncTemplateSystem:
         try:
             # Import here to avoid circular imports
             from sqlalchemy.orm import Session
-
             from src.api.fastapi.themes import router as themes_router
             from src.database.connection import get_db_session
             from src.database.models import CustomTheme, Setting

--- a/src/api/fastapi/themes.py
+++ b/src/api/fastapi/themes.py
@@ -14,7 +14,6 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db_session
 from src.database.models import CustomTheme
 

--- a/src/api/fastapi/two_factor_auth.py
+++ b/src/api/fastapi/two_factor_auth.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import (
     require_admin,
     require_authentication,

--- a/src/api/fastapi/users.py
+++ b/src/api/fastapi/users.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db_session
 from src.database.models import User
 

--- a/src/api/fastapi/video_discovery.py
+++ b/src/api/fastapi/video_discovery.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.models import Artist

--- a/src/api/fastapi/video_indexing.py
+++ b/src/api/fastapi/video_indexing.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.imvdb_service import imvdb_service

--- a/src/api/fastapi/video_indexing_page.py
+++ b/src/api/fastapi/video_indexing_page.py
@@ -8,7 +8,6 @@ import logging
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
-
 from src.api.fastapi.template_system import template_system
 
 logger = logging.getLogger(__name__)

--- a/src/api/fastapi/video_organization.py
+++ b/src/api/fastapi/video_organization.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Path as PathParam
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.job_queue import (

--- a/src/api/fastapi/video_quality.py
+++ b/src/api/fastapi/video_quality.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-
 from src.services.job_queue import BackgroundJob, JobPriority, JobType, get_job_queue
 from src.utils.logger import get_logger
 

--- a/src/api/fastapi/videos.py
+++ b/src/api/fastapi/videos.py
@@ -19,7 +19,6 @@ Refactored into: 10 specialized modules for better maintainability
 """
 
 from fastapi import APIRouter
-
 from src.api.fastapi.videos_blacklist import router as blacklist_router
 from src.api.fastapi.videos_bulk import router as bulk_router
 from src.api.fastapi.videos_crud import router as crud_router

--- a/src/api/fastapi/videos_blacklist.py
+++ b/src/api/fastapi/videos_blacklist.py
@@ -18,7 +18,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/videos_bulk.py
+++ b/src/api/fastapi/videos_bulk.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import get_current_user
 from src.api.fastapi.videos_models import (
     BulkDeleteRequest,

--- a/src/api/fastapi/videos_crud.py
+++ b/src/api/fastapi/videos_crud.py
@@ -24,7 +24,6 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from fastapi import Query
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import get_current_user
 from src.api.fastapi.videos_models import BulkDownloadRequest
 from src.database.connection import get_db_session

--- a/src/api/fastapi/videos_import.py
+++ b/src/api/fastapi/videos_import.py
@@ -15,7 +15,6 @@ from datetime import datetime
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import get_current_user
 from src.database.connection import get_db_session
 from src.database.models import Artist, Video, VideoStatus

--- a/src/api/fastapi/videos_metadata.py
+++ b/src/api/fastapi/videos_metadata.py
@@ -20,7 +20,6 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from sqlalchemy import or_
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import get_current_user
 from src.api.fastapi.videos_models import BulkRefreshMetadataRequest
 from src.database.connection import get_db_session

--- a/src/api/fastapi/videos_models.py
+++ b/src/api/fastapi/videos_models.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
-
 from src.database.models import VideoStatus
 
 # ========================================================================================

--- a/src/api/fastapi/videos_search.py
+++ b/src/api/fastapi/videos_search.py
@@ -21,7 +21,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query, status
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.models import Artist, Video

--- a/src/api/fastapi/videos_streaming.py
+++ b/src/api/fastapi/videos_streaming.py
@@ -23,7 +23,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Request
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.config.config import Config
 from src.database.connection import get_db_session

--- a/src/api/fastapi/videos_thumbnails.py
+++ b/src/api/fastapi/videos_thumbnails.py
@@ -26,7 +26,6 @@ from fastapi import Path as FastAPIPath
 from fastapi import Query, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session, joinedload
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/vlc_streaming.py
+++ b/src/api/fastapi/vlc_streaming.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-
 from src.api.fastapi.auth_dependencies import (
     get_current_user,
     require_authentication,

--- a/src/api/fastapi/webhooks.py
+++ b/src/api/fastapi/webhooks.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field, HttpUrl, validator
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.webhook_service import (

--- a/src/api/fastapi/websocket_integration.py
+++ b/src/api/fastapi/websocket_integration.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, Optional, Set
 
 from fastapi import WebSocket, WebSocketDisconnect
 from fastapi.routing import APIRouter
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.api.websocket_integration")

--- a/src/api/fastapi/websocket_jobs.py
+++ b/src/api/fastapi/websocket_jobs.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
-
 from src.jobs.redis_manager import redis_manager
 
 # Authentication dependency removed for now - WebSocket auth handled separately

--- a/src/api/fastapi/week29_integration.py
+++ b/src/api/fastapi/week29_integration.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import JSONResponse
-
 from src.integrations.youtube_importer import (
     ImportType,
     VideoQuality,

--- a/src/api/fastapi/wizard.py
+++ b/src/api/fastapi/wizard.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.models import WizardState, WizardStatus, WizardStep
@@ -332,7 +331,6 @@ async def create_admin_user(
                     # not the default admin/mvidarr that init_db wrote on first run.
                     try:
                         import bcrypt
-
                         from src.services.settings_service import SettingsService
 
                         password_hash = bcrypt.hashpw(

--- a/src/api/fastapi/wizard_middleware.py
+++ b/src/api/fastapi/wizard_middleware.py
@@ -9,9 +9,8 @@ from typing import Callable
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.database.models import WizardState, WizardStatus
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = logging.getLogger("mvidarr.wizard_middleware")
 

--- a/src/api/fastapi/youtube_playlists.py
+++ b/src/api/fastapi/youtube_playlists.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.youtube_playlist_service import youtube_playlist_service

--- a/src/api/fastapi/youtube_quota.py
+++ b/src/api/fastapi/youtube_quota.py
@@ -5,7 +5,6 @@ Provides real-time visibility into YouTube API quota usage.
 """
 
 from fastapi import APIRouter, Depends
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.utils.youtube_cache import get_youtube_cache
 from src.utils.youtube_quota_tracker import get_quota_tracker

--- a/src/api/fastapi/ytdlp.py
+++ b/src/api/fastapi/ytdlp.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.services.ytdlp_service import ytdlp_service

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import Cookie, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-
 from src.auth.jwt_handler import jwt_handler
 from src.services.async_base_service import AsyncBaseService
 from src.utils.logger import get_logger

--- a/src/auth/jwt_handler.py
+++ b/src/auth/jwt_handler.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional
 import jwt
 from jwt.exceptions import PyJWTError
 from passlib.context import CryptContext
-
 from src.services.async_base_service import AsyncBaseService
 from src.utils.logger import get_logger
 

--- a/src/auth_integration.py
+++ b/src/auth_integration.py
@@ -6,7 +6,6 @@ Integrates authentication middleware, routes, and endpoint protection.
 from datetime import datetime
 
 from flask import Flask, jsonify
-
 from src.api.auth import register_auth_routes
 from src.api.protected_endpoints import (
     apply_authentication_protection,

--- a/src/database/async_connection.py
+++ b/src/database/async_connection.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.pool import QueuePool
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.database.async_connection")

--- a/src/database/bulk_models.py
+++ b/src/database/bulk_models.py
@@ -23,7 +23,6 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.orm import relationship
-
 from src.database.connection import Base
 
 

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -9,7 +9,6 @@ from threading import Lock
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 from sqlalchemy.pool import QueuePool
-
 from src.config.config import Config
 from src.utils.logger import get_logger
 

--- a/src/database/ensure_themes.py
+++ b/src/database/ensure_themes.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 from sqlalchemy import text
-
 from src.database.connection import get_db
 from src.utils.logger import get_logger
 

--- a/src/database/import_export_models.py
+++ b/src/database/import_export_models.py
@@ -21,7 +21,6 @@ from sqlalchemy import (
     String,
 )
 from sqlalchemy.orm import relationship
-
 from src.database.connection import Base
 
 

--- a/src/database/init_db.py
+++ b/src/database/init_db.py
@@ -3,7 +3,6 @@ Database initialization and migration utilities
 """
 
 from sqlalchemy import text
-
 from src.database.connection import Base
 from src.database.models import CustomTheme, Setting, User, WizardState
 from src.utils.logger import get_logger
@@ -205,7 +204,6 @@ def init_default_settings():
 def ensure_default_credentials(force_reset=False):
     """Ensure default authentication credentials exist in settings"""
     import bcrypt
-
     from src.database.connection import get_db
 
     try:

--- a/src/database/job_models.py
+++ b/src/database/job_models.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 from sqlalchemy import JSON, Column, DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import validates
-
 from src.database.models import Base
 from src.services.job_queue import BackgroundJob, JobPriority, JobStatus, JobType
 

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -8,7 +8,6 @@ from typing import Dict, List
 
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
-
 from src.database.connection import get_db
 from src.utils.logger import get_logger
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -11,9 +11,8 @@ from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import relationship, validates
-from werkzeug.security import check_password_hash, generate_password_hash
-
 from src.database.connection import Base
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 class VideoStatus(Enum):

--- a/src/database/performance_optimizations.py
+++ b/src/database/performance_optimizations.py
@@ -4,7 +4,6 @@ Implements strategic indexes and query optimizations for critical bottlenecks
 """
 
 from sqlalchemy import text
-
 from src.database.connection import engine
 from src.database.models import Artist, Download, Video, VideoStatus
 from src.utils.logger import get_logger
@@ -647,7 +646,6 @@ class DatabasePerformanceOptimizer:
     def optimize_video_indexing_stats(self, session):
         """Optimized query for video indexing statistics - FIXED"""
         from sqlalchemy import case, func
-
         from src.database.models import VideoStatus
 
         # Use separate targeted queries to avoid outer join counting issues

--- a/src/database/search_models.py
+++ b/src/database/search_models.py
@@ -12,7 +12,6 @@ from sqlalchemy import JSON, Boolean, Column, DateTime
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import Float, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
-
 from src.database.connection import Base
 
 

--- a/src/integrations/youtube_importer.py
+++ b/src/integrations/youtube_importer.py
@@ -14,7 +14,6 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
 import yt_dlp
-
 from src.services.enhanced_artist_discovery_service import get_enhanced_artist_discovery
 from src.services.music_video_detector import get_music_video_detector
 from src.services.redis_service import get_redis_client

--- a/src/jobs/base_task.py
+++ b/src/jobs/base_task.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from celery import Task
-
 from src.jobs.redis_manager import redis_manager
 from src.utils.logger import get_logger
 

--- a/src/jobs/celery_app.py
+++ b/src/jobs/celery_app.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 from celery import Celery
 from celery.signals import after_setup_logger, worker_ready, worker_shutting_down
 from kombu import Queue
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.jobs.celery_app")

--- a/src/jobs/metadata_tasks.py
+++ b/src/jobs/metadata_tasks.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 from celery import Task
-
 from src.config.config import Config
 from src.database.connection import get_db, init_db_standalone
 from src.database.models import Artist, Video

--- a/src/jobs/redis_manager.py
+++ b/src/jobs/redis_manager.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import redis
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.jobs.redis_manager")

--- a/src/jobs/wizard_tasks.py
+++ b/src/jobs/wizard_tasks.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from celery import Task
-
 from src.database.connection import get_db, init_db_standalone
 from src.jobs.celery_app import celery_app
 from src.services.video_indexing_service import video_indexing_service

--- a/src/middleware/analytics_middleware.py
+++ b/src/middleware/analytics_middleware.py
@@ -10,8 +10,6 @@ from typing import Any, Dict, Optional
 
 import psutil
 from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.middleware.auto_scaling_middleware import ResourceMetrics
 from src.services.analytics_service import (
     MetricPoint,
@@ -19,6 +17,7 @@ from src.services.analytics_service import (
     get_analytics_service,
 )
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger("mvidarr.middleware.analytics")
 

--- a/src/middleware/api_gateway_middleware.py
+++ b/src/middleware/api_gateway_middleware.py
@@ -6,9 +6,6 @@ FastAPI middleware integration for API Gateway functionality
 import asyncio
 
 from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
-
 from src.services.api_gateway import (
     RouteRule,
     RoutingStrategy,
@@ -16,6 +13,8 @@ from src.services.api_gateway import (
     get_api_gateway,
 )
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 logger = get_logger("mvidarr.middleware.api_gateway")
 

--- a/src/middleware/auth_middleware.py
+++ b/src/middleware/auth_middleware.py
@@ -6,7 +6,6 @@ Provides central authentication handling and request context setup.
 from flask import g, jsonify, redirect, request
 from flask import session as flask_session
 from flask import url_for
-
 from src.services.audit_service import AuditEventType, AuditService
 from src.services.auth_service import AuthService
 from src.utils.logger import get_logger

--- a/src/middleware/auto_scaling_middleware.py
+++ b/src/middleware/auto_scaling_middleware.py
@@ -12,10 +12,9 @@ from typing import Any, Dict, List, Optional
 
 import psutil
 from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger("mvidarr.middleware.auto_scaling")
 

--- a/src/middleware/cache_middleware.py
+++ b/src/middleware/cache_middleware.py
@@ -10,10 +10,9 @@ import time
 from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger("mvidarr.middleware.cache")
 

--- a/src/middleware/circuit_breaker_middleware.py
+++ b/src/middleware/circuit_breaker_middleware.py
@@ -11,11 +11,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from fastapi import Request, status
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 logger = get_logger("mvidarr.middleware.circuit_breaker")
 

--- a/src/middleware/dynamic_auth_middleware.py
+++ b/src/middleware/dynamic_auth_middleware.py
@@ -4,7 +4,6 @@ Checks authentication requirements on each request based on database settings.
 """
 
 from flask import jsonify, redirect, render_template, request, session, url_for
-
 from src.services.settings_service import SettingsService
 from src.utils.logger import get_logger
 
@@ -196,7 +195,6 @@ class DynamicAuthMiddleware:
             if is_authenticated and not request.cookies.get("session_token"):
                 try:
                     from flask import after_this_request
-
                     from src.services.session_store import SessionStore
 
                     username = session.get("username", "admin")

--- a/src/middleware/jwt_auth_middleware.py
+++ b/src/middleware/jwt_auth_middleware.py
@@ -13,10 +13,9 @@ from typing import Dict, List, Optional, Tuple
 
 import jwt
 from fastapi import Request, status
+from src.utils.logger import get_logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse, RedirectResponse
-
-from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.middleware.jwt_auth")
 

--- a/src/middleware/performance_middleware.py
+++ b/src/middleware/performance_middleware.py
@@ -7,14 +7,13 @@ import time
 from typing import Callable, Optional
 
 from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
-
 from src.services.performance_monitor import (
     get_performance_monitor,
     track_api_response_time,
     track_error_rate,
 )
 from src.utils.logger import get_logger
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger("mvidarr.middleware.performance")
 

--- a/src/middleware/rate_limiting_middleware.py
+++ b/src/middleware/rate_limiting_middleware.py
@@ -11,10 +11,9 @@ from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple
 
 from fastapi import Request, status
+from src.utils.logger import get_logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-
-from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.middleware.rate_limiting")
 

--- a/src/middleware/security_validation_middleware.py
+++ b/src/middleware/security_validation_middleware.py
@@ -12,10 +12,9 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, Request, status
+from src.utils.logger import get_logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-
-from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.middleware.security_validation")
 

--- a/src/middleware/simple_auth_middleware.py
+++ b/src/middleware/simple_auth_middleware.py
@@ -5,7 +5,6 @@ Simple authentication middleware for single-user system
 from functools import wraps
 
 from flask import jsonify, redirect, request, url_for
-
 from src.services.settings_service import SettingsService
 from src.services.simple_auth_service import SimpleAuthService
 from src.utils.logger import get_logger

--- a/src/security_config.py
+++ b/src/security_config.py
@@ -5,7 +5,6 @@ Security configuration and initialization for MVidarr
 import os
 
 from flask import Flask
-
 from src.utils.logger import get_logger
 from src.utils.security import SecureConfig, apply_security_headers
 

--- a/src/services/advanced_search_service.py
+++ b/src/services/advanced_search_service.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sqlalchemy import and_, desc, or_
 from sqlalchemy.orm import Session, joinedload
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video, VideoStatus
 from src.database.search_models import (

--- a/src/services/allmusic_service.py
+++ b/src/services/allmusic_service.py
@@ -11,7 +11,6 @@ from urllib.parse import quote_plus, urljoin
 
 import requests
 from bs4 import BeautifulSoup
-
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 

--- a/src/services/api_gateway.py
+++ b/src/services/api_gateway.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 import aiohttp
-
 from src.services.analytics_service import (
     MetricPoint,
     MetricType,

--- a/src/services/api_versioning_service.py
+++ b/src/services/api_versioning_service.py
@@ -12,7 +12,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from packaging import version
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.utils.logger import get_logger
 

--- a/src/services/artist_auto_processing_service.py
+++ b/src/services/artist_auto_processing_service.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Any, Dict
 
 from flask import current_app
-
 from src.database.models import Artist
 from src.utils.logger import get_logger
 

--- a/src/services/artist_browser_service.py
+++ b/src/services/artist_browser_service.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import asc, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Artist, Video
 from src.services.enhanced_artist_discovery_service import get_enhanced_artist_discovery

--- a/src/services/async_admin_service.py
+++ b/src/services/async_admin_service.py
@@ -172,7 +172,6 @@ class AsyncAdminService(AsyncBaseService):
             # Database connectivity check
             try:
                 from sqlalchemy import text
-
                 from src.database.async_connection import async_db_manager
 
                 async with async_db_manager.session_scope() as session:

--- a/src/services/async_artist_service.py
+++ b/src/services/async_artist_service.py
@@ -7,7 +7,6 @@ import re
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import text
-
 from src.services.async_base_service import AsyncBaseService, AsyncServiceError
 
 

--- a/src/services/async_base_service.py
+++ b/src/services/async_base_service.py
@@ -12,7 +12,6 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
-
 from src.database.async_connection import async_db_manager
 from src.utils.logger import get_logger
 

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 from flask import request
 from flask import session as flask_session
-
 from src.database.models import User
 from src.utils.logger import get_logger
 

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -16,7 +16,6 @@ except ImportError:
     FLASK_AVAILABLE = False
 
 from sqlalchemy.exc import IntegrityError
-
 from src.database.connection import get_db
 from src.database.models import SessionStatus, User, UserRole, UserSession
 from src.utils.logger import get_logger

--- a/src/services/base_media_server_service.py
+++ b/src/services/base_media_server_service.py
@@ -9,7 +9,6 @@ from typing import Dict, List
 
 import requests
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist
 from src.utils.logger import get_logger

--- a/src/services/bulk_operations_service.py
+++ b/src/services/bulk_operations_service.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
-
 from src.database.bulk_models import (
     BulkOperation,
     BulkOperationAudit,

--- a/src/services/collection_maintenance_service.py
+++ b/src/services/collection_maintenance_service.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import asc, desc, select
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.redis_service import get_redis_client

--- a/src/services/collection_performance_service.py
+++ b/src/services/collection_performance_service.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Optional
 
 import psutil
 from sqlalchemy import func, select
-
 from src.database.async_connection import get_async_session
 from src.database.models import Artist, Video
 from src.services.redis_service import get_redis_client

--- a/src/services/discogs_service.py
+++ b/src/services/discogs_service.py
@@ -13,7 +13,6 @@ from typing import Dict, List, Optional
 from urllib.parse import quote_plus
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.discogs")

--- a/src/services/duplicate_detection_service.py
+++ b/src/services/duplicate_detection_service.py
@@ -12,7 +12,6 @@ from typing import Dict, List
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist, Download, Video
 from src.utils.logger import get_logger

--- a/src/services/dynamic_playlist_service.py
+++ b/src/services/dynamic_playlist_service.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist, Playlist, PlaylistEntry, PlaylistType, Video
 from src.utils.logger import get_logger

--- a/src/services/emby_service.py
+++ b/src/services/emby_service.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
-
 from src.services.base_media_server_service import (
     BaseMediaServerService,
     MediaItem,

--- a/src/services/enhanced_artist_discovery_service.py
+++ b/src/services/enhanced_artist_discovery_service.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional
 
 import requests
 from sqlalchemy import and_, desc
-
 from src.database.connection import get_db
 from src.database.models import Artist
 from src.services.imvdb_service import imvdb_service

--- a/src/services/export_collectors.py
+++ b/src/services/export_collectors.py
@@ -7,7 +7,6 @@ import json
 from typing import Any, Dict, Generator
 
 from sqlalchemy.orm import joinedload
-
 from src.database.connection import get_db
 from src.database.import_export_models import (
     ExportedArtist,

--- a/src/services/export_formatters.py
+++ b/src/services/export_formatters.py
@@ -10,7 +10,6 @@ import zipfile
 from pathlib import Path
 
 import yaml
-
 from src.database.import_export_models import ExportData, ExportFormat, ExportOptions
 from src.services.export_csv_builders import (
     create_artists_csv,

--- a/src/services/export_service.py
+++ b/src/services/export_service.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from sqlalchemy import and_
-
 from src.database.connection import get_db
 from src.database.import_export_models import (
     ExportOperation,

--- a/src/services/ffmpeg_streaming_service.py
+++ b/src/services/ffmpeg_streaming_service.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 
 from flask import Response
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.ffmpeg_streaming")

--- a/src/services/health_monitoring.py
+++ b/src/services/health_monitoring.py
@@ -120,7 +120,6 @@ def get_database_status() -> Dict:
     """
     try:
         from sqlalchemy import text
-
         from src.database.connection import get_db
 
         with get_db() as session:

--- a/src/services/image_thread_pool.py
+++ b/src/services/image_thread_pool.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import psutil
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.image_thread_pool")

--- a/src/services/import_operations.py
+++ b/src/services/import_operations.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
-
 from src.database.import_export_models import (
     ExportedArtist,
     ExportedPlaylist,

--- a/src/services/import_parsers.py
+++ b/src/services/import_parsers.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, List
 
 import defusedxml.ElementTree as ET
 import yaml
-
 from src.database.import_export_models import (
     ExportData,
     ExportedArtist,

--- a/src/services/import_service.py
+++ b/src/services/import_service.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from sqlalchemy import and_
-
 from src.database.connection import get_db
 from src.database.import_export_models import (
     ImportOperation,

--- a/src/services/imvdb/imvdb_client.py
+++ b/src/services/imvdb/imvdb_client.py
@@ -6,7 +6,6 @@ import time
 from typing import Dict, Optional
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.imvdb_client")

--- a/src/services/imvdb_discovery_service.py
+++ b/src/services/imvdb_discovery_service.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional, Set
 
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video, VideoStatus
 from src.services.imvdb_service import imvdb_service

--- a/src/services/jellyfin_service.py
+++ b/src/services/jellyfin_service.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
-
 from src.services.base_media_server_service import (
     BaseMediaServerService,
     MediaItem,

--- a/src/services/lastfm_service.py
+++ b/src/services/lastfm_service.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Dict, List
 
 import requests
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video, VideoStatus
 from src.services.imvdb_service import imvdb_service

--- a/src/services/local_network_share.py
+++ b/src/services/local_network_share.py
@@ -15,11 +15,10 @@ from typing import Any, Dict, List, Optional
 
 import netifaces
 import qrcode
-from zeroconf import ServiceInfo, Zeroconf
-
 from src.services.performance_monitor import get_performance_monitor
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger
+from zeroconf import ServiceInfo, Zeroconf
 
 logger = get_logger("mvidarr.local_network_share")
 

--- a/src/services/maintenance_tasks.py
+++ b/src/services/maintenance_tasks.py
@@ -105,7 +105,6 @@ def optimize_database() -> Dict:
     """
     try:
         from sqlalchemy import text
-
         from src.database.connection import get_db
 
         results = []

--- a/src/services/media_server_sync_service.py
+++ b/src/services/media_server_sync_service.py
@@ -7,7 +7,6 @@ from enum import Enum
 from typing import Dict, List
 
 from sqlalchemy import and_, or_
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video, VideoStatus
 from src.services.base_media_server_service import BaseMediaServerService

--- a/src/services/metadata_artist_enricher.py
+++ b/src/services/metadata_artist_enricher.py
@@ -17,7 +17,6 @@ from typing import Dict, List
 
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
-
 from src.database.connection import get_db
 from src.database.models import Artist
 from src.utils.logger import get_logger

--- a/src/services/metadata_enrichment_service.py
+++ b/src/services/metadata_enrichment_service.py
@@ -18,7 +18,6 @@ Refactored into: 7 specialized modules for better maintainability
 from typing import Dict
 
 from sqlalchemy import or_
-
 from src.database.connection import get_db
 from src.database.models import Artist
 from src.services.allmusic_service import allmusic_service

--- a/src/services/metadata_models.py
+++ b/src/services/metadata_models.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.metadata_models")

--- a/src/services/metadata_validation_service.py
+++ b/src/services/metadata_validation_service.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List
 
 from sqlalchemy import desc, or_
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video
 from src.services.metadata_enrichment_service import metadata_enrichment_service

--- a/src/services/metadata_video_enricher.py
+++ b/src/services/metadata_video_enricher.py
@@ -18,7 +18,6 @@ from typing import Optional
 import requests
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import flag_modified
-
 from src.database.connection import get_db
 from src.database.models import Video
 from src.services.discogs_service import discogs_service

--- a/src/services/mobile_web_service.py
+++ b/src/services/mobile_web_service.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, desc, select
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.playlist_management_service import get_playlist_management_service

--- a/src/services/music_search_service.py
+++ b/src/services/music_search_service.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import and_, asc, desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.enhanced_artist_discovery_service import get_enhanced_artist_discovery

--- a/src/services/musicbrainz_service.py
+++ b/src/services/musicbrainz_service.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 from urllib.parse import quote_plus
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.musicbrainz")

--- a/src/services/network_streaming_service.py
+++ b/src/services/network_streaming_service.py
@@ -15,7 +15,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.redis_service import get_redis_client

--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -11,7 +11,6 @@ from urllib.parse import urlencode
 import requests
 from flask import request
 from flask import session as flask_session
-
 from src.database.connection import get_db
 from src.database.models import User, UserRole, UserSession
 from src.utils.logger import get_logger

--- a/src/services/performance_monitor.py
+++ b/src/services/performance_monitor.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import psutil
-
 from src.services.media_cache_manager import MediaCacheManager
 from src.utils.logger import get_logger
 

--- a/src/services/playlist_management_service.py
+++ b/src/services/playlist_management_service.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import and_, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.enhanced_artist_discovery_service import get_enhanced_artist_discovery

--- a/src/services/plex_service.py
+++ b/src/services/plex_service.py
@@ -9,7 +9,6 @@ from urllib.parse import urljoin
 
 import defusedxml.ElementTree as ET
 import requests
-
 from src.database.connection import get_db
 from src.database.models import Artist
 from src.utils.logger import get_logger

--- a/src/services/scheduler_service_v2.py
+++ b/src/services/scheduler_service_v2.py
@@ -23,7 +23,6 @@ from celery.beat import ScheduleEntry
 from celery.schedules import crontab
 from celery.schedules import schedule as celery_schedule
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist, ScheduledJob
 from src.jobs.celery_app import celery_app

--- a/src/services/search_optimization_service.py
+++ b/src/services/search_optimization_service.py
@@ -8,7 +8,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import text
-
 from src.database.connection import get_db
 from src.utils.logger import get_logger
 

--- a/src/services/search_presets_service.py
+++ b/src/services/search_presets_service.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, desc
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import User
 from src.database.search_models import (

--- a/src/services/simple_auth_service.py
+++ b/src/services/simple_auth_service.py
@@ -7,7 +7,6 @@ import hashlib
 from typing import Optional, Tuple
 
 from flask import session as flask_session
-
 from src.services.settings_service import SettingsService
 from src.utils.logger import get_logger
 

--- a/src/services/smart_home_integration_service.py
+++ b/src/services/smart_home_integration_service.py
@@ -14,7 +14,6 @@ from urllib.parse import urlparse
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.redis_service import get_redis_client

--- a/src/services/spotify_connect_service.py
+++ b/src/services/spotify_connect_service.py
@@ -6,7 +6,6 @@ import time
 from typing import Dict
 
 import requests
-
 from src.services.spotify_service import spotify_service
 from src.utils.logger import get_logger
 

--- a/src/services/spotify_service.py
+++ b/src/services/spotify_service.py
@@ -11,7 +11,6 @@ from urllib.parse import urlencode
 
 import requests
 from sqlalchemy import or_
-
 from src.database.connection import get_db
 from src.database.models import Artist, Video, VideoStatus
 from src.services.imvdb_service import imvdb_service

--- a/src/services/spotify_sync_service.py
+++ b/src/services/spotify_sync_service.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
 from sqlalchemy import and_, or_
-
 from src.database.connection import get_db
 from src.database.models import Artist, Playlist, PlaylistEntry, Video
 from src.services.imvdb_service import imvdb_service

--- a/src/services/sync_manager.py
+++ b/src/services/sync_manager.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import aiofiles
-
 from src.services.personal_backup import CloudProvider, get_personal_backup_service
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger

--- a/src/services/thumbnail_optimization_service.py
+++ b/src/services/thumbnail_optimization_service.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from PIL import Image
-
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 

--- a/src/services/thumbnail_service.py
+++ b/src/services/thumbnail_service.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 
 import requests
 from PIL import Image, ImageOps
-
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 

--- a/src/services/two_factor_service.py
+++ b/src/services/two_factor_service.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pyotp
 import qrcode
-
 from src.database.connection import get_db
 from src.database.models import User
 from src.services.audit_service import AuditService

--- a/src/services/vevo_service.py
+++ b/src/services/vevo_service.py
@@ -12,7 +12,6 @@ from urllib.parse import quote, urljoin
 
 import httpx
 from bs4 import BeautifulSoup
-
 from src.services.media_cache_manager import CacheType, get_media_cache_manager
 from src.services.performance_monitor import track_media_processing_time
 from src.utils.logger import get_logger

--- a/src/services/video_browser_service.py
+++ b/src/services/video_browser_service.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, asc, desc, func, or_, select
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.enhanced_artist_discovery_service import get_enhanced_artist_discovery

--- a/src/services/video_indexing_service.py
+++ b/src/services/video_indexing_service.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from sqlalchemy.exc import IntegrityError
-
 from src.database.connection import get_db
 from src.database.models import Artist, Download, Video, VideoStatus
 from src.services.imvdb_service import imvdb_service

--- a/src/services/video_recovery_service.py
+++ b/src/services/video_recovery_service.py
@@ -6,7 +6,6 @@ import os
 from typing import Optional
 
 from sqlalchemy import and_
-
 from src.database.connection import get_db
 from src.database.models import Video, VideoStatus
 from src.services.settings_service import settings

--- a/src/services/vimeo_service.py
+++ b/src/services/vimeo_service.py
@@ -12,7 +12,6 @@ from urllib.parse import quote, urljoin
 
 import httpx
 from bs4 import BeautifulSoup
-
 from src.services.media_cache_manager import CacheType, get_media_cache_manager
 from src.services.performance_monitor import track_media_processing_time
 from src.utils.logger import get_logger

--- a/src/services/vlc_streaming_service.py
+++ b/src/services/vlc_streaming_service.py
@@ -11,7 +11,6 @@ import subprocess
 import time
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.vlc_streaming")

--- a/src/services/watch_history_service.py
+++ b/src/services/watch_history_service.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
-
 from src.database.async_connection import get_async_session
 from src.database.models import Video
 from src.services.performance_monitor import get_performance_monitor

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import requests
-
 from src.services.settings_service import SettingsService
 from src.utils.logger import get_logger
 

--- a/src/services/websocket_job_events.py
+++ b/src/services/websocket_job_events.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any, Dict, Optional, Set
 
 from flask_socketio import SocketIO, emit, join_room, leave_room
-
 from src.middleware.simple_auth_middleware import get_current_user
 
 from .job_queue import BackgroundJob, JobStatus

--- a/src/services/wikipedia_service.py
+++ b/src/services/wikipedia_service.py
@@ -5,7 +5,6 @@ Wikipedia API service for artist thumbnail retrieval
 import re
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.wikipedia_service")

--- a/src/services/workers/bulk_video_metadata_worker.py
+++ b/src/services/workers/bulk_video_metadata_worker.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional
 
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
-
 from src.database.connection import get_db
 from src.database.models import Video
 from src.services.background_worker_base import HybridWorker

--- a/src/services/workers/metadata_enrichment_worker.py
+++ b/src/services/workers/metadata_enrichment_worker.py
@@ -192,7 +192,6 @@ class MetadataEnrichmentWorker(HybridWorker):
         # Create Flask app context for the enrichment service
         # This is needed because the enrichment service expects Flask context
         from flask import Flask
-
         from src.database.connection import init_db
 
         app = Flask(__name__)

--- a/src/services/youtube_playlist_service.py
+++ b/src/services/youtube_playlist_service.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 
 import requests
 from sqlalchemy.orm import Session
-
 from src.database.connection import get_db
 from src.database.models import Artist, PlaylistMonitor, Video, VideoStatus
 from src.services.settings_service import settings

--- a/src/services/youtube_search_service.py
+++ b/src/services/youtube_search_service.py
@@ -6,7 +6,6 @@ import re
 from typing import Dict, List, Optional
 
 import requests
-
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 from src.utils.youtube_cache import get_youtube_cache

--- a/src/services/youtube_service.py
+++ b/src/services/youtube_service.py
@@ -6,7 +6,6 @@ Handles YouTube API integration for video search and data retrieval
 from typing import Any, Dict, Optional
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)

--- a/src/services/ytdlp_history.py
+++ b/src/services/ytdlp_history.py
@@ -10,7 +10,6 @@ import threading
 from typing import Dict, List
 
 from sqlalchemy.orm import joinedload
-
 from src.database.connection import get_db
 from src.database.models import Artist, Download, Video
 from src.services.settings_service import settings

--- a/src/tasks/scheduled_tasks.py
+++ b/src/tasks/scheduled_tasks.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Optional
 
 from celery import Task
 from celery.utils.log import get_task_logger
-
 from src.database.connection import get_db
 from src.database.models import Artist, Download, ScheduledJob, Video, VideoStatus
 from src.jobs.celery_app import celery_app

--- a/src/testing/load_testing.py
+++ b/src/testing/load_testing.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 import psutil
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.testing.load_testing")

--- a/src/testing/load_testing_framework.py
+++ b/src/testing/load_testing_framework.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 import psutil
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.testing.load")

--- a/src/testing/migration_validation.py
+++ b/src/testing/migration_validation.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import aiohttp
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.testing.migration_validation")

--- a/src/testing/performance_benchmarks.py
+++ b/src/testing/performance_benchmarks.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 import psutil
-
 from src.services.database_service import DatabaseService
 from src.services.redis_service import get_redis_client
 from src.utils.logger import get_logger

--- a/src/utils/async_file_operations.py
+++ b/src/utils/async_file_operations.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import aiofiles
-
 from src.utils.async_subprocess import run_system_command
 from src.utils.logger import get_logger
 

--- a/src/utils/auth_decorators.py
+++ b/src/utils/auth_decorators.py
@@ -7,7 +7,6 @@ from functools import wraps
 from flask import jsonify, redirect, request
 from flask import session as flask_session
 from flask import url_for
-
 from src.database.models import UserRole
 from src.services.auth_service import (
     AuthenticationError,

--- a/src/utils/httpx_async_client.py
+++ b/src/utils/httpx_async_client.py
@@ -11,7 +11,6 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 import httpx
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.utils.httpx_async_client")

--- a/src/utils/performance_tester.py
+++ b/src/utils/performance_tester.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.utils.performance_tester")

--- a/src/utils/performance_testing.py
+++ b/src/utils/performance_testing.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import requests
-
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.performance.testing")


### PR DESCRIPTION
## Summary

- **HIGH** lxml 4.9.3 → 6.1.0 — CVE-2026-41066: XXE allows reading local files via default iterparse()/ETCompatXMLParser() config
- **MEDIUM** python-multipart 0.0.26 → 0.0.27 — CVE-2026-42561: DoS via oversized/repeated multipart headers exhausting CPU in FastAPI/Starlette workers
- **MEDIUM** python-dotenv 1.0.0 → 1.2.2 — CVE-2026-28684: symlink following in set_key() allows arbitrary file overwrite via cross-device rename fallback
- **HOUSEKEEPING** Fixed broken \`-r requirements-prod.txt\` include in requirements-dev.txt (file does not exist) → changed to \`-r requirements.txt\`
- isort import order fixes across src/ for CI compliance
- Version bump 0.12.7 → 0.12.8

## Test plan
- [x] pip-audit clean on requirements.txt (mysqlclient build excluded — no CVEs)
- [x] pip-audit clean on requirements-fastapi.txt
- [x] pip-audit clean on requirements-dev.txt (dev-unique packages, user confirmed health check skip)
- [x] Dependabot alerts #6 (python-dotenv) and #7 (lxml) dismissed
- [x] black + isort formatting verified clean across all of src/