### PR TITLE
fix: security sweep 2026-06-02 — PyJWT 2.12.0 → 2.13.0 (5 CVEs)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ flower==2.0.1
 werkzeug==3.1.8  # Security: CVE-2026-21860, CVE-2026-27199 Windows device names fix
 bcrypt==4.1.2
 cryptography>=42.0.0
-PyJWT==2.12.0  # Security: CVE-2026-32597 crit header validation fix
+PyJWT==2.13.0  # Security: CVE-2026-32597 crit header validation fix, PYSEC-2026-175/176/177/178/179 JWKS/HMAC/DoS fixes
 passlib==1.7.4
 pyotp==2.9.0
 qrcode==7.4.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.13"
+__version__ = "0.12.14"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

- **PyJWT 2.12.0 → 2.13.0** — fixes 5 vulnerabilities found by pip-audit:
  - PYSEC-2026-179: HMAC algorithm confusion (issuer public key usable as HMAC secret)
  - PYSEC-2026-178: Detached JWS DoS via oversized unencoded payload (CPU/memory burn on invalid sig)
  - PYSEC-2026-177: Unbounded JWKS fetches via unknown kid header (unauthenticated DoS)
  - PYSEC-2026-176: Algorithm allow-list bypass via PyJWK key object binding
  - PYSEC-2026-175: PyJWKClient SSRF via file://, ftp://, data:// URI schemes
- **Version bumped to 0.12.14**

### Note on the 3 open code scanning alerts (zeroconf CVE-2026-47180/83/84)
These are **stale alerts** — Trivy scanned commit `2dd4904` which had `zeroconf==0.132.2`. The fix to `0.149.7` (threshold: `>=0.149.5`) was already merged in v0.12.11. A fresh security scan was triggered manually and will auto-close these alerts once it completes.

## Test plan

- [x] pip-audit clean on requirements.txt — no known vulnerabilities found
- [x] pip-audit clean on requirements-dev.txt — no known vulnerabilities found
- [x] black + isort formatting passes (378 files unchanged)
- [x] Security scan re-triggered on main to clear stale zeroconf alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)