### PR TITLE
fix(settings): add a real, reachable entry point to 2FA setup

### DIFF
--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -771,8 +771,38 @@ document.addEventListener('DOMContentLoaded', function() {
             updateUserManagementSection(); // Initial check
             updateUserCredentialsSection(); // Initial check for credentials section
         }
+        loadTwoFactorStatus();
     }
 });
+
+// Load and display the current user's 2FA status on the Settings page.
+// The only pre-existing entry point to /2fa/setup was in an unreachable
+// template (dashboard.html, which nothing ever routes to) — this wires a
+// real, reachable one into Settings instead (#334 investigation).
+async function loadTwoFactorStatus() {
+    // Distinct ID from the pre-existing (dead, unreachable) 'twoFactorStatus'
+    // element referenced elsewhere in settings.html's dead
+    // adminUserManagement-adjacent code — see #334 investigation.
+    const statusEl = document.getElementById('securityTwoFactorStatus');
+    const enableLink = document.getElementById('twoFactorEnableLink');
+    if (!statusEl) return;
+
+    try {
+        const response = await apiRequest('/2fa/api/status');
+        let message = 'Two-factor authentication is not enabled for your account.';
+        if (response.enabled) {
+            message = '✅ Two-factor authentication is enabled.';
+            if (typeof response.backup_codes_remaining === 'number') {
+                message += ` ${response.backup_codes_remaining} backup code(s) remaining.`;
+            }
+        }
+        statusEl.textContent = message;
+        if (enableLink) enableLink.style.display = response.enabled ? 'none' : 'inline-block';
+    } catch (error) {
+        console.log('Could not load 2FA status:', error);
+        statusEl.textContent = 'Could not load two-factor authentication status.';
+    }
+}
 
 // Metadata Services Functions
 

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -302,6 +302,19 @@ input:checked + .slider:before {
             </div>
         </div>
 
+        <div class="settings-section" id="twoFactorSection">
+            <h2>🛡️ Two-Factor Authentication</h2>
+            <div class="form-help">
+                <small>Add an extra verification step to your login using an authenticator app.</small>
+            </div>
+            <div class="form-group">
+                <small id="securityTwoFactorStatus">Loading status…</small>
+            </div>
+            <div class="form-group">
+                <a id="twoFactorEnableLink" href="/2fa/setup" class="btn btn-primary" style="display: none;">🔐 Enable Two-Factor Authentication</a>
+            </div>
+        </div>
+
 
         <div class="settings-section">
             <h2>Paths</h2>


### PR DESCRIPTION
## Summary

Reported directly by the user: "There is not place to configure OAuth or 2FA."

The `/2fa/setup` flow itself fully works — the only place that ever linked to it, `dashboard.html`'s "Security Settings" section, is unreachable (`/dashboard` redirects to `/`, which renders a completely different template). Adds a real "Two-Factor Authentication" section to Settings: live status from `GET /2fa/api/status`, and a working link to `/2fa/setup` when not enabled.

**Also found while investigating**: `settings.html` already has a second, separate 2FA-enable flow (a JS-generated modal, `insertAdjacentHTML`) inside an already-known-dead code block from an earlier task — nothing calls `openModal('twoFactorModal')` anywhere. Left untouched rather than resurrecting a second, unverified implementation; used a distinct element ID to guarantee no collision.

**Deliberately not included**: an inline "disable 2FA" button — `POST /2fa/api/disable` verifies the password against a different, potentially-stale credential store than the one you actually log in with (filed as #334). Building UI on that now would just expose more people to it.

**OAuth's equivalent gap** (no UI to configure provider credentials at all) is real but bigger in scope — tracked separately, not in this PR.

## Test plan

- [x] No backend changes
- [x] Full suite: 123 passed, 1 skipped, unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>