### PR TITLE
chore: dependency sweep 2026-07-25 — Dependabot PRs #292-299

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -151,7 +151,7 @@ jobs:
     - uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
     

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
         
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.319.0
+        uses: ruby/setup-ruby@v1.321.0
         with:
           ruby-version: '3.1'
           bundler-cache: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 

--- a/.github/workflows/unified-security.yml
+++ b/.github/workflows/unified-security.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ sphinx-rtd-theme==1.3.0
 playwright==1.40.0
 pytest-playwright==0.7.2
 Pillow==12.3.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix
-imagehash==4.3.1
+imagehash==4.3.2
 
 # Additional Development Tools
 # Add any IDE-specific or development-only packages here

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ beautifulsoup4==4.15.0
 lxml==6.1.1  # Security: CVE-2026-41066 XXE local file read fix, GHSA-4jhm-jv67-739f xlink:href URL bypass fix, CVE-2025-7424/CVE-2025-11731 libxslt fixes
 
 # Background Tasks
-celery==5.3.4
-redis==5.0.1
+celery==5.6.3
+redis==8.0.1
 flower==2.0.1
 
 # Security
@@ -70,7 +70,7 @@ zeroconf==0.149.16
 # Monitoring and Logging
 prometheus-client==0.19.0
 structlog==23.2.0
-sentry-sdk==2.63.0
+sentry-sdk==2.66.1
 
 # Production Server - ASGI (FastAPI)
 # uvicorn already included in fastapi dependencies above

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.21"
+__version__ = "0.12.22"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary
Routine dependency-currency sweep incorporating all 8 open Dependabot PRs. No CVEs involved — GitHub-native scans (issues, Dependabot alerts, code-scanning alerts) were all clear before this sweep started.

- Bumps `celery` 5.3.4 → 5.6.3 (#297)
- Bumps `redis` 5.0.1 → 8.0.1 (#298) — 3 major versions
- Bumps `sentry-sdk` 2.63.0 → 2.66.1 (#296)
- Bumps `imagehash` 4.3.1 → 4.3.2, dev-only (#295)
- Bumps `ruby/setup-ruby` 1.319.0 → 1.321.0 (#294)
- Bumps `actions/setup-python` v6 → v7 (#293)
- Bumps `actions/labeler` v6 → v7 (#292)
- `psutil` bump (#299) intentionally **excluded this round** — see note below
- Version bumped to 0.12.22

### Extra verification on the two major-version jumps
- **celery**: PR #297's original CI run timed out at 6h — investigated the log and found it hung during `apt-get update` (mirror stall), never reached pytest. Reran CI: `test (3.11)` and `test (3.12)` both passed in ~3min.
- **redis**: redis-py 8.0 changed RESP3-by-default behavior. Live-tested in the `mvidarr-dev` container: upgraded packages, restarted supervisord, confirmed `celery inspect ping` succeeds, and confirmed `redis_manager.set_job_progress`/`get_job_progress`/`cache` round-trip correctly through the connection pool. Also found (and left alone, out of scope) a pre-existing bug: `redis_manager.health_check()` calls `self.redis_client.ping()` directly without `ensure_connection()`, so it throws `NoneType` if called before any other Redis op establishes the lazy connection — unrelated to this version bump, worth a follow-up issue.

### psutil (#299) not included
5.9.6 → 7.2.2 is 2 major versions. Reviewed every call site in `src/` (`virtual_memory`, `cpu_percent`, `cpu_count`, `disk_usage`, `disk_io_counters`, `net_io_counters`, `net_if_addrs`, `pids`, `Process().memory_info`, `getloadavg`) — none touch APIs removed/deprecated in psutil 6/7, so risk looks low, but it wasn't part of the original approved verification pass. Leaving it for a follow-up PR rather than scope-creeping this one.

## Test plan
- [x] pip-audit clean on requirements.txt, requirements-dev.txt, requirements-fastapi.txt (before and after)
- [x] `pip check` clean in rebuilt dev container — no broken requirements
- [x] black + isort clean across src/
- [x] CI green on celery PR rerun (3.11 + 3.12)
- [x] CI already green on redis PR (3.11 + 3.12)
- [x] Live functional check in mvidarr-dev container: migrations ran, celery-beat/worker/fastapi all started clean, celery ping OK, redis job-progress/cache round-trip OK