### PR TITLE
fix: security sweep 2026-06-19 — v0.12.16

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
           --tmpfs /var/lib/mysql-logs:rw,noexec,nosuid,size=128m
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -148,7 +148,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -181,7 +181,7 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -228,7 +228,7 @@ jobs:
     environment: production
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Deploy to production
       run: |
@@ -248,7 +248,7 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Create release assets
       run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/workflows/docker-size-monitoring.yml
+++ b/.github/workflows/docker-size-monitoring.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.313.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -131,7 +131,7 @@ jobs:
         
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -201,7 +201,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Create source archive
       run: |
@@ -251,7 +251,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6

--- a/.github/workflows/unified-security.yml
+++ b/.github/workflows/unified-security.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -1,6 +1,6 @@
 # FastAPI Core Framework
 fastapi==0.136.3
-starlette>=1.2.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
+starlette>=1.3.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0
 
@@ -25,7 +25,7 @@ httpx==0.25.2
 sqlalchemy[asyncio]>=2.0.23
 aiomysql>=0.2.0
 cryptography>=48.0.1
-python-multipart>=0.0.27  # Security: CVE-2026-24486, CVE-2026-40347 DoS fix, CVE-2026-42561 header parsing DoS fix
+python-multipart>=0.0.32  # Security: CVE-2026-53539 quadratic CPU DoS fix, CVE-2026-53538 parameter smuggling fix, CVE-2026-53537 Content-Disposition smuggling fix, CVE-2026-45152 negative Content-Length fix
 
 # Keep pymysql for Flask compatibility during migration
 pymysql>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 
 # Core Framework - FastAPI primary, Flask for backwards compatibility
 fastapi==0.136.3
-starlette>=1.2.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
+starlette>=1.3.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0
-python-multipart==0.0.27  # Security: CVE-2026-24486 path traversal fix, CVE-2026-40347 DoS fix, CVE-2026-42561 header parsing DoS fix
+python-multipart==0.0.32  # Security: CVE-2026-53539 quadratic CPU DoS fix, CVE-2026-53538 parameter smuggling fix, CVE-2026-53537 Content-Disposition smuggling fix, CVE-2026-45152 negative Content-Length fix
 jinja2==3.1.6
 
 # Flask - Optional backwards compatibility (to be fully removed in future release)
@@ -70,7 +70,7 @@ zeroconf==0.149.16
 # Monitoring and Logging
 prometheus-client==0.19.0
 structlog==23.2.0
-sentry-sdk==2.8.0
+sentry-sdk==2.63.0
 
 # Production Server - ASGI (FastAPI)
 # uvicorn already included in fastapi dependencies above
@@ -79,7 +79,7 @@ sentry-sdk==2.8.0
 yarl>=1.12.0
 aiofiles==25.1.0
 python-slugify==8.0.1
-bleach==6.1.0
+bleach==6.4.0  # Security: Dependabot #20 formaction URI scheme bypass fix, #19 Unicode URI sanitization fix
 humanize==4.9.0
 
 # Video processing (legacy support)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.15"
+__version__ = "0.12.16"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

Security dependency upgrades + non-security Dependabot processing for v0.12.16.

### Security Fixes

| Severity | Package | From | To | CVEs/Alerts |
|----------|---------|------|----|-------------|
| HIGH (CVSS 7.5) | python-multipart | 0.0.27 | 0.0.32 | CVE-2026-53539 quadratic CPU DoS — crafted form body exhausts workers |
| MEDIUM (CVSS 6.1) | bleach | 6.1.0 | 6.4.0 | Dependabot #20: `formaction` URI scheme bypass allows `javascript:` through sanitizer |
| LOW | python-multipart | 0.0.27 | 0.0.32 | CVE-2026-53538 semicolon parameter smuggling |
| LOW | python-multipart | 0.0.27 | 0.0.32 | CVE-2026-53537 Content-Disposition RFC 2231 smuggling |
| LOW | python-multipart | 0.0.27 | 0.0.32 | CVE-2026-45152 negative Content-Length buffers full body |
| LOW | bleach | 6.1.0 | 6.4.0 | Dependabot #19: Unicode > U+00A0 URI sanitization bypass |

Closes Dependabot alerts: #15 #16 #17 #18 #19 #20

### Non-Security Dependabot PRs (included)

- **sentry-sdk** 2.8.0 → 2.63.0 — 2.x series backward-compat; includes FastAPI 0.137 double-wrap fix. Supersedes PR #257
- **starlette floor** >=1.2.1 → >=1.3.1 in requirements.txt + requirements-fastapi.txt. Supersedes PR #254
- **actions/checkout** v6 → v7 across 8 active workflows — v7 blocks unsafe fork PR checkout attack. Supersedes PR #256

Supersedes (will close): Dependabot PRs #252 #254 #255 #256 #257 #258

Deferred: qrcode 7.4.2 → 8.2 (Dependabot PR #253) — major version bump, no security urgency, needs API compatibility review.

## Test plan

- [x] pip-audit clean on requirements.txt — `No known vulnerabilities found`
- [x] pip-audit clean on requirements-dev.txt — `No known vulnerabilities found`
- [x] pip check on changed packages (python-multipart, bleach, sentry-sdk, starlette, fastapi) — `No broken requirements found`
- [x] black + isort formatting — `378 files left unchanged`
- [ ] Health endpoint 200 on localhost:5000 after merge
- [ ] pytest suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)