### PR TITLE
fix(auth): credentials update 405 + missing ADMIN role check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -252,5 +252,10 @@ app.log
 *.bak
 *.old
 
+# Claude Code local tooling (worktrees, session state) — never belongs in
+# a build context; can contain full nested checkouts + venvs
+.claude/
+.claude/**
+
 # Large log files
 *.log

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -691,7 +691,7 @@ function updateUserCredentialsSection() {
 // Load current credentials for display
 async function loadCurrentCredentials() {
     try {
-        const response = await apiRequest('/auth/credentials');
+        const response = await apiRequest('/api/auth/credentials');
         const usernameField = document.getElementById('auth_username');
         if (usernameField && response.username) {
             usernameField.value = response.username;
@@ -736,7 +736,7 @@ async function updateCredentials() {
     try {
         showLoading('Updating credentials...');
         
-        await apiRequest('/auth/credentials', {
+        await apiRequest('/api/auth/credentials', {
             method: 'POST',
             body: JSON.stringify({
                 username: username,
@@ -752,31 +752,6 @@ async function updateCredentials() {
         
     } catch (error) {
         showError('Failed to update credentials: ' + error.message);
-    }
-}
-
-// Reset credentials to default
-async function resetCredentials() {
-    if (!confirm('Are you sure you want to reset credentials to default values?')) {
-        return;
-    }
-    
-    try {
-        showLoading('Resetting credentials...');
-        
-        await apiRequest('/auth/credentials/reset', {
-            method: 'POST'
-        });
-        
-        showSuccess('Credentials reset to default (admin/mvidarr)');
-        loadCurrentCredentials();
-        
-        // Clear password fields
-        document.getElementById('auth_password').value = '';
-        document.getElementById('auth_password_confirm').value = '';
-        
-    } catch (error) {
-        showError('Failed to reset credentials: ' + error.message);
     }
 }
 

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -299,7 +299,6 @@ input:checked + .slider:before {
             </div>
             <div class="form-group">
                 <button onclick="updateCredentials()" class="btn btn-primary">🔑 Update Credentials</button>
-                <button onclick="resetCredentials()" class="btn btn-secondary">🔄 Reset to Default</button>
             </div>
         </div>
 

--- a/src/api/fastapi/auth.py
+++ b/src/api/fastapi/auth.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.auth_dependencies import require_admin
 from src.database.connection import get_db_session
 from src.database.models import UserRole
 from src.services.audit_service import (
@@ -591,9 +591,16 @@ async def get_credentials():
 @router.post("/credentials")
 async def update_credentials(
     credentials: CredentialsRequest,
-    current_user: dict = Depends(require_authentication),
+    current_user: dict = Depends(require_admin),
 ):
-    """Update username and password for simple auth (requires authentication)"""
+    """Update username and password for simple auth (requires ADMIN role).
+
+    This changes the credential SimpleAuthService authenticates every
+    browser login against — not just the caller's own account — so it must
+    be gated on role, not merely on being logged in (found during dev
+    testing ahead of v1.0.0: any authenticated USER/MANAGER/READONLY
+    session could previously change the instance-wide login credentials).
+    """
     try:
         from src.services.simple_auth_service import SimpleAuthService
 

--- a/src/api/fastapi/template_system.py
+++ b/src/api/fastapi/template_system.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -317,7 +317,7 @@ class AsyncTemplateSystem:
             # Check if authentication middleware is enabled
             from src.services.settings_service import settings
 
-            auth_enabled = settings.get("require_authentication", True)
+            auth_enabled = settings.get_bool("require_authentication", True)
             auth_context["auth_enabled"] = auth_enabled
 
             # If authentication is disabled, provide a mock user context
@@ -378,7 +378,9 @@ class AsyncTemplateSystem:
                 "app_name": settings.get("app_name", "MVidarr"),
                 "app_version": settings.get("app_version", "1.0.0"),
                 "theme": settings.get("default_theme", "dark"),
-                "require_authentication": settings.get("require_authentication", True),
+                "require_authentication": settings.get_bool(
+                    "require_authentication", True
+                ),
                 "enable_2fa": settings.get("enable_2fa", False),
                 "max_upload_size": settings.get("max_upload_size_mb", 100),
             }
@@ -793,15 +795,34 @@ def render_template_response(template_name: str):
 
 # Authentication dependency for protected templates
 async def require_authentication(request: Request):
-    """Require authentication for template access"""
+    """Require authentication for template access.
+
+    Raises (rather than returns) the redirect: a value *returned* from a
+    FastAPI `Depends()` callable is just an ordinary parameter passed to
+    the route handler — it is never used as the actual HTTP response
+    unless the handler explicitly checks and returns it. None of this
+    file's callers do, so a previous version of this function that
+    `return`ed a RedirectResponse here was silently ignored by every
+    route using it (found during manual testing ahead of v1.0.0: /settings
+    and 8 other pages rendered normally for fully anonymous requests).
+    Raising an HTTPException halts the request unconditionally, matching
+    the pattern require_admin below already used (by relying on the same
+    accidental side effect, not deliberately).
+    """
     if not hasattr(request.state, "user") or request.state.user is None:
-        if settings.get("require_authentication", True):
-            # Redirect to login page
-            from fastapi.responses import RedirectResponse
+        if settings.get_bool("require_authentication", True):
+            raise HTTPException(
+                status_code=status.HTTP_302_FOUND,
+                headers={"Location": "/auth/login"},
+            )
 
-            return RedirectResponse(url="/auth/login", status_code=302)
-
-    return request.state.user
+    # getattr, not a bare attribute access: request.state is a Starlette
+    # State object whose __getattr__ raises AttributeError for a key that
+    # was never set (hasattr() above only *looks* safe because hasattr()
+    # itself swallows that exception) — reachable whenever authentication
+    # is genuinely not required and no session/JWT middleware ever touched
+    # request.state.user at all.
+    return getattr(request.state, "user", None)
 
 
 async def require_admin(request: Request):

--- a/src/database/init_db.py
+++ b/src/database/init_db.py
@@ -55,7 +55,7 @@ def init_default_settings():
         ("debug_mode", "false", "Enable debug mode"),
         (
             "require_authentication",
-            "false",
+            "true",
             "Require user login to access the application",
         ),
         (

--- a/tests/unit/test_credentials_endpoint.py
+++ b/tests/unit/test_credentials_endpoint.py
@@ -1,0 +1,73 @@
+"""Tests for POST /api/auth/credentials — found broken during manual dev
+testing ahead of v1.0.0 (2026-08-11):
+
+1. The frontend's "Update Credentials" button called POST /auth/credentials
+   (the legacy_router prefix), but only GET is registered there — the real
+   POST-capable route lives under /api/auth/credentials. Fixed in
+   frontend/static/main.js; not covered here (that's a frontend bug, this
+   file covers the backend route itself).
+2. The route only required `require_authentication` — any authenticated
+   session (USER, MANAGER, READONLY) could change the instance-wide
+   SimpleAuth login credential, not just admins. Fixed by switching to
+   `require_admin`; this file pins that behavior.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth import router
+from src.api.fastapi.auth_dependencies import require_admin
+
+
+def _make_client(current_user):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_admin] = lambda: current_user
+    return TestClient(app)
+
+
+class TestUpdateCredentialsRoleGating:
+    def test_admin_can_update_credentials(self):
+        client = _make_client({"role": "ADMIN", "user_id": 1})
+        with patch(
+            "src.services.simple_auth_service.SimpleAuthService.set_credentials",
+            return_value=(True, "Credentials updated"),
+        ):
+            response = client.post(
+                "/api/auth/credentials",
+                json={"username": "admin", "password": "N3wPassw0rd!"},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_non_admin_role_is_rejected_before_reaching_the_route(self):
+        # require_admin itself raises 403 for a non-ADMIN role — this test
+        # exercises the real dependency (not overridden) to confirm the
+        # route is actually wired to it, not merely require_authentication.
+        app = FastAPI()
+        app.include_router(router)
+
+        from src.api.fastapi.auth_dependencies import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: {
+            "role": "USER",
+            "user_id": 2,
+            "authenticated": True,
+        }
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/auth/credentials",
+            json={"username": "admin", "password": "N3wPassw0rd!"},
+        )
+        assert response.status_code == 403
+
+    def test_missing_fields_still_validated_after_role_check(self):
+        client = _make_client({"role": "ADMIN", "user_id": 1})
+        response = client.post(
+            "/api/auth/credentials", json={"username": "", "password": ""}
+        )
+        assert response.status_code in (400, 422)

--- a/tests/unit/test_template_system_auth_gate.py
+++ b/tests/unit/test_template_system_auth_gate.py
@@ -1,0 +1,145 @@
+"""Tests for template_system.py's require_authentication/require_admin —
+found broken during manual dev testing ahead of v1.0.0 (2026-08-11).
+
+Two independent bugs, both fixed here:
+
+1. require_authentication tried to enforce a redirect by *returning* a
+   RedirectResponse from a FastAPI Depends() callable. A value returned
+   from a dependency is just an ordinary parameter passed to the route
+   handler — it is never used as the actual HTTP response unless the
+   handler explicitly checks and returns it. None of the 9 frontend
+   routes using this dependency did (settings, scheduler dashboard/jobs,
+   youtube-playlists, spotify/lastfm/lidarr managers, enrichment, 2FA
+   setup), so every one of them rendered normally for fully anonymous
+   requests. Fixed by raising an HTTPException instead — that halts the
+   request unconditionally regardless of what the handler does with the
+   dependency's return value.
+
+2. The "require_authentication" setting is stored as the string "false"
+   in the database. `if settings.get("require_authentication", True):`
+   checks Python truthiness on that STRING, and any non-empty string
+   (including the literal text "false") is truthy — so this check always
+   took the "auth is required" branch regardless of the setting's actual
+   value. Fixed by using SettingsService.get_bool(), which parses the
+   string content instead of checking non-emptiness.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from src.api.fastapi.template_system import require_admin, require_authentication
+
+
+def _make_anonymous_request():
+    """A request with no request.state.user set at all — the state of
+    every real anonymous request that never goes through the JWT/session
+    middleware's authenticated branch.
+    """
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/settings",
+        "headers": [(b"host", b"localhost")],
+        "query_string": b"",
+        "server": ("localhost", 5000),
+        "client": ("127.0.0.1", 12345),
+        "scheme": "http",
+        "app": None,
+    }
+    return Request(scope)
+
+
+def _make_authenticated_request(role="USER"):
+    request = _make_anonymous_request()
+    user = MagicMock()
+    user.role = role
+    request.state.user = user
+    return request
+
+
+class TestRequireAuthenticationRaisesInsteadOfReturning:
+    @pytest.mark.asyncio
+    async def test_anonymous_request_raises_a_redirect_when_auth_required(self):
+        request = _make_anonymous_request()
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_authentication(request)
+        assert exc_info.value.status_code == 302
+        assert exc_info.value.headers["Location"] == "/auth/login"
+
+    @pytest.mark.asyncio
+    async def test_anonymous_request_passes_through_when_auth_not_required(self):
+        request = _make_anonymous_request()
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=False
+        ):
+            result = await require_authentication(request)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_authenticated_request_passes_through_regardless_of_setting(self):
+        request = _make_authenticated_request(role="USER")
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            result = await require_authentication(request)
+        assert result is request.state.user
+
+
+class TestRequireAdminStillEnforcesRoleForRealUsers:
+    @pytest.mark.asyncio
+    async def test_admin_user_passes(self):
+        request = _make_authenticated_request(role="admin")
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            result = await require_admin(request)
+        assert result is request.state.user
+
+    @pytest.mark.asyncio
+    async def test_non_admin_user_is_rejected(self):
+        request = _make_authenticated_request(role="user")
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_admin(request)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_anonymous_request_is_redirected_not_silently_admitted(self):
+        # Regression pin: before the fix, require_authentication's ignored
+        # RedirectResponse return value was truthy and had no .role
+        # attribute, so require_admin happened to 403 anonymous users by
+        # accident. Now it must raise the same 302 require_authentication
+        # itself raises, for the correct reason.
+        request = _make_anonymous_request()
+        with patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_admin(request)
+        assert exc_info.value.status_code == 302
+
+
+class TestRequireAuthenticationSettingBoolParsing:
+    def test_stored_false_string_is_not_truthy(self):
+        # Regression pin for the settings.get() vs settings.get_bool()
+        # bug: SettingsService.get() returns the raw string "false", and
+        # `if "false":` is True in Python (non-empty string). get_bool()
+        # must be used everywhere this setting gates behavior.
+        from src.services.settings_service import SettingsService
+
+        with patch.object(SettingsService, "get", return_value="false"):
+            assert SettingsService.get_bool("require_authentication", True) is False
+
+    def test_stored_true_string_is_truthy(self):
+        from src.services.settings_service import SettingsService
+
+        with patch.object(SettingsService, "get", return_value="true"):
+            assert SettingsService.get_bool("require_authentication", False) is True


### PR DESCRIPTION
## Summary

Found during manual dev testing of the v1.0.0 auth cluster (#322), via the Settings page.

### Commit 1: credentials update 405 + missing ADMIN role check
1. **405 on "Update Credentials"**: the button called `POST /auth/credentials`, but that path only registers `GET` (different router prefix than the real POST-capable `/api/auth/credentials`). Pre-existing bug, not a #322 regression. Fixed both call sites in `main.js`.
2. **Missing RBAC on the credentials endpoint**: `POST /api/auth/credentials` only required `require_authentication`, not an admin role. Switched to `require_admin`.
3. **Removed dead "Reset to Default" button**: called a nonexistent endpoint; hardcoded-default credential reset was deliberately removed as a backdoor in v0.12.0 — this was leftover dead UI.
4. Fixed `.dockerignore`: `.claude/` wasn't excluded, causing local dev image builds to hang recursively chmod-ing an irrelevant 1.5GB+ directory.

### Commit 2: frontend page auth guard silently never enforced
Tracing *why* the Credentials panel was invisible led to a bigger, currently-live bug: **9 frontend pages** (`/settings`, `/scheduler/dashboard`, `/scheduler/jobs`, `/youtube-playlists`, `/spotify-manager`, `/lastfm-manager`, `/lidarr-manager`, `/enrichment`, `/2fa/setup`) rendered their page shell for **fully anonymous requests**, due to two compounding bugs in `template_system.py`:

1. `require_authentication()` tried to enforce a login redirect by *returning* a `RedirectResponse` from a `Depends()` callable — FastAPI never uses a dependency's return value as the actual HTTP response unless the route handler explicitly checks it, and none of the 9 did. Fixed by raising an `HTTPException` instead.
2. The gating DB setting is stored as the string `"false"` and was checked with plain Python truthiness (`if settings.get(...)`) — any non-empty string, including the text `"false"`, is truthy. Fixed by using `SettingsService.get_bool()`.

**Severity**: real data/API access was never affected — verified empirically throughout (`GET /api/settings/` correctly 401s with no session, both before and after). This was page-shell exposure, not data or account compromise; `JWTAuthMiddleware` and `auth_dependencies.py`'s route-level checks (hardened in #322) remained the real, effective boundary the whole time.

Also: fresh installs now default `require_authentication` to `"true"` (was `"false"`) — secure-by-default. Existing installs' stored value is untouched. Corrected #323, which had wrongly characterized `JWTAuthMiddleware` as dead — it's live and registered app-wide; the actual bug lived elsewhere.

## Test plan

- [x] `tests/unit/test_credentials_endpoint.py` — pins ADMIN-only gating on the credentials endpoint
- [x] `tests/unit/test_template_system_auth_gate.py` — pins raise-not-return, `get_bool` string parsing, and the `getattr` fix, using a real Starlette `Request`
- [x] Full suite: 116 passed, 1 skipped, no regressions
- [x] Manually verified in `mvidarr-dev`: credentials update succeeds; anonymous `/settings` now redirects to `/auth/login` instead of 200

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>