### PR TITLE
fix: 2FA Enable links point at JSON stub instead of real setup page

### DIFF
--- a/frontend/templates/dashboard.html
+++ b/frontend/templates/dashboard.html
@@ -96,7 +96,7 @@
                     Manage 2FA
                 </a>
             {% else %}
-                <a href="/2fa/setup" class="btn btn-primary" aria-label="Enable two-factor authentication">
+                <a href="/auth/2fa/setup" class="btn btn-primary" aria-label="Enable two-factor authentication">
                     <iconify-icon icon="mdi:shield-plus" aria-hidden="true"></iconify-icon>
                     Enable 2FA
                 </a>

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -311,7 +311,13 @@ input:checked + .slider:before {
                 <small id="securityTwoFactorStatus">Loading status…</small>
             </div>
             <div class="form-group">
-                <a id="twoFactorEnableLink" href="/2fa/setup" class="btn btn-primary" style="display: none;">🔐 Enable Two-Factor Authentication</a>
+                <!-- /auth/2fa/setup renders the real HTML setup page
+                     (frontend_router.py's two_fa_setup_page -> auth/2fa_setup.html).
+                     Do not point this at /2fa/setup: that path collides with an
+                     unfinished JSON-stub route of the same name under the /2fa
+                     API router (two_factor_auth.py's setup_page), which always
+                     returns raw JSON regardless of its response_class annotation. -->
+                <a id="twoFactorEnableLink" href="/auth/2fa/setup" class="btn btn-primary" style="display: none;">🔐 Enable Two-Factor Authentication</a>
             </div>
         </div>
 

--- a/tests/unit/test_2fa_setup_link_target.py
+++ b/tests/unit/test_2fa_setup_link_target.py
@@ -1,0 +1,46 @@
+"""Regression test: the "Enable Two-Factor Authentication" link must point
+at the real HTML setup page, not the JSON-stub route of the same name.
+
+Root cause of the original bug: settings.html and dashboard.html both
+linked to /2fa/setup, a plain browser navigation target. That path is
+served by two_factor_auth.py's setup_page — an unfinished placeholder
+(literally commented "In a real implementation, this would render the 2FA
+setup template. For now, return setup instructions") that always returns
+JSONResponse regardless of its response_class=HTMLResponse annotation, so
+clicking the link showed the browser's raw JSON viewer instead of a page.
+
+The real, fully-built setup page (QR code, manual entry key, backup codes,
+token confirmation form) lives at /auth/2fa/setup, registered in
+frontend_router.py's two_fa_setup_page -> auth/2fa_setup.html. The two
+paths differ only by the /auth prefix, and both resolve, which is exactly
+why the wrong one silently "worked" (200 OK) without any error to notice.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+# The JSON-stub route. Any href pointing exactly here (not /auth/2fa/setup)
+# is the regression this test guards against.
+STUB_PATH_PATTERN = re.compile(r'href=["\']\/2fa\/setup["\']')
+
+REAL_SETUP_PATH = "/auth/2fa/setup"
+
+
+class TestTwoFactorSetupLinkTarget:
+    def test_settings_page_links_to_real_setup_page(self):
+        html = (TEMPLATES_DIR / "settings.html").read_text()
+        assert not STUB_PATH_PATTERN.search(html), (
+            "settings.html links to the /2fa/setup JSON stub instead of "
+            f"the real {REAL_SETUP_PATH} HTML page"
+        )
+        assert REAL_SETUP_PATH in html
+
+    def test_dashboard_page_links_to_real_setup_page(self):
+        html = (TEMPLATES_DIR / "dashboard.html").read_text()
+        assert not STUB_PATH_PATTERN.search(html), (
+            "dashboard.html links to the /2fa/setup JSON stub instead of "
+            f"the real {REAL_SETUP_PATH} HTML page"
+        )
+        assert REAL_SETUP_PATH in html


### PR DESCRIPTION
## Root cause
The "Enable Two-Factor Authentication" links on Settings (added in #335) and Dashboard pointed at `/2fa/setup`, a plain browser navigation target served by `two_factor_auth.py`'s `setup_page` — an unfinished placeholder that always returns `JSONResponse` regardless of its `response_class=HTMLResponse` annotation (its own comment: *"In a real implementation, this would render the 2FA setup template. For now, return setup instructions"*). Clicking it showed the browser's raw JSON viewer.

The real, fully-built setup page (QR code, manual entry key, backup codes, confirmation form) already exists at `/auth/2fa/setup` (`frontend_router.py`'s `two_fa_setup_page` → `auth/2fa_setup.html`). This was a one-prefix link-target bug, not a missing feature — both paths return 200, which is why it went unnoticed.

## Fix
- `frontend/templates/settings.html`, `frontend/templates/dashboard.html`: link now points at `/auth/2fa/setup`.
- `tests/unit/test_2fa_setup_link_target.py`: regression test guarding both templates against reverting to the stub path.

## Testing
- New test passes standalone (2 passed).
- Full `tests/unit` suite could not be run end-to-end in this environment — `httpx` isn't installed, which is a pre-existing gap unrelated to this change (same failure affects many untouched test files, e.g. `test_users_api.py`, `test_verify_login.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)