### PR TITLE
fix: security sweep 2026-06-06 — aiohttp CVEs + dependency updates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -195,7 +195,7 @@ jobs:
     
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -12,6 +12,6 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5
         with:
           process-only: 'issues'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,9 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: dessant/lock-threads@v5
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      - uses: dessant/lock-threads@v6
         with:
           issue-inactive-days: '90'
           exclude-issue-created-before: ''

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -87,7 +87,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,14 +15,14 @@ Flask-Session==0.8.0
 # Database
 SQLAlchemy==2.0.23
 PyMySQL==1.1.1
-alembic==1.13.1
+alembic==1.18.4
 mysqlclient>=2.2.0
 
 # HTTP and API
-requests==2.33.0  # Security: CVE-2026-25645 predictable temp file creation fix
+requests==2.34.2  # Security: CVE-2026-25645 predictable temp file creation fix
 urllib3==2.7.0  # Security: CVE-2026-44431 sensitive-header forwarding fix, CVE-2026-44432 decompression-bomb fix
 httpx==0.25.2
-aiohttp==3.13.4  # Security: CVE-2026-22815/34513-34520/34525 header injection + DoS fixes
+aiohttp==3.14.0  # Security: CVE-2026-22815/34513-34520/34525 header injection + DoS fixes, CVE-2026-34993 CookieJar deserialization RCE fix, CVE-2026-47265 cross-origin cookie leak fix
 
 # Image Processing
 Pillow==12.2.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
@@ -51,7 +51,7 @@ flower==2.0.1
 
 # Security
 werkzeug==3.1.8  # Security: CVE-2026-21860, CVE-2026-27199 Windows device names fix
-bcrypt==4.1.2
+bcrypt==5.0.0
 cryptography>=42.0.0
 PyJWT==2.13.0  # Security: CVE-2026-32597 crit header validation fix, PYSEC-2026-175/176/177/178/179 JWKS/HMAC/DoS fixes
 passlib==1.7.4
@@ -66,7 +66,7 @@ tqdm==4.66.3
 psutil==5.9.6
 schedule==1.2.0
 netifaces==0.11.0
-zeroconf==0.149.7
+zeroconf==0.149.16
 
 # Monitoring and Logging
 prometheus-client==0.19.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.14"
+__version__ = "0.12.15"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"

--- a/src/services/simple_auth_service.py
+++ b/src/services/simple_auth_service.py
@@ -49,6 +49,9 @@ class SimpleAuthService:
             if len(password) < 8:
                 return False, "Password must be at least 8 characters long"
 
+            if len(password.encode()) > 72:
+                return False, "Password must be 72 bytes or fewer"
+
             # Hash password using bcrypt
             import bcrypt
 
@@ -109,13 +112,20 @@ class SimpleAuthService:
                 password_sha256 = hashlib.sha256(password.encode()).hexdigest()
                 if password_sha256 == stored_password_hash:
                     # Password matches - migrate to bcrypt
-                    new_hash = bcrypt.hashpw(
-                        password.encode(), bcrypt.gensalt()
-                    ).decode()
-                    SettingsService.set("simple_auth_password", new_hash)
-                    logger.info(
-                        f"User authenticated and password migrated to bcrypt: {username}"
-                    )
+                    try:
+                        new_hash = bcrypt.hashpw(
+                            password.encode(), bcrypt.gensalt()
+                        ).decode()
+                        SettingsService.set("simple_auth_password", new_hash)
+                        logger.info(
+                            f"User authenticated and password migrated to bcrypt: {username}"
+                        )
+                    except ValueError:
+                        # bcrypt 5.0.0+ raises ValueError for passwords > 72 bytes;
+                        # skip migration and leave legacy hash in place
+                        logger.warning(
+                            f"bcrypt migration skipped for {username}: password exceeds 72 bytes"
+                        )
                     return True, "Authentication successful"
                 else:
                     return False, "Invalid username or password"


### PR DESCRIPTION
## Summary

- **CVE-2026-34993** aiohttp 3.13.4 → 3.14.0: \`CookieJar.load()\` deserialization → arbitrary code execution (MEDIUM)
- **CVE-2026-47265** aiohttp 3.13.4 → 3.14.0: per-request cookies leaked via cross-origin redirect (MEDIUM)
- **bcrypt 4.1.2 → 5.0.0**: breaking change — passwords >72 bytes now raise \`ValueError\` instead of silently truncating; added explicit guard in \`simple_auth_service.py\`
- **requests** 2.33.0 → 2.34.2, **alembic** 1.13.1 → 1.18.4, **zeroconf** 0.149.7 → 0.149.16
- **GitHub Actions Node 24**: docker/metadata-action v6, upload-pages-artifact v5, labeler v6, label-actions v5, lock-threads v6 (removed \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` workaround)
- Version bumped 0.12.14 → 0.12.15
- Supersedes Dependabot PRs #230, #231, #232, #233, #234, #235, #236, #237, #238, #239

## Test plan

- [x] pip-audit clean on requirements.txt and requirements-dev.txt (no known vulnerabilities)
- [x] pip check — no broken requirements
- [x] black/isort formatting clean across src/
- [ ] CI full test suite passes on this PR
- [ ] Health endpoint 200 after Docker rebuild (Step 9)