### PR TITLE
chore: remove unused moviepy dependency, fix Dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,18 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly
 
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ opencv-python-headless>=4.13.0.92
 
 # Media Processing
 python-ffmpeg==2.0.12
-moviepy==1.0.3
 
 # Data Processing
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
- Remove `moviepy==1.0.3` from `requirements.txt` — verified zero imports anywhere in the codebase via repo-wide grep, and already flagged as removable in `docs/DOCKER_OPTIMIZATION_GUIDE.md`. Closes the need for PR #247 (moviepy 1.0.3 -> 2.2.1, a major version bump with breaking changes for an unused 80MB dependency), which has been closed.
- Add `target-branch: dev` to all three `.github/dependabot.yml` update blocks (pip, docker, github-actions) so future Dependabot PRs follow the dev-first branch strategy in CLAUDE.md instead of opening directly against `main`.

## Test plan
- [x] `pip check` — no broken requirements after removal
- [x] `black --check src/` and `isort --profile black --check-only src/` — clean
- [x] No `.py` files reference `moviepy`, `MoviePy`, `VideoFileClip`, or `ImageSequenceClip`