### PR TITLE
fix: security sweep 2026-05-16 — urllib3 CVE-2026-44431/44432

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /app
 COPY requirements.txt requirements-fastapi.txt ./
 
 # Install Python dependencies (both Flask/core and FastAPI)
-RUN pip install --no-cache-dir -r requirements.txt -r requirements-fastapi.txt
+RUN pip install --no-cache-dir --timeout 120 -r requirements.txt -r requirements-fastapi.txt
 
 # Copy application code
 COPY . .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@
 # Development and Testing
 pytest==9.0.3  # Security: CVE-2025-71176 tmpdir vuln fix
 pytest-cov==7.1.0  # Upgraded for pytest 9 compatibility
-pytest-asyncio==0.23.8  # Upgraded for pytest 9 compatibility
+pytest-asyncio==1.3.0  # pytest 9 compatible (requires >=8.2,<10; 0.x series does not support pytest 9.x)
 pytest-flask==1.3.0
 pytest-mock==3.12.0
 
@@ -25,7 +25,7 @@ sphinx-rtd-theme==1.3.0
 
 # Visual Testing and Browser Automation
 playwright==1.40.0
-pytest-playwright==0.4.3
+pytest-playwright==0.7.2
 Pillow==12.2.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
 imagehash==4.3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mysqlclient>=2.2.0
 
 # HTTP and API
 requests==2.33.0  # Security: CVE-2026-25645 predictable temp file creation fix
-urllib3==2.6.3  # Security: CVE-2026-21441 decompression-bomb fix
+urllib3==2.7.0  # Security: CVE-2026-44431 sensitive-header forwarding fix, CVE-2026-44432 decompression-bomb fix
 httpx==0.25.2
 aiohttp==3.13.4  # Security: CVE-2026-22815/34513-34520/34525 header injection + DoS fixes
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.9"
+__version__ = "0.12.10"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

- **urllib3 2.6.3 → 2.7.0** — fixes CVE-2026-44431 (HIGH, CVSS 5.3: sensitive `Authorization`/`Cookie` headers forwarded across origins in proxied low-level redirects) and CVE-2026-44432 (HIGH, CVSS 7.5: decompression-bomb safeguards bypassed in streaming API). Closes Dependabot alerts #8 and #9.
- **pytest-asyncio 0.23.8 → 1.3.0** — 0.x series requires `pytest<9`; 1.3.0 requires `pytest>=8.2,<10`. Fixes broken dependency constraint that silently prevented pip-audit and the test suite from running against `requirements-dev.txt`.
- **pytest-playwright 0.4.3 → 0.7.2** — 0.4.3 requires `pytest<8.0.0`, incompatible with pinned `pytest==9.0.3`. 0.7.2 requires `pytest>=6.2.4,<10.0.0`.
- **Dockerfile** — added `--timeout 120` to `pip install` to prevent read timeouts on slow PyPI connections during Docker builds.
- **Version bump** — 0.12.9 → 0.12.10

## Test plan

- [x] pip-audit clean on all requirements files (requirements.txt, requirements-dev.txt, requirements-fastapi.txt)
- [x] Docker dev stack built successfully with urllib3 2.7.0 installed (confirmed via `pip show urllib3`)
- [x] Health endpoint `http://localhost:5001/health` returns `{"status": "healthy"}` — all 3 containers healthy
- [x] Dependabot alerts #8 and #9 will auto-close after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)