### PR TITLE
fix: dependabot sweep 2026-07-19 — 6 dependency/CI bumps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
         
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.316.0
+        uses: ruby/setup-ruby@v1.319.0
         with:
           ruby-version: '3.1'
           bundler-cache: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pytest-mock==3.12.0
 
 # Code Quality and Formatting
 black==26.3.1  # Security: CVE-2026-32274 arbitrary file write fix
-flake8==6.1.0
+flake8==7.3.0
 mypy==2.1.0
 bandit==1.7.5
 pip-audit==2.10.0

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -23,12 +23,12 @@ httpx==0.28.1
 
 # Database - Async Support
 sqlalchemy[asyncio]>=2.0.51
-aiomysql>=0.2.0
+aiomysql>=0.3.2
 cryptography>=48.0.1
 python-multipart>=0.0.32  # Security: CVE-2026-53539 quadratic CPU DoS fix, CVE-2026-53538 parameter smuggling fix, CVE-2026-53537 Content-Disposition smuggling fix, CVE-2026-45152 negative Content-Length fix
 
 # Keep pymysql for Flask compatibility during migration
-pymysql>=1.0.2
+pymysql>=1.2.0
 
 # Security utilities
 werkzeug>=3.1.8  # Security: CVE-2026-21860

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Session==0.8.0
 
 # Database
 SQLAlchemy==2.0.51
-PyMySQL==1.1.1
+PyMySQL==1.2.0
 alembic==1.18.5
 mysqlclient>=2.2.0
 
@@ -36,12 +36,12 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2  # Security: CVE-2026-28684 symlink following arbitrary file overwrite fix
 pydantic==2.13.4
 pydantic-settings==2.14.2  # Security: GHSA-4xgf-cpjx-pc3j NestedSecretsSettingsSource symlink traversal fix
-marshmallow==3.26.2
+marshmallow==4.3.0
 PyYAML==6.0.3
 
 # HTML Parsing (for AllMusic web scraping)
 beautifulsoup4==4.15.0
-lxml==6.1.0  # Security: CVE-2026-41066 XXE local file read fix
+lxml==6.1.1  # Security: CVE-2026-41066 XXE local file read fix, GHSA-4jhm-jv67-739f xlink:href URL bypass fix, CVE-2025-7424/CVE-2025-11731 libxslt fixes
 
 # Background Tasks
 celery==5.3.4

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.20"
+__version__ = "0.12.21"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary
Bundles the 6 open Dependabot PRs into one sweep, superseding #290, #289, #288, #287, #286, #285.

- **lxml 6.1.0 → 6.1.1** — fixes GHSA-4jhm-jv67-739f (`xlink:href` missing from known link attrs, URL bypass in embedded SVG/MathML) and bundles libxslt fixes for CVE-2025-7424 / CVE-2025-11731
- **marshmallow 3.26.2 → 4.3.0** — major bump, but zero usages found anywhere in `src/`; zero practical risk (flagged separately for possible removal)
- **flake8 6.1.0 → 7.3.0** — dev-only lint tool, not shipped
- **aiomysql >=0.2.0 → >=0.3.2** — fixes GHSA-r397-ff8c-wv2g (local_infile load bypass)
- **pymysql 1.1.1/>=1.0.2 → 1.2.0** — both `requirements.txt` and `requirements-fastapi.txt`; note v1.2.0 makes TLS required-by-default when the server supports it — verified against live MariaDB
- **ruby/setup-ruby 1.316.0 → 1.319.0** — GitHub Actions Pages workflow, CI-only

Version bumped 0.12.20 → 0.12.21.

## Test plan
- [x] `pip-audit` clean on `requirements.txt`, `requirements-fastapi.txt`, `requirements-dev.txt`
- [x] `black --check` / `isort --check-only` clean on `src/`
- [x] Rebuilt local Docker (`docker-compose.dev.yml`, `--no-cache`) from this branch — image builds cleanly with all 6 bumped versions, no resolver conflicts
- [x] `mvidarr-dev` container healthy; migrations ran successfully against live MariaDB
- [x] `/api/health/`, `/api/health/database`, `/api/health/dashboard` all confirm live DB connectivity via the bumped PyMySQL/aiomysql drivers (table_count 108, video_count 31 — pre-existing data intact, no TLS-default regression)
- [x] Full pytest suite: 58 passed, 1 skipped