### PR TITLE
fix(2fa): GET /2fa/api/status crashed with 500 for every caller

### DIFF
--- a/src/api/fastapi/two_factor_auth.py
+++ b/src/api/fastapi/two_factor_auth.py
@@ -302,13 +302,18 @@ async def get_two_factor_status(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
-        # Get status from service
-        status_data = TwoFactorService.get_user_two_factor_status(user.id)
+        # Get status from service. Note: get_two_factor_status's return
+        # dict has no "last_used" or "setup_date" keys — this codebase
+        # doesn't track either yet, so these always fall through to the
+        # response model's None defaults. Not a regression: they never
+        # had real values before this fix either, since the service call
+        # itself always raised (see git history for the prior bug).
+        status_data = TwoFactorService.get_two_factor_status(user.id)
 
         return TwoFactorStatusResponse(
             enabled=status_data.get("enabled", False),
             last_used=status_data.get("last_used"),
-            backup_codes_remaining=status_data.get("backup_codes_remaining", 0),
+            backup_codes_remaining=status_data.get("backup_codes_count", 0),
             setup_date=status_data.get("setup_date"),
         )
 

--- a/tests/unit/test_two_factor_status_endpoint.py
+++ b/tests/unit/test_two_factor_status_endpoint.py
@@ -1,0 +1,142 @@
+"""Regression test for GET /2fa/api/status returning 500 for every caller.
+
+Root cause: the endpoint called TwoFactorService.get_user_two_factor_status
+(src/api/fastapi/two_factor_auth.py:306), a method that has never existed
+on TwoFactorService — the real method is get_two_factor_status. This went
+unnoticed because nothing in the frontend ever called this endpoint until
+a Settings page fix wired it up (2026-08-11), immediately surfacing the
+crash via the browser console.
+
+Also fixed: even with the correct method name, the endpoint read a
+"backup_codes_remaining" key that the real method never returns — it
+returns "backup_codes_count" instead. Confirmed by reading
+TwoFactorService.get_two_factor_status directly, not guessed.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.two_factor_auth import router
+from src.database.connection import Base, get_db_session
+from src.database.models import User, UserRole
+
+
+@pytest.fixture
+def session_factory():
+    # StaticPool + check_same_thread=False: get_db_session is a sync
+    # generator dependency, dispatched to a worker thread by anyio while
+    # the async route handler runs on the event-loop thread.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[User.__table__])
+    return sessionmaker(bind=engine)
+
+
+def _seed_user(session_factory, two_factor_enabled=False, backup_codes=None):
+    session = session_factory()
+    user = User(
+        username="someone",
+        email="someone@test.local",
+        password="Sup3rSecret!",
+        role=UserRole.USER,
+    )
+    user.two_factor_enabled = two_factor_enabled
+    if backup_codes is not None:
+        import json
+
+        user.backup_codes = json.dumps(backup_codes)
+    session.add(user)
+    session.commit()
+    user_id = user.id
+    session.close()
+    return user_id
+
+
+@contextmanager
+def _fake_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()
+
+
+def _patch_get_db(session_factory):
+    # TwoFactorService.get_two_factor_status uses get_db() internally — a
+    # completely separate access path from the FastAPI-injected
+    # get_db_session dependency overridden below. two_factor_service.py
+    # imports get_db via `from src.database.connection import get_db` at
+    # module level, which binds its OWN name in that module's namespace —
+    # patching src.database.connection.get_db does not affect it, since
+    # that patch only rebinds the name where it was originally defined,
+    # not everywhere it was already imported. Must patch it where it's
+    # actually looked up: src.services.two_factor_service.get_db.
+    return patch(
+        "src.services.two_factor_service.get_db",
+        lambda: _fake_get_db(session_factory),
+    )
+
+
+def _make_client(session_factory, user_id):
+    app = FastAPI()
+    app.include_router(router)
+
+    def _override_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = _override_db
+    app.dependency_overrides[require_authentication] = lambda: {
+        "user_id": user_id,
+        "role": "USER",
+        "authenticated": True,
+    }
+    return TestClient(app)
+
+
+class TestTwoFactorStatusEndpoint:
+    def test_returns_200_not_500_for_a_user_without_2fa(self, session_factory):
+        user_id = _seed_user(session_factory, two_factor_enabled=False)
+        client = _make_client(session_factory, user_id)
+
+        with _patch_get_db(session_factory):
+            response = client.get("/2fa/api/status")
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    def test_returns_correct_backup_codes_remaining_for_enabled_user(
+        self, session_factory
+    ):
+        user_id = _seed_user(
+            session_factory,
+            two_factor_enabled=True,
+            backup_codes=["code1", "code2", "code3"],
+        )
+        client = _make_client(session_factory, user_id)
+
+        with _patch_get_db(session_factory):
+            response = client.get("/2fa/api/status")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        # Regression pin: the endpoint used to read "backup_codes_remaining"
+        # from the service's response dict, which only ever has
+        # "backup_codes_count" — silently always defaulting to 0.
+        assert body["backup_codes_remaining"] == 3


### PR DESCRIPTION
## Summary

Found live: within seconds of #335 (settings-page 2FA entry point) actually calling this endpoint for the first time ever, it 500'd.

Root cause was in the server log, not guessed:
```
AttributeError: type object 'TwoFactorService' has no attribute 'get_user_two_factor_status'. Did you mean: 'get_two_factor_status'?
```

Pre-existing bug — this endpoint predates this session's work; nothing in the frontend had ever called it before, so it silently rotted.

Also fixed: even with the correct method name, the endpoint read a `backup_codes_remaining` key that `get_two_factor_status` never returns — the real key is `backup_codes_count`. Confirmed by reading the method directly. Would have silently always reported 0 remaining codes.

## Test plan

- [x] `tests/unit/test_two_factor_status_endpoint.py` — TDD-verified against the live bug (reproduced the exact 500, then the exact wrong-count bug) before fixing either
- [x] Full suite: 125 passed, 1 skipped, no regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>