### PR TITLE
fix: security sweep 2026-08-09

### DIFF
--- a/frontend/templates/videos.html
+++ b/frontend/templates/videos.html
@@ -1235,21 +1235,13 @@ async function playVideo(videoId, title, localPath, videoUrl) {
             hasLoaded = true;
             clearTimeout(loadTimeout);
         });
-        
-        // Check if format is likely unsupported and warn immediately
-        let formatUnsupported = localPath.toLowerCase().endsWith('.mkv') || 
-                               localPath.toLowerCase().endsWith('.avi');
-        
-        if (formatUnsupported) {
-            // Show immediate warning for known unsupported formats
-            setTimeout(() => {
-                if (!hasLoaded) {
-                    console.warn('Likely unsupported format detected:', localPath);
-                    showVideoError(videoId, localPath, mimeType, 'This video format may not be supported by your browser');
-                }
-            }, 3000); // Check after 3 seconds
-        }
-        
+
+        // Note: MKV/AVI files are transcoded in real time via /stream-transcode, which
+        // can legitimately take longer than a few seconds to start. The 30-second
+        // loadTimeout above already reports a genuine "format may not be supported"
+        // warning if the stream never loads — a shorter premature check here caused
+        // false positives that destroyed an otherwise-succeeding transcoded player.
+
     } else if (videoUrl && videoUrl !== 'null' && videoUrl !== 'undefined') {
         // Fall back to YouTube or other URL
         if (videoUrl.includes('youtube.com') || videoUrl.includes('youtu.be')) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ mysqlclient>=2.2.0
 requests==2.34.2  # Security: CVE-2026-25645 predictable temp file creation fix
 urllib3==2.7.0  # Security: CVE-2026-44431 sensitive-header forwarding fix, CVE-2026-44432 decompression-bomb fix
 httpx==0.28.1
-aiohttp==3.14.1  # Security: CVE-2026-22815/34513-34520/34525 header injection + DoS fixes, CVE-2026-34993 CookieJar deserialization RCE fix, CVE-2026-47265 cross-origin cookie leak fix
+aiohttp==3.14.3  # Security: CVE-2026-69244 OOB heap read in C parser error path, CVE-2026-69243 WS upgrade request smuggling, CVE-2026-59881 WS decompression without negotiated permessage-deflate fixes; also carries CVE-2026-22815/34513-34520/34525, CVE-2026-34993, CVE-2026-47265 fixes
 
 # Image Processing
 Pillow==12.3.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "0.12.23"
+__version__ = "0.12.24"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"

--- a/src/api/fastapi/artists_thumbnails.py
+++ b/src/api/fastapi/artists_thumbnails.py
@@ -665,7 +665,26 @@ async def scan_missing_thumbnails(
 
         stale_count = 0
         for artist_id, artist_name, thumb_path in artists_with_path:
-            if not Path(thumb_path).exists():
+            # Distinguish "confirmed missing" from "couldn't check" (e.g. a
+            # transient stat/permission error or a volume not yet mounted).
+            # Only a clean, successful False from exists() proves the file is
+            # actually gone -- an exception must never be treated as proof of
+            # deletion, or a momentary filesystem hiccup would permanently
+            # wipe a valid thumbnail reference from the database.
+            try:
+                file_exists = Path(thumb_path).exists()
+            except OSError as path_error:
+                logger.warning(
+                    f"Could not verify thumbnail path for artist {artist_name} "
+                    f"(ID: {artist_id}), skipping stale-check: {thumb_path} ({path_error})"
+                )
+                continue
+
+            if not file_exists:
+                logger.info(
+                    f"Confirmed missing thumbnail file for artist {artist_name} "
+                    f"(ID: {artist_id}): {thumb_path}"
+                )
                 artists_without_thumbnails.append((artist_id, artist_name))
                 stale_count += 1
                 # Clear the stale path from database


### PR DESCRIPTION
## Summary
- **Security (HIGH+MEDIUM)**: aiohttp 3.14.1 → 3.14.3 in `requirements.txt` (`requirements-dev.txt` inherits via `-r requirements.txt`; `requirements-fastapi.txt` unaffected)
  - CVE-2026-69244 / GHSA-cq5v-8q36-5273 (HIGH) — OOB heap read in C HTTP response parser error path
  - CVE-2026-69243 / GHSA-mfx4-hv73-q22v (MEDIUM) — HTTP request smuggling via WebSocket upgrade
  - CVE-2026-59881 / GHSA-mq44-7p77-q5h7 (MEDIUM) — WS client decompresses frames without negotiated permessage-deflate
  - Closes Dependabot alerts #23–#28, code scanning alerts #79–#81
  - Supersedes/closes Dependabot PR #308
- Closes #307 — removed premature 3s false-positive "format not supported" warning on MKV/AVI playback that raced against real-time transcoding and killed the live player; the existing 30s `loadTimeout` already handles genuine failures
- Closes #306 (partial/defensive fix) — `scan_missing_thumbnails()` no longer treats a failed filesystem check (OSError) as proof a thumbnail was deleted; only a clean, confirmed-missing file now clears the DB reference, and the checked path is now logged. Root cause not fully reproduced — flagged as candidate fix, issue may need to be reopened if the symptom recurs.
- Version bumped 0.12.23 → 0.12.24

## Test plan
- [x] Full dependency resolve clean (`pip install --dry-run`, no conflicts) — aiohttp-3.14.3 confirmed
- [x] pip-audit clean on all three requirements files (requirements.txt, requirements-dev.txt, requirements-fastapi.txt)
- [x] black + isort clean on src/
- [x] Local Docker (mvidarr-dev, port 5001) rebuilt from this branch — health endpoint healthy, version confirms 0.12.24
- [x] Full pytest suite passed inside rebuilt container (58 passed, 1 skipped)
- [x] GitHub issues #306, #307 closed post-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)