### PR TITLE
fix(auth): session-cookie users locked out of protected pages

### DIFF
--- a/src/api/fastapi/template_system.py
+++ b/src/api/fastapi/template_system.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from src.database.models import UserRole
 from src.services.settings_service import settings
 from src.utils.logger import get_logger
 
@@ -794,6 +795,48 @@ def render_template_response(template_name: str):
 
 
 # Authentication dependency for protected templates
+async def _current_template_user(request: Request):
+    """Resolve the authenticated user for this request by validating its
+    session_token cookie directly via SessionStore, exactly like
+    auth_dependencies.get_optional_user does for API routes.
+
+    This does NOT rely on request.state.user/.session_user, and that is
+    deliberate: JWTAuthMiddleware only populates those for paths outside
+    its own public_paths list — and /settings, /admin, /dashboard, and
+    every other page this file protects are ALL listed as public there,
+    so the middleware returns early and never touches request.state for
+    them at all, regardless of whether a valid session cookie is present.
+    An earlier version of this function checked request.state.user (and
+    later request.state.session_user too) and, for these specific
+    routes, found neither — REAL logged-in users were bounced to
+    /auth/login exactly like anonymous ones (found via direct testing
+    immediately after that fix shipped, ahead of v1.0.0, 2026-08-11).
+
+    Delegating to get_optional_user reuses the same, already-hardened
+    session-validation logic every /api/* route depends on, instead of
+    maintaining a second, independently-buggy copy of it here.
+    """
+    from src.api.fastapi.auth_dependencies import get_optional_user
+
+    return await get_optional_user(request)
+
+
+def _template_user_role(user) -> str:
+    """Extract a role string from SessionStore.validate_session's dict
+    shape (the only shape _current_template_user can now return). Always
+    uppercase — UserRole enum values (ADMIN, USER, MANAGER, READONLY)
+    are stored/compared uppercase throughout this codebase's session-
+    based auth; an earlier version of require_admin compared against the
+    literal lowercase "admin", which would have 403'd even a genuine
+    ADMIN session.
+    """
+    if isinstance(user, dict):
+        role = user.get("role", "")
+    else:
+        role = getattr(user, "role", "")
+    return str(role).upper()
+
+
 async def require_authentication(request: Request):
     """Require authentication for template access.
 
@@ -809,26 +852,21 @@ async def require_authentication(request: Request):
     the pattern require_admin below already used (by relying on the same
     accidental side effect, not deliberately).
     """
-    if not hasattr(request.state, "user") or request.state.user is None:
+    user = await _current_template_user(request)
+    if user is None:
         if settings.get_bool("require_authentication", True):
             raise HTTPException(
                 status_code=status.HTTP_302_FOUND,
                 headers={"Location": "/auth/login"},
             )
 
-    # getattr, not a bare attribute access: request.state is a Starlette
-    # State object whose __getattr__ raises AttributeError for a key that
-    # was never set (hasattr() above only *looks* safe because hasattr()
-    # itself swallows that exception) — reachable whenever authentication
-    # is genuinely not required and no session/JWT middleware ever touched
-    # request.state.user at all.
-    return getattr(request.state, "user", None)
+    return user
 
 
 async def require_admin(request: Request):
     """Require admin role for template access"""
     user = await require_authentication(request)
-    if user and getattr(user, "role", "user") != "admin":
+    if user and _template_user_role(user) != UserRole.ADMIN.value:
         raise HTTPException(status_code=403, detail="Admin access required")
     return user
 

--- a/tests/unit/test_template_system_auth_gate.py
+++ b/tests/unit/test_template_system_auth_gate.py
@@ -1,7 +1,6 @@
 """Tests for template_system.py's require_authentication/require_admin —
-found broken during manual dev testing ahead of v1.0.0 (2026-08-11).
-
-Two independent bugs, both fixed here:
+found broken during manual dev testing ahead of v1.0.0 (2026-08-11), in
+three rounds as each fix exposed the next layer:
 
 1. require_authentication tried to enforce a redirect by *returning* a
    RedirectResponse from a FastAPI Depends() callable. A value returned
@@ -11,33 +10,40 @@ Two independent bugs, both fixed here:
    routes using this dependency did (settings, scheduler dashboard/jobs,
    youtube-playlists, spotify/lastfm/lidarr managers, enrichment, 2FA
    setup), so every one of them rendered normally for fully anonymous
-   requests. Fixed by raising an HTTPException instead — that halts the
-   request unconditionally regardless of what the handler does with the
-   dependency's return value.
+   requests. Fixed by raising an HTTPException instead.
 
 2. The "require_authentication" setting is stored as the string "false"
-   in the database. `if settings.get("require_authentication", True):`
-   checks Python truthiness on that STRING, and any non-empty string
-   (including the literal text "false") is truthy — so this check always
-   took the "auth is required" branch regardless of the setting's actual
-   value. Fixed by using SettingsService.get_bool(), which parses the
-   string content instead of checking non-emptiness.
+   in the database and was checked with plain Python truthiness, where
+   any non-empty string (including the literal text "false") is truthy.
+   Fixed by using SettingsService.get_bool().
+
+3. Fixing #1 immediately exposed a third, pre-existing bug: this file's
+   user-resolution logic depended on request.state.user (and, briefly,
+   request.state.session_user too) — attributes JWTAuthMiddleware only
+   populates for paths OUTSIDE its own public_paths list. /settings,
+   /admin, and every other page this file protects are ALL listed as
+   public there, so the middleware never touches request.state for them
+   regardless of whether a valid session cookie is present. Real
+   logged-in users were bounced to /auth/login exactly like anonymous
+   visitors (reported directly by the user testing dev immediately after
+   the round-2 fix shipped). Fixed by delegating to
+   auth_dependencies.get_optional_user, which validates the session_token
+   cookie directly via SessionStore — the same, already-hardened logic
+   every /api/* route already depends on — instead of maintaining a
+   second, independently-buggy copy of session resolution here.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
 
 from src.api.fastapi.template_system import require_admin, require_authentication
+from src.database.models import UserRole
 
 
-def _make_anonymous_request():
-    """A request with no request.state.user set at all — the state of
-    every real anonymous request that never goes through the JWT/session
-    middleware's authenticated branch.
-    """
+def _make_request():
     scope = {
         "type": "http",
         "method": "GET",
@@ -52,19 +58,26 @@ def _make_anonymous_request():
     return Request(scope)
 
 
-def _make_authenticated_request(role="USER"):
-    request = _make_anonymous_request()
-    user = MagicMock()
-    user.role = role
-    request.state.user = user
-    return request
+def _session_user(role="USER"):
+    """SessionStore.validate_session's real return shape."""
+    return {
+        "username": "someone",
+        "authenticated": True,
+        "user_id": 1,
+        "role": role,
+    }
+
+
+TEMPLATE_SYSTEM_GET_OPTIONAL_USER = (
+    "src.api.fastapi.auth_dependencies.get_optional_user"
+)
 
 
 class TestRequireAuthenticationRaisesInsteadOfReturning:
     @pytest.mark.asyncio
     async def test_anonymous_request_raises_a_redirect_when_auth_required(self):
-        request = _make_anonymous_request()
-        with patch(
+        request = _make_request()
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=None), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=True
         ):
             with pytest.raises(HTTPException) as exc_info:
@@ -74,37 +87,66 @@ class TestRequireAuthenticationRaisesInsteadOfReturning:
 
     @pytest.mark.asyncio
     async def test_anonymous_request_passes_through_when_auth_not_required(self):
-        request = _make_anonymous_request()
-        with patch(
+        request = _make_request()
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=None), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=False
         ):
             result = await require_authentication(request)
         assert result is None
 
+
+class TestRequireAuthenticationValidatesTheSessionCookieDirectly:
+    """The real-world bug: /settings (and every page this file protects)
+    is in JWTAuthMiddleware's public_paths, so request.state is never
+    populated for it — this function must resolve the session itself.
+    """
+
     @pytest.mark.asyncio
-    async def test_authenticated_request_passes_through_regardless_of_setting(self):
-        request = _make_authenticated_request(role="USER")
-        with patch(
+    async def test_valid_session_passes_through(self):
+        request = _make_request()
+        user = _session_user(role="USER")
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=user), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=True
         ):
             result = await require_authentication(request)
-        assert result is request.state.user
+        assert result == user
+
+    @pytest.mark.asyncio
+    async def test_valid_session_is_not_redirected_to_login(self):
+        # Regression pin for the exact bug reported during manual testing:
+        # a genuinely logged-in user kept getting bounced back to
+        # /auth/login when visiting /settings, on a page that
+        # JWTAuthMiddleware itself never blocks (it's in public_paths).
+        request = _make_request()
+        user = _session_user(role="ADMIN")
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=user), patch(
+            "src.api.fastapi.template_system.settings.get_bool", return_value=True
+        ):
+            try:
+                await require_authentication(request)
+            except HTTPException:
+                pytest.fail(
+                    "a request with a valid session cookie must not be "
+                    "redirected to login"
+                )
 
 
 class TestRequireAdminStillEnforcesRoleForRealUsers:
     @pytest.mark.asyncio
     async def test_admin_user_passes(self):
-        request = _make_authenticated_request(role="admin")
-        with patch(
+        request = _make_request()
+        user = _session_user(role=UserRole.ADMIN.value)
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=user), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=True
         ):
             result = await require_admin(request)
-        assert result is request.state.user
+        assert result == user
 
     @pytest.mark.asyncio
     async def test_non_admin_user_is_rejected(self):
-        request = _make_authenticated_request(role="user")
-        with patch(
+        request = _make_request()
+        user = _session_user(role=UserRole.USER.value)
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=user), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=True
         ):
             with pytest.raises(HTTPException) as exc_info:
@@ -113,13 +155,8 @@ class TestRequireAdminStillEnforcesRoleForRealUsers:
 
     @pytest.mark.asyncio
     async def test_anonymous_request_is_redirected_not_silently_admitted(self):
-        # Regression pin: before the fix, require_authentication's ignored
-        # RedirectResponse return value was truthy and had no .role
-        # attribute, so require_admin happened to 403 anonymous users by
-        # accident. Now it must raise the same 302 require_authentication
-        # itself raises, for the correct reason.
-        request = _make_anonymous_request()
-        with patch(
+        request = _make_request()
+        with patch(TEMPLATE_SYSTEM_GET_OPTIONAL_USER, return_value=None), patch(
             "src.api.fastapi.template_system.settings.get_bool", return_value=True
         ):
             with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
## Summary

Reported directly by the user immediately after merging #326: repeatedly logging in and clearing cache still bounced them back to `/auth/login` when visiting `/settings`.

**Root cause**: `template_system.py`'s `require_authentication()` resolved the current user by reading `request.state` attributes `JWTAuthMiddleware` populates. But `/settings`, `/admin`, `/dashboard`, and every other page this file protects are **all** listed in that middleware's own `public_paths` set — so the middleware returns early for them and never touches `request.state` at all, regardless of whether a valid session cookie is present.

This bug pre-dates #326 and was masked by it: real logged-in users already looked "unauthenticated" to this function, but the redirect it tried to issue was a return value nobody checked (the bug #326 fixed), so it was silently discarded and nobody noticed. Fixing the return-vs-raise bug without also fixing this meant the now-enforced redirect fired for genuinely authenticated users too, not just anonymous ones.

**Fix**: `require_authentication` now delegates to `auth_dependencies.get_optional_user`, which validates the `session_token` cookie directly against `SessionStore` — the same, already-hardened logic every `/api/*` route already depends on — instead of relying on middleware state these specific routes never receive.

Also fixed: `require_admin`'s role check compared against the literal lowercase `"admin"`, but `UserRole` enum values (and everything `SessionStore` stores) are uppercase (`"ADMIN"`, `"USER"`, `"MANAGER"`, `"READONLY"`) — this would have 403'd even a genuine ADMIN session once the user was actually being found at all.

## Test plan

- [x] `tests/unit/test_template_system_auth_gate.py` rewritten to mock `get_optional_user` directly (the real integration point)
- [x] Full suite: 117 passed, 1 skipped, no regressions
- [x] **Real end-to-end verification**: logged in through the actual running server (not a mocked/side-process session), confirmed `/settings`, `/admin`, `/scheduler/dashboard` all return 200 with a valid session and 302 for anonymous requests

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>