### PR TITLE
fix(auth): 2FA silently fails on success + unreadable backup codes (live lockout root cause)

### DIFF
--- a/frontend/templates/auth/2fa_setup.html
+++ b/frontend/templates/auth/2fa_setup.html
@@ -128,6 +128,7 @@
         
         .backup-code {
             background: white;
+            color: #212529;
             padding: 0.5rem;
             border-radius: 4px;
             font-family: monospace;

--- a/src/services/two_factor_service.py
+++ b/src/services/two_factor_service.py
@@ -160,6 +160,7 @@ class TwoFactorService:
                     # Log failed verification attempt
                     AuditService.log_security_event(
                         "2fa_verification_failed",
+                        "2FA setup verification failed — invalid TOTP token",
                         user=user,
                         additional_data={
                             "setup_confirmation": True,
@@ -175,11 +176,12 @@ class TwoFactorService:
 
                 # Log successful 2FA setup
                 AuditService.log_user_action(
-                    "2fa_enabled",
+                    "enabled",
+                    "2fa",
                     user=user,
-                    admin_user_id=admin_user_id,
                     additional_data={
-                        "setup_timestamp": datetime.now(timezone.utc).isoformat()
+                        "admin_user_id": admin_user_id,
+                        "setup_timestamp": datetime.now(timezone.utc).isoformat(),
                     },
                 )
 
@@ -212,6 +214,7 @@ class TwoFactorService:
                     if not check_password_hash(user.password_hash, password):
                         AuditService.log_security_event(
                             "2fa_disable_failed",
+                            "2FA disable attempt failed — incorrect password",
                             user=user,
                             additional_data={"reason": "incorrect_password"},
                         )
@@ -226,10 +229,11 @@ class TwoFactorService:
 
                 # Log 2FA disable
                 AuditService.log_user_action(
-                    "2fa_disabled",
+                    "disabled",
+                    "2fa",
                     user=user,
-                    admin_user_id=admin_user_id,
                     additional_data={
+                        "admin_user_id": admin_user_id,
                         "disabled_by_admin": admin_user_id is not None,
                         "disable_timestamp": datetime.now(timezone.utc).isoformat(),
                     },
@@ -305,6 +309,7 @@ class TwoFactorService:
                             # Log backup code usage
                             AuditService.log_security_event(
                                 "2fa_backup_code_used",
+                                "2FA login accepted a backup recovery code",
                                 user=user,
                                 additional_data={"remaining_codes": len(backup_codes)},
                             )
@@ -315,11 +320,16 @@ class TwoFactorService:
 
                 # Verify TOTP token
                 if TwoFactorService.verify_totp_token(user.two_factor_secret, token):
-                    AuditService.log_security_event("2fa_login_success", user=user)
+                    AuditService.log_security_event(
+                        "2fa_login_success",
+                        "2FA login verification succeeded",
+                        user=user,
+                    )
                     return True, "Two-factor authentication successful"
                 else:
                     AuditService.log_security_event(
                         "2fa_login_failed",
+                        "2FA login verification failed — invalid TOTP token",
                         user=user,
                         additional_data={"provided_token": token},
                     )
@@ -358,10 +368,11 @@ class TwoFactorService:
 
                 # Log backup code regeneration
                 AuditService.log_user_action(
-                    "2fa_backup_codes_regenerated",
+                    "backup_codes_regenerated",
+                    "2fa",
                     user=user,
-                    admin_user_id=admin_user_id,
                     additional_data={
+                        "admin_user_id": admin_user_id,
                         "regenerated_by_admin": admin_user_id is not None,
                         "regenerate_timestamp": datetime.now(timezone.utc).isoformat(),
                     },

--- a/tests/unit/test_two_factor_service_audit_logging.py
+++ b/tests/unit/test_two_factor_service_audit_logging.py
@@ -1,0 +1,242 @@
+"""Regression tests for TwoFactorService's broken AuditService call sites.
+
+Root cause (found 2026-08-12, live lockout incident): every
+AuditService.log_security_event / log_user_action call in
+src/services/two_factor_service.py passes arguments that don't match the
+real method signatures — missing the required `message` argument (or, for
+log_user_action, missing `resource` and passing a nonexistent
+`admin_user_id` kwarg). Each call site raises TypeError at the call itself
+(argument binding fails before AuditService's own body — and its own
+internal try/except — ever runs).
+
+Every TwoFactorService method wraps its whole body in `except Exception`,
+so the TypeError is swallowed and turned into a reported failure — even on
+the SUCCESS path, after the DB write already committed. Concretely:
+confirm_two_factor_setup sets user.two_factor_enabled = True and commits,
+then immediately crashes calling AuditService.log_user_action, returning
+False to the caller. The frontend shows "verification failed" while 2FA is
+now actually enabled with no confirmed-working authenticator entry —
+exactly what caused a real admin lockout.
+
+These tests call the real (unpatched) AuditService — the bug is a call-time
+argument-binding TypeError, so mocking AuditService away would hide it.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pyotp
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.database.connection import Base
+from src.database.models import User, UserRole
+from src.services.two_factor_service import TwoFactorService
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__])
+    return sessionmaker(bind=engine)
+
+
+@contextmanager
+def _fake_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()
+
+
+def _patch_get_db(session_factory):
+    # See tests/unit/test_two_factor_status_endpoint.py for why this has to
+    # patch src.services.two_factor_service.get_db specifically.
+    return patch(
+        "src.services.two_factor_service.get_db",
+        lambda: _fake_get_db(session_factory),
+    )
+
+
+def _seed_user(session_factory, password="Sup3rSecret!", two_factor_enabled=False):
+    session = session_factory()
+    user = User(
+        username="someone",
+        email="someone@test.local",
+        password=password,
+        role=UserRole.USER,
+    )
+    user.two_factor_enabled = two_factor_enabled
+    session.add(user)
+    session.commit()
+    user_id = user.id
+    session.close()
+    return user_id
+
+
+class TestConfirmTwoFactorSetup:
+    def test_valid_token_enables_2fa_and_returns_success(self, session_factory):
+        user_id = _seed_user(session_factory)
+        secret = TwoFactorService.generate_secret()
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.two_factor_secret = secret
+        session.commit()
+        session.close()
+
+        valid_token = pyotp.TOTP(secret).now()
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.confirm_two_factor_setup(
+                user_id, valid_token
+            )
+
+        assert success is True
+        assert message == "Two-factor authentication enabled successfully"
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        assert user.two_factor_enabled is True
+        session.close()
+
+    def test_invalid_token_returns_failure_without_crashing(self, session_factory):
+        user_id = _seed_user(session_factory)
+        secret = TwoFactorService.generate_secret()
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.two_factor_secret = secret
+        session.commit()
+        session.close()
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.confirm_two_factor_setup(
+                user_id, "000000"
+            )
+
+        assert success is False
+        # Pin the real rejection message, not a swallowed TypeError like
+        # "Confirmation failed: log_security_event() missing 1 required
+        # positional argument: 'message'".
+        assert message == "Invalid verification code. Please try again."
+
+
+class TestDisableTwoFactor:
+    def test_correct_password_disables_2fa_and_returns_success(self, session_factory):
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.disable_two_factor(
+                user_id, "Sup3rSecret!"
+            )
+
+        assert success is True
+        assert message == "Two-factor authentication disabled successfully"
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        assert user.two_factor_enabled is False
+        session.close()
+
+    def test_wrong_password_returns_failure_without_crashing(self, session_factory):
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.disable_two_factor(
+                user_id, "WrongPassword!"
+            )
+
+        assert success is False
+        assert message == "Incorrect password"
+
+
+class TestVerifyTwoFactorLogin:
+    def test_valid_totp_returns_success(self, session_factory):
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+        secret = TwoFactorService.generate_secret()
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.two_factor_secret = secret
+        session.commit()
+        session.close()
+
+        valid_token = pyotp.TOTP(secret).now()
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.verify_two_factor_login(
+                user_id, valid_token
+            )
+
+        assert success is True
+        assert message == "Two-factor authentication successful"
+
+    def test_invalid_totp_returns_failure_without_crashing(self, session_factory):
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+        secret = TwoFactorService.generate_secret()
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.two_factor_secret = secret
+        session.commit()
+        session.close()
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.verify_two_factor_login(
+                user_id, "000000"
+            )
+
+        assert success is False
+        assert message == "Invalid verification code"
+
+    def test_valid_backup_code_returns_success_and_consumes_code(self, session_factory):
+        import json
+
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.backup_codes = json.dumps(["ABCD1234", "EFGH5678"])
+        session.commit()
+        session.close()
+
+        with _patch_get_db(session_factory):
+            success, message = TwoFactorService.verify_two_factor_login(
+                user_id, "abcd1234"
+            )
+
+        assert success is True
+        assert message == "Backup code accepted"
+
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        remaining = json.loads(user.backup_codes)
+        assert remaining == ["EFGH5678"]
+        session.close()
+
+
+class TestRegenerateBackupCodes:
+    def test_correct_password_regenerates_codes_without_crashing(self, session_factory):
+        import json
+
+        user_id = _seed_user(session_factory, two_factor_enabled=True)
+        session = session_factory()
+        user = session.query(User).filter_by(id=user_id).first()
+        user.backup_codes = json.dumps(["OLDCODE1"])
+        session.commit()
+        session.close()
+
+        with _patch_get_db(session_factory):
+            success, message, new_codes = TwoFactorService.regenerate_backup_codes(
+                user_id, "Sup3rSecret!"
+            )
+
+        assert success is True
+        assert message == "Backup codes regenerated successfully"
+        assert new_codes is not None
+        assert "OLDCODE1" not in new_codes
+        assert len(new_codes) == 8


### PR DESCRIPTION
## Summary

Found and fixed live during dev 2FA testing right after #340 merged — the user got locked out of the `admin` account mid-investigation (immediately unblocked via a direct DB fix; this PR is the real fix).

### Commit 1: TwoFactorService audit-log calls crash, silently failing successful 2FA operations

Every `AuditService.log_security_event`/`log_user_action` call in `two_factor_service.py` passed arguments that don't match the real method signatures (missing required `message`; `log_user_action` missing `resource`, passing a nonexistent `admin_user_id` kwarg). Each raised a `TypeError` at the call site, swallowed by the caller's own `except Exception`, and reported as a generic failure — **even on success, after the DB write had already committed**.

Concretely: `confirm_two_factor_setup` sets `user.two_factor_enabled = True`, commits, then crashes on the very next line logging the action — returning `False` to the frontend while 2FA is actually now enabled. That's exactly what caused the lockout: the UI showed "verification failed," the user canceled out, but the account was already 2FA-protected with no confirmed-working authenticator entry.

Same bug hit `disable_two_factor`, and all three branches of `verify_two_factor_login` (TOTP success, TOTP failure, backup code). The backup-code branch is worse: its crash lands inside a nested `except (json.JSONDecodeError, TypeError)` that silently swallows it and falls through to re-validate the same value as a TOTP token — after the backup code was already consumed and committed. A user entering a valid backup code would see it rejected and lose the code for nothing.

Fixed all 9 call sites to match `AuditService`'s real signatures.

### Commit 2: backup recovery codes unreadable (white-on-white) in dark mode

`.backup-code` set `background: white` with no explicit `color`, inheriting the page's `--text-primary` (also white in this app's default dark theme) — codes rendered but were invisible. Screenshot: `docs/screenshots/backup recovery codes.png`.

## Test plan

- [x] New `tests/unit/test_two_factor_service_audit_logging.py` — 8 cases covering `confirm_two_factor_setup`, `disable_two_factor`, `verify_two_factor_login` (TOTP + backup code), `regenerate_backup_codes`, success and failure paths
- [x] Verified RED against pre-fix code — all 8 fail with the exact swallowed-TypeError messages
- [x] GREEN after the fix
- [x] Full `tests/unit/` suite: 87 passed, no regressions (4 unrelated pre-existing failures in this local env from yt-dlp binary not being installed — excluded, not caused by this change)
- [x] Both fixes deployed live to the dev container and manually verified (health check green, fix file present)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>