### PR TITLE
style(auth): larger login artwork with tighter, responsive spacing

### DIFF
--- a/frontend/templates/auth/login.html
+++ b/frontend/templates/auth/login.html
@@ -42,21 +42,26 @@
             border: 1px solid var(--border-primary, #444444);
             border-radius: 10px;
             box-shadow: 0 12px 40px var(--shadow, rgba(0,0,0,0.3));
-            padding: 32px 28px;
+            padding: 16px 20px 28px;
             width: 100%;
-            max-width: 380px;
+            max-width: 600px;
             margin: 1rem;
         }
 
         .logo {
             text-align: center;
-            margin-bottom: 28px;
+            margin-bottom: 12px;
         }
 
         .logo img {
-            width: 100%;
-            max-width: 220px;
+            display: block;
+            margin: 0 auto;
+            /* Native asset is 612x562 — cap at 500px tall on screens with
+               room for it, but shrink proportionally (never crop/overflow)
+               on narrower viewports via max-width. */
             height: auto;
+            max-height: 500px;
+            max-width: 100%;
         }
 
         .form-group {
@@ -152,7 +157,7 @@
         @media (max-width: 480px) {
             .login-container {
                 margin: 0.5rem;
-                padding: 24px 20px;
+                padding: 12px 16px 20px;
             }
         }
     </style>


### PR DESCRIPTION
## Summary

Requested directly by the user: less padding around the login artwork, and the image at "full 500px height, or a screen-appropriate approximation."

- Reduced container padding and widened it to comfortably fit the larger image
- Reduced spacing between the image and the form below
- Image now caps at 500px tall where there's room, but scales down proportionally (never crops/overflows) on narrower viewports
- Mobile padding tightened to match

Purely visual — no backend changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>