### PR TITLE
fix(wizard): complete_wizard_step should reconcile admin User, like skip_wizard does

### DIFF
--- a/src/api/fastapi/wizard.py
+++ b/src/api/fastapi/wizard.py
@@ -437,8 +437,29 @@ async def complete_wizard_step(
             next_step = step_order[current_index + 1]
             wizard_state.advance_to_step(next_step)
 
+        just_completed = wizard_state.status == WizardStatus.COMPLETED
+
         session.commit()
         session.refresh(wizard_state)
+
+        # Mirrors skip_wizard's own reconciliation call below: if this step
+        # just brought the wizard to COMPLETED without ever going through
+        # POST /create-admin (e.g. a direct API caller advancing the
+        # admin_account step without creating an admin), the configured
+        # SimpleAuth credential would otherwise resolve to a READONLY
+        # session until the next application restart (#325).
+        if just_completed:
+            try:
+                from src.database.init_db import ensure_admin_user_for_credentials
+                from src.services.settings_service import SettingsService
+
+                ensure_admin_user_for_credentials(
+                    SettingsService.get("simple_auth_username")
+                )
+            except Exception as reconcile_err:
+                logger.error(
+                    f"Failed to reconcile admin user after wizard completion: {reconcile_err}"
+                )
 
         return WizardStateResponse(**wizard_state.to_dict())
 

--- a/tests/unit/test_wizard_completion_reconciliation.py
+++ b/tests/unit/test_wizard_completion_reconciliation.py
@@ -1,0 +1,131 @@
+"""Regression test for issue #325: complete_wizard_step() didn't reconcile
+the admin User row the way skip_wizard() already does.
+
+Without this, an install that reaches WizardStatus.COMPLETED via
+complete_wizard_step() without ever calling POST /create-admin directly
+(possible via direct API use, bypassing wizard.js's own UI flow, which
+always calls create-admin before advancing) would have the configured
+SimpleAuth credential resolve to a READONLY session until the next
+application restart — the exact bug already fixed for skip_wizard() in
+the auth-cluster branch's final review, just missing here.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.fastapi.wizard import router
+from src.database.connection import Base, get_db_session
+from src.database.models import WizardState, WizardStatus, WizardStep
+
+
+@pytest.fixture
+def session_factory():
+    # StaticPool + check_same_thread=False: get_db_session is a sync
+    # generator dependency, so FastAPI runs it via anyio's threadpool
+    # while the async route handler runs on the event-loop thread.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[WizardState.__table__])
+    return sessionmaker(bind=engine)
+
+
+def _make_client(session_factory):
+    app = FastAPI()
+    app.include_router(router)
+
+    def _override_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = _override_db
+    return TestClient(app)
+
+
+def _seed_wizard_state(session_factory, **flags):
+    session = session_factory()
+    state = WizardState(
+        status=WizardStatus.IN_PROGRESS,
+        current_step=WizardStep.VIDEO_IMPORT,
+        admin_account_completed=True,
+        directories_completed=True,
+        api_config_completed=True,
+        video_import_completed=False,
+        **flags,
+    )
+    session.add(state)
+    session.commit()
+    session.close()
+
+
+RECONCILE_PATCH_TARGET = "src.database.init_db.ensure_admin_user_for_credentials"
+
+
+class TestCompleteWizardStepReconciliation:
+    def test_completing_the_final_step_reconciles_the_admin_user(self, session_factory):
+        _seed_wizard_state(session_factory)
+        client = _make_client(session_factory)
+
+        with patch(RECONCILE_PATCH_TARGET) as mock_reconcile, patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="admin",
+        ):
+            response = client.post("/api/wizard/steps/video_import/complete", json={})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "completed"
+        mock_reconcile.assert_called_once_with("admin")
+
+    def test_completing_a_non_final_step_does_not_reconcile(self, session_factory):
+        # Seed a wizard genuinely mid-flow (not one step away from
+        # completion) so completing this step cannot trigger COMPLETED.
+        session = session_factory()
+        state = WizardState(
+            status=WizardStatus.IN_PROGRESS,
+            current_step=WizardStep.WELCOME,
+            admin_account_completed=False,
+            directories_completed=False,
+            api_config_completed=False,
+            video_import_completed=False,
+        )
+        session.add(state)
+        session.commit()
+        session.close()
+        client = _make_client(session_factory)
+
+        with patch(RECONCILE_PATCH_TARGET) as mock_reconcile:
+            response = client.post("/api/wizard/steps/welcome/complete", json={})
+
+        assert response.status_code == 200
+        assert response.json()["status"] != "completed"
+        mock_reconcile.assert_not_called()
+
+
+class TestSkipWizardStillReconciles:
+    """Confirm the fix didn't disturb skip_wizard's existing, already-
+    correct reconciliation call.
+    """
+
+    def test_skip_still_reconciles(self, session_factory):
+        client = _make_client(session_factory)
+
+        with patch(RECONCILE_PATCH_TARGET) as mock_reconcile, patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="admin",
+        ):
+            response = client.post("/api/wizard/skip")
+
+        assert response.status_code == 200
+        mock_reconcile.assert_called_once_with("admin")


### PR DESCRIPTION
## Summary

Fixes #325.

`skip_wizard()` already calls `ensure_admin_user_for_credentials()` immediately after committing `WizardStatus.SKIPPED`, so a skipped install doesn't have to wait for a restart to get a working admin session. `complete_wizard_step()` — the normal, non-skip completion path — didn't have the equivalent call.

In practice low-risk (the web UI always calls `POST /create-admin` before advancing, which creates the real admin row directly), but reachable via direct API use. Worst case: admin session falls back to READONLY until the next restart.

Fix mirrors `skip_wizard()`'s existing pattern exactly.

## Test plan

- [x] `tests/unit/test_wizard_completion_reconciliation.py` — new coverage (none existed for these endpoints at all), TDD-verified against the pre-fix code
- [x] Full suite: 120 passed, 1 skipped, no regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>