### PR TITLE
chore: dependency sweep v0.12.18 (Dependabot PRs #269-274)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
         
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.314.0
+        uses: ruby/setup-ruby@v1.315.0
         with:
           ruby-version: '3.1'
           bundler-cache: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ sphinx-rtd-theme==1.3.0
 # Visual Testing and Browser Automation
 playwright==1.40.0
 pytest-playwright==0.7.2
-Pillow==12.2.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
+Pillow==12.3.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
 imagehash==4.3.1
 
 # Additional Development Tools

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -1,5 +1,5 @@
 # FastAPI Core Framework
-fastapi==0.138.1
+fastapi==0.139.0
 starlette>=1.3.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # MVidarr Enhanced - Production Dependencies
 
 # Core Framework - FastAPI primary, Flask for backwards compatibility
-fastapi==0.138.1
+fastapi==0.139.0
 starlette>=1.3.1  # Security: PYSEC-2026-161 Host header injection fix, GHSA-7f5h-v6xp-fcq8, GHSA-f96h-pmfr-66vw
 typing-inspection>=0.4.2
 uvicorn[standard]==0.24.0
@@ -25,8 +25,8 @@ httpx==0.28.1
 aiohttp==3.14.1  # Security: CVE-2026-22815/34513-34520/34525 header injection + DoS fixes, CVE-2026-34993 CookieJar deserialization RCE fix, CVE-2026-47265 cross-origin cookie leak fix
 
 # Image Processing
-Pillow==12.2.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
-opencv-python-headless>=4.13.0.92
+Pillow==12.3.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
+opencv-python-headless>=5.0.0.93
 
 # Media Processing
 python-ffmpeg==2.0.12
@@ -59,9 +59,9 @@ qrcode==7.4.2
 defusedxml==0.7.1
 
 # Utilities
-click==8.1.7
+click==8.4.2
 colorama==0.4.6
-tqdm==4.66.3
+tqdm==4.68.3
 psutil==5.9.6
 schedule==1.2.0
 netifaces==0.11.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.17"
+__version__ = "0.12.18"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

Consolidates 6 Dependabot PRs into a single sweep. All CI-green on both 3.11 and 3.12 before consolidation.

- fastapi 0.138.1 → **0.139.0** — minor feature (`app.frontend()` dep support), no breaking changes
- Pillow 12.2.0 → **12.3.0** — removes non-image ImageCms modes (not used by mvidarr)
- opencv-python-headless >=4.13.0.92 → **>=5.0.0.93** — major version; mvidarr uses stable core APIs (cvtColor, Laplacian, filter2D, CascadeClassifier) that are unchanged in OpenCV 5
- click 8.1.7 → **8.4.2** — fix release, explicitly backwards compatible
- tqdm 4.66.3 → **4.68.3** — bug fixes only
- ruby/setup-ruby 1.314.0 → **1.315.0** — CI action for GitHub Pages

Version bumped to **0.12.18**.

Closes #269 #270 #271 #272 #273 #274

## Test plan

- [x] pip-audit clean on all requirements files (pre and post fix)
- [x] pip check — no broken requirements
- [x] black + isort formatting verified (378 files unchanged)
- [x] All 6 source Dependabot PRs had passing CI (security + test 3.11/3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)