### PR TITLE
chore: dependency sweep 2026-08-01 — pytest, tqdm, sphinx, redis, psutil

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 -r requirements.txt
 
 # Development and Testing
-pytest==9.0.3  # Security: CVE-2025-71176 tmpdir vuln fix
+pytest==9.1.1  # Security: CVE-2025-71176 tmpdir vuln fix
 pytest-cov==7.1.0  # Upgraded for pytest 9 compatibility
 pytest-asyncio==1.4.0  # pytest 9 compatible (requires >=8.2,<10; 0.x series does not support pytest 9.x)
 pytest-flask==1.3.0
@@ -20,8 +20,8 @@ pip-audit==2.10.0
 isort
 
 # Documentation
-sphinx==7.2.6
-sphinx-rtd-theme==1.3.0
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
 
 # Visual Testing and Browser Automation
 playwright==1.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ lxml==6.1.1  # Security: CVE-2026-41066 XXE local file read fix, GHSA-4jhm-jv67-
 
 # Background Tasks
 celery==5.6.3
-redis==8.0.1
+redis==8.1.0
 flower==2.0.1
 
 # Security
@@ -61,8 +61,8 @@ defusedxml==0.7.1
 # Utilities
 click==8.4.2
 colorama==0.4.6
-tqdm==4.68.3
-psutil==5.9.6
+tqdm==4.70.0
+psutil==7.2.2
 schedule==1.2.0
 netifaces==0.11.0
 zeroconf==0.149.16

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.22"
+__version__ = "0.12.23"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary
Routine dependency sweep. Full scan (open issues, Dependabot security alerts, code-scanning alerts, pip-audit on all 3 requirements files) came back clean — no CVEs involved. This closes out 5 open routine Dependabot version-bump PRs.

- Closes/supersedes #304 — pytest 9.0.3 → 9.1.1 (dev)
- Closes/supersedes #303 — tqdm 4.68.3 → 4.70.0
- Closes/supersedes #302 — sphinx 7.2.6 → 9.1.0 (dev); also bumped sphinx-rtd-theme 1.3.0 → 3.1.0 since 1.3.0 pins `sphinx<8`, which conflicted
- Closes/supersedes #301 — redis 8.0.1 → 8.1.0
- Closes/supersedes #299 — psutil 5.9.6 → 7.2.2 (previously deferred in v0.12.22; reviewed the 6.0.0/7.0.0 changelogs against every psutil API this codebase calls — no overlap with the documented breaking changes)
- Version bumped 0.12.22 → 0.12.23

## Test plan
- [x] pip-audit clean on requirements.txt, requirements-fastapi.txt, requirements-dev.txt
- [x] Full dependency resolution (`pip install --dry-run`) — no conflicts after sphinx-rtd-theme bump
- [x] black/isort clean across src/
- [x] Local Docker rebuild (mvidarr-dev, port 5001) — image builds clean, migrations apply, FastAPI/Celery worker/beat all start
- [x] Health endpoint (`/api/health/`) returns healthy
- [x] pytest suite: 58 passed, 1 skipped (matches prior baseline)