### PR TITLE
fix: unstick videos stuck in queue (stop/clear-stuck/force-clear-all)

### DIFF
--- a/src/api/fastapi/metube.py
+++ b/src/api/fastapi/metube.py
@@ -65,6 +65,7 @@ class DownloadResponse(BaseModel):
     download_id: Optional[int] = None
     error: Optional[str] = None
     deleted_count: Optional[int] = None  # For clear history operations
+    cleared_count: Optional[int] = None  # For clear-stuck / force-clear-all
 
 
 class QueueResponse(BaseModel):
@@ -339,6 +340,25 @@ async def add_music_video_download(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _parse_queue_item_id(download_id: str) -> tuple[str, int]:
+    """
+    Parse a queue item ID into (kind, numeric_id).
+
+    Queue items are sourced from two different tables (see
+    unified_download_service.get_download_queue): "db_123" and bare "123"
+    both refer to a Download.id, while "video_123" refers to a Video.id
+    (a video shown as DOWNLOADING with no live Download row to match).
+    """
+    try:
+        if download_id.startswith("db_"):
+            return "download", int(download_id[3:])
+        if download_id.startswith("video_"):
+            return "video", int(download_id[6:])
+        return "download", int(download_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=400, detail="Invalid download ID format")
+
+
 @router.post("/download/{download_id}/stop", response_model=DownloadResponse)
 async def stop_download(
     download_id: str,
@@ -348,21 +368,16 @@ async def stop_download(
     """Stop a specific download"""
     try:
         user_id = current_user.get("user_id", 1)
-
-        # Parse download_id (handle both integer and "db_123" format)
-        try:
-            if download_id.startswith("db_"):
-                actual_id = int(download_id[3:])  # Remove "db_" prefix
-            else:
-                actual_id = int(download_id)
-        except (ValueError, AttributeError):
-            raise HTTPException(status_code=400, detail="Invalid download ID format")
+        kind, actual_id = _parse_queue_item_id(download_id)
 
         logger.info(
-            f"Stopping download {actual_id} for user {current_user.get('username')}"
+            f"Stopping {kind} {actual_id} for user {current_user.get('username')}"
         )
 
-        result = ytdlp_service.stop_download(actual_id)
+        if kind == "video":
+            result = ytdlp_service.stop_video_download(actual_id)
+        else:
+            result = ytdlp_service.stop_download(actual_id)
 
         if not result.get("success"):
             raise HTTPException(status_code=400, detail=result)
@@ -385,21 +400,16 @@ async def retry_download(
     """Retry a failed download"""
     try:
         user_id = current_user.get("user_id", 1)
-
-        # Parse download_id (handle both integer and "db_123" format)
-        try:
-            if download_id.startswith("db_"):
-                actual_id = int(download_id[3:])  # Remove "db_" prefix
-            else:
-                actual_id = int(download_id)
-        except (ValueError, AttributeError):
-            raise HTTPException(status_code=400, detail="Invalid download ID format")
+        kind, actual_id = _parse_queue_item_id(download_id)
 
         logger.info(
-            f"Retrying download {actual_id} for user {current_user.get('username')}"
+            f"Retrying {kind} {actual_id} for user {current_user.get('username')}"
         )
 
-        result = ytdlp_service.retry_download(actual_id)
+        if kind == "video":
+            result = ytdlp_service.retry_video_download(actual_id)
+        else:
+            result = ytdlp_service.retry_download(actual_id)
 
         if not result.get("success"):
             raise HTTPException(status_code=400, detail=result)
@@ -512,6 +522,32 @@ async def clear_stuck_downloads(
 
             cleared_count += 1
 
+        # The queue view is driven by Video.status, not the Download table —
+        # a video can be stuck at DOWNLOADING with no Download row left in
+        # queued/downloading (already finished, failed, or never created).
+        # The loop above only catches videos reachable via such a row, so
+        # also reset any video stuck at DOWNLOADING directly.
+        if force:
+            orphaned_videos = (
+                session.query(Video)
+                .filter(Video.status == VideoStatus.DOWNLOADING)
+                .all()
+            )
+        else:
+            orphaned_videos = (
+                session.query(Video)
+                .filter(
+                    Video.status == VideoStatus.DOWNLOADING,
+                    Video.updated_at < cutoff_time,
+                )
+                .all()
+            )
+
+        for video in orphaned_videos:
+            logger.info(f"Resetting orphaned stuck video {video.id}: {video.title}")
+            video.status = VideoStatus.WANTED
+            cleared_count += 1
+
         session.commit()
 
         if force:
@@ -524,6 +560,7 @@ async def clear_stuck_downloads(
             "message": message,
             "download_id": None,
             "error": None,
+            "cleared_count": cleared_count,
         }
 
         return DownloadResponse(**result)
@@ -579,6 +616,18 @@ async def force_clear_all_downloads(
 
             cleared_count += 1
 
+        # Also reset videos stuck at DOWNLOADING with no matching Download
+        # row left in queued/downloading (see clear_stuck_downloads above).
+        orphaned_videos = (
+            session.query(Video).filter(Video.status == VideoStatus.DOWNLOADING).all()
+        )
+        for video in orphaned_videos:
+            logger.info(
+                f"Force resetting orphaned stuck video {video.id}: {video.title}"
+            )
+            video.status = VideoStatus.WANTED
+            cleared_count += 1
+
         session.commit()
 
         result = {
@@ -586,6 +635,7 @@ async def force_clear_all_downloads(
             "message": f"Force cleared {cleared_count} downloads",
             "download_id": None,
             "error": None,
+            "cleared_count": cleared_count,
         }
 
         return DownloadResponse(**result)

--- a/src/services/download_service_adapter.py
+++ b/src/services/download_service_adapter.py
@@ -451,6 +451,44 @@ class DownloadServiceAdapter:
                 "error": "Download not found",
             }
 
+    def stop_video_download(self, video_id: int) -> Dict[str, Any]:
+        """Stop a video stuck in the queue (video-sourced queue entry)"""
+        success = self.unified_service.reset_stuck_video(video_id)
+
+        if success:
+            return {
+                "success": True,
+                "message": f"Video {video_id} download stopped",
+                "download_id": None,
+                "error": None,
+            }
+        else:
+            return {
+                "success": False,
+                "message": "Video not found",
+                "download_id": None,
+                "error": "Video not found",
+            }
+
+    def retry_video_download(self, video_id: int) -> Dict[str, Any]:
+        """Reset a stuck video back to WANTED so it can be redownloaded"""
+        success = self.unified_service.reset_stuck_video(video_id)
+
+        if success:
+            return {
+                "success": True,
+                "message": f"Video {video_id} reset to WANTED for retry",
+                "download_id": None,
+                "error": None,
+            }
+        else:
+            return {
+                "success": False,
+                "message": "Video not found",
+                "download_id": None,
+                "error": "Video not found",
+            }
+
     def retry_download(self, download_id: int) -> Dict[str, Any]:
         """Retry a failed/stopped download (API compatibility method)"""
         try:

--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -1001,7 +1001,9 @@ class UnifiedDownloadService:
                 for video, artist_name in downloading_videos:
                     queue_items.append(
                         {
-                            "id": video.id,
+                            # Prefixed to disambiguate from Download-table IDs
+                            # (see "db_" prefix below) — this is a Video.id.
+                            "id": f"video_{video.id}",
                             "artist": artist_name,
                             "title": video.title,
                             "url": video.url or video.youtube_url,
@@ -1130,6 +1132,50 @@ class UnifiedDownloadService:
 
         logger.warning(f"Download {download_id} not found")
         return False
+
+    def reset_stuck_video(self, video_id: int) -> bool:
+        """
+        Unstick a video shown as DOWNLOADING in the queue.
+
+        The queue (get_download_queue) is built from Video.status, not the
+        Download table, so a video can be stuck there with no Download row
+        left in "queued"/"downloading"/"pending" (or none at all). Stop any
+        such Download row AND reset the Video status directly, so this is
+        the counterpart to cancel_download() for video-sourced queue entries.
+        """
+        try:
+            from src.database.connection import get_db
+            from src.database.models import Download, Video, VideoStatus
+
+            with get_db() as session:
+                video = session.query(Video).filter(Video.id == video_id).first()
+                if not video:
+                    logger.warning(f"Video {video_id} not found")
+                    return False
+
+                download = (
+                    session.query(Download)
+                    .filter(
+                        Download.video_id == video_id,
+                        Download.status.in_(["queued", "downloading", "pending"]),
+                    )
+                    .first()
+                )
+                if download:
+                    download.status = "stopped"
+                    download.error_message = "Download stopped by user"
+                    download.updated_at = datetime.utcnow()
+
+                if video.status == VideoStatus.DOWNLOADING:
+                    video.status = VideoStatus.WANTED
+
+                session.commit()
+                logger.info(f"Reset stuck video {video_id} to WANTED")
+                return True
+
+        except Exception as e:
+            logger.error(f"Error resetting stuck video {video_id}: {e}")
+            return False
 
 
 # Global service instance

--- a/tests/unit/test_metube_queue_id_parsing.py
+++ b/tests/unit/test_metube_queue_id_parsing.py
@@ -1,0 +1,29 @@
+"""Tests for parsing queue item IDs in the stop/retry endpoints.
+
+The download queue mixes two ID spaces: "db_123"/bare "123" identify a
+Download.id row, while "video_123" identifies a Video.id (queue entries
+built from Video.status == DOWNLOADING with no live Download row to match).
+_parse_queue_item_id must route each form to the right table.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.fastapi.metube import _parse_queue_item_id
+
+
+class TestParseQueueItemId:
+    def test_bare_integer_is_a_download_id(self):
+        assert _parse_queue_item_id("1982") == ("download", 1982)
+
+    def test_db_prefixed_is_a_download_id(self):
+        assert _parse_queue_item_id("db_1982") == ("download", 1982)
+
+    def test_video_prefixed_is_a_video_id(self):
+        assert _parse_queue_item_id("video_1982") == ("video", 1982)
+
+    @pytest.mark.parametrize("bad_id", ["not-a-number", "db_abc", "video_", ""])
+    def test_invalid_formats_raise_400(self, bad_id):
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_queue_item_id(bad_id)
+        assert exc_info.value.status_code == 400

--- a/tests/unit/test_stuck_video_recovery.py
+++ b/tests/unit/test_stuck_video_recovery.py
@@ -1,0 +1,143 @@
+"""Tests for recovering videos stuck in DOWNLOADING status via the queue stop/clear actions.
+
+The download queue (GET /api/metube/queue) is built from Video.status ==
+DOWNLOADING, but the historical stop/clear-stuck endpoints only ever touched
+the Download table. A video stuck at DOWNLOADING with no matching Download
+row (or one already past "queued"/"downloading"/"pending") could never be
+unstuck through the UI. These tests cover the service-layer fix.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.database.connection import Base
+from src.database.models import Artist, Download, Video, VideoStatus
+from src.services.unified_download_service import UnifiedDownloadService
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
+    )
+    return sessionmaker(bind=engine)
+
+
+@contextmanager
+def _fake_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()
+
+
+def _service():
+    # Bypass __init__: it constructs a real YtDlpManager(), which requires a
+    # yt-dlp executable on PATH. reset_stuck_video only touches the database.
+    return UnifiedDownloadService.__new__(UnifiedDownloadService)
+
+
+def _seed_video(
+    session_factory, status=VideoStatus.DOWNLOADING, with_stuck_download=False
+):
+    session = session_factory()
+    artist = Artist(name="Test Artist")
+    session.add(artist)
+    session.commit()
+
+    video = Video(artist_id=artist.id, title="Test Song", status=status)
+    session.add(video)
+    session.commit()
+
+    if with_stuck_download:
+        download = Download(
+            artist_id=artist.id,
+            video_id=video.id,
+            title="Test Song",
+            original_url="https://example.com/watch",
+            status="downloading",
+        )
+        session.add(download)
+        session.commit()
+
+    video_id = video.id
+    session.close()
+    return video_id
+
+
+class TestResetStuckVideo:
+    def test_returns_false_when_video_not_found(self, session_factory):
+        service = _service()
+        with patch_get_db(session_factory):
+            assert service.reset_stuck_video(999999) is False
+
+    def test_resets_video_with_no_backing_download_row(self, session_factory):
+        video_id = _seed_video(session_factory, with_stuck_download=False)
+        service = _service()
+
+        with patch_get_db(session_factory):
+            assert service.reset_stuck_video(video_id) is True
+
+        session = session_factory()
+        video = session.get(Video, video_id)
+        assert video.status == VideoStatus.WANTED
+
+    def test_resets_video_and_stops_backing_download_row(self, session_factory):
+        video_id = _seed_video(session_factory, with_stuck_download=True)
+        service = _service()
+
+        with patch_get_db(session_factory):
+            assert service.reset_stuck_video(video_id) is True
+
+        session = session_factory()
+        video = session.get(Video, video_id)
+        assert video.status == VideoStatus.WANTED
+        download = session.query(Download).filter(Download.video_id == video_id).first()
+        assert download.status == "stopped"
+
+    def test_leaves_completed_download_row_alone(self, session_factory):
+        """A video's download row that already finished should not be touched."""
+        session = session_factory()
+        artist = Artist(name="Test Artist")
+        session.add(artist)
+        session.commit()
+        video = Video(
+            artist_id=artist.id, title="Test Song", status=VideoStatus.DOWNLOADING
+        )
+        session.add(video)
+        session.commit()
+        download = Download(
+            artist_id=artist.id,
+            video_id=video.id,
+            title="Test Song",
+            original_url="https://example.com/watch",
+            status="completed",
+        )
+        session.add(download)
+        session.commit()
+        video_id, download_id = video.id, download.id
+        session.close()
+
+        service = _service()
+        with patch_get_db(session_factory):
+            assert service.reset_stuck_video(video_id) is True
+
+        session = session_factory()
+        video = session.get(Video, video_id)
+        download = session.get(Download, download_id)
+        assert video.status == VideoStatus.WANTED
+        assert download.status == "completed"
+
+
+def patch_get_db(session_factory):
+    from unittest.mock import patch
+
+    return patch(
+        "src.database.connection.get_db", lambda: _fake_get_db(session_factory)
+    )


### PR DESCRIPTION
## Summary
Fixes the reported bug: videos stuck in the download queue couldn't be individually stopped (400 error) or force-cleared ("no videos found" despite visibly stuck entries).

## Root cause
The download queue (`GET /api/metube/queue`) is built from `Video.status == DOWNLOADING`, not the `Download` table. But every action on that queue only ever touched the `Download` table by `Download.id`:

- **`/stop` 400**: queue items sourced from `Video` rows returned a bare `Video.id` as `"id"`. `stop_download` always interpreted that as a `Download.id`, so the lookup hit the wrong table/row and 400'd with "Download not found or already completed" — for essentially any video-sourced queue entry.
- **"Force Clear" reports nothing found**: `clear-stuck`/`force-clear-all` only reset `Video.status` back to `WANTED` when reachable via a `Download` row still in `queued/downloading/pending`. A video stuck at `DOWNLOADING` with no such `Download` row (already finished, failed, or never created) was invisible to the clear.
- Separately, the frontend's success handler checks `data.cleared_count`, but the backend never included that field in its response — so the UI always said "No stuck downloads found to clear" regardless of what actually happened server-side.

## Fix
- `get_download_queue()` now prefixes video-sourced ids as `"video_123"` (mirrors the existing `"db_123"` convention for Download-sourced ids), so the id is no longer ambiguous.
- New `UnifiedDownloadService.reset_stuck_video(video_id)`: cancels any live `Download` row for that video **and** resets `Video.status` directly, so it works whether or not a matching `Download` row still exists.
- `stop_download`/`retry_download` now parse `video_`/`db_`/bare-int ids and route to the right table.
- `clear-stuck`/`force-clear-all` now also reset orphaned stuck videos (`DOWNLOADING` with no matching live `Download` row), and both return a real `cleared_count`.

## Tests
27 unit tests pass (`tests/unit/test_stuck_video_recovery.py`, `tests/unit/test_metube_queue_id_parsing.py`, plus the existing `test_unified_download_service.py` suite for regression). The stuck-video tests use a real in-memory SQLite-backed session (via the actual SQLAlchemy models) rather than mocks, verifying actual row mutations — written test-first (RED confirmed against pre-fix code, then GREEN).

## Test plan
- [x] `black --check` / `isort --check-only` clean
- [x] `python -m py_compile` clean
- [x] All 27 relevant unit tests pass
- [ ] Manual on prod after deploy: force-clear a genuinely stuck video and confirm it leaves the queue
- [ ] Manual on prod after deploy: individually stop a stuck video and confirm no 400

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>