### PR TITLE
chore: Dependabot sweep 2026-06-01 — pip bumps + Actions upgrades

### DIFF
--- a/.github/workflows/archived/auth-security.yml
+++ b/.github/workflows/archived/auth-security.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6

--- a/.github/workflows/archived/ci.yml
+++ b/.github/workflows/archived/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -270,7 +270,7 @@ jobs:
       actions: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6
@@ -404,13 +404,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -429,7 +429,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile.production

--- a/.github/workflows/archived/compliance-monitoring.yml
+++ b/.github/workflows/archived/compliance-monitoring.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6
@@ -186,7 +186,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: CIS Control 1 - Inventory and Control of Hardware Assets
       run: |
@@ -321,7 +321,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: NIST Identify Function
       run: |
@@ -456,7 +456,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Download compliance artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/archived/incident-response.yml
+++ b/.github/workflows/archived/incident-response.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Initialize incident response
       run: |
@@ -241,7 +241,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Implement containment measures
       run: |
@@ -312,7 +312,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Assess incident impact
       run: |
@@ -365,7 +365,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Develop recovery plan
       run: |

--- a/.github/workflows/archived/kubernetes-deployment.yml
+++ b/.github/workflows/archived/kubernetes-deployment.yml
@@ -58,7 +58,7 @@ jobs:
       istio-changed: ${{ steps.changes.outputs.istio }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -136,13 +136,13 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -187,7 +187,7 @@ jobs:
       url: https://dev.mvidarr.example.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure kubectl
         run: |
@@ -243,7 +243,7 @@ jobs:
       url: https://staging.mvidarr.example.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure kubectl
         run: |
@@ -300,7 +300,7 @@ jobs:
       url: https://mvidarr.example.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/archived/secret-scan.yml
+++ b/.github/workflows/archived/secret-scan.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Full history for comprehensive secret detection
 

--- a/.github/workflows/archived/security-policy-enforcement.yml
+++ b/.github/workflows/archived/security-policy-enforcement.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Initialize policy enforcement
       run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
           --tmpfs /var/lib/mysql-logs:rw,noexec,nosuid,size=128m
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -148,7 +148,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -181,13 +181,13 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -207,7 +207,7 @@ jobs:
           type=sha
     
     - name: Build and push Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile.production
@@ -228,7 +228,7 @@ jobs:
     environment: production
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Deploy to production
       run: |
@@ -248,7 +248,7 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Create release assets
       run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile.production
@@ -67,7 +67,7 @@ jobs:
 
     - name: Build development image
       if: github.ref == 'refs/heads/dev'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile.production

--- a/.github/workflows/docker-size-monitoring.yml
+++ b/.github/workflows/docker-size-monitoring.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -34,7 +34,7 @@ jobs:
         sudo apt-get install -y bc
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
 
     - name: Comment on PR or Issue
       if: github.event_name == 'workflow_run' && steps.monitor.outputs.exit_code != '0'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const exitCode = '${{ steps.monitor.outputs.exit_code }}';

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.190.0
@@ -99,4 +99,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -131,13 +131,13 @@ jobs:
         
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -152,7 +152,7 @@ jobs:
 
     - name: Build and push by digest
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile.production
@@ -167,7 +167,7 @@ jobs:
     
     steps:
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -201,7 +201,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Create source archive
       run: |
@@ -251,7 +251,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6

--- a/.github/workflows/unified-security.yml
+++ b/.github/workflows/unified-security.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -1,6 +1,6 @@
 # FastAPI Core Framework
 fastapi==0.136.3
-starlette>=1.0.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
+starlette>=1.2.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0
 
@@ -12,7 +12,7 @@ websockets==12.0
 jinja2==3.1.6
 
 # Static files serving
-aiofiles==23.2.1
+aiofiles==25.1.0
 
 # Validation and serialization  
 pydantic==2.13.4
@@ -31,7 +31,7 @@ python-multipart>=0.0.27  # Security: CVE-2026-24486, CVE-2026-40347 DoS fix, CV
 pymysql>=1.0.2
 
 # Security utilities
-werkzeug>=3.1.5  # Security: CVE-2026-21860
+werkzeug>=3.1.8  # Security: CVE-2026-21860
 
 # Background job dependencies (already installed)
 # asyncio (built-in)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # Core Framework - FastAPI primary, Flask for backwards compatibility
 fastapi==0.136.3
-starlette>=1.0.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
+starlette>=1.2.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0
 python-multipart==0.0.27  # Security: CVE-2026-24486 path traversal fix, CVE-2026-40347 DoS fix, CVE-2026-42561 header parsing DoS fix
@@ -33,12 +33,12 @@ python-ffmpeg==2.0.12
 moviepy==1.0.3
 
 # Data Processing
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-dotenv==1.2.2  # Security: CVE-2026-28684 symlink following arbitrary file overwrite fix
 pydantic==2.13.4
 pydantic-settings==2.14.1
 marshmallow==3.26.2
-PyYAML==6.0.1
+PyYAML==6.0.3
 
 # HTML Parsing (for AllMusic web scraping)
 beautifulsoup4==4.12.2
@@ -50,7 +50,7 @@ redis==5.0.1
 flower==2.0.1
 
 # Security
-werkzeug==3.1.6  # Security: CVE-2026-21860, CVE-2026-27199 Windows device names fix
+werkzeug==3.1.8  # Security: CVE-2026-21860, CVE-2026-27199 Windows device names fix
 bcrypt==4.1.2
 cryptography>=42.0.0
 PyJWT==2.12.0  # Security: CVE-2026-32597 crit header validation fix
@@ -78,7 +78,7 @@ sentry-sdk==2.8.0
 
 # Additional utilities
 yarl>=1.12.0
-aiofiles==23.2.1
+aiofiles==25.1.0
 python-slugify==8.0.1
 bleach==6.1.0
 humanize==4.9.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.11"
+__version__ = "0.12.12"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

Consolidates 10 Dependabot PRs (#215–#222, #224–#225) into one commit to avoid sequential merge conflicts.

### Pip dependencies
- **aiofiles** 23.2.1 → 25.1.0 (year-based versioning, stable API)
- **starlette** >=1.0.1 → >=1.2.1 (already resolving to 1.2.1, tightens pin)
- **python-dateutil** 2.8.2 → 2.9.0.post0
- **werkzeug** 3.1.6 → 3.1.8
- **PyYAML** 6.0.1 → 6.0.3

### GitHub Actions (Node.js 24 compatible versions)
- **actions/checkout** v5 → v6
- **docker/login-action** v3 → v4
- **docker/build-push-action** v6 → v7
- **actions/github-script** v7 → v9
- **actions/deploy-pages** v4 → v5

### Deferred
- **#223** (python 3.12-slim → 3.14-slim): Deferred — major Python version jump risks breaking native extension builds (mysqlclient, netifaces, opencv). Requires test build first.

### Version
0.12.11 → 0.12.12

## Test plan
- [x] pip-audit clean on all three requirements files
- [x] All Actions bumps verified against official release pages
- [ ] CI/CD green after merge