### PR TITLE
fix(auth): 2FA "return to profile" links point at a nonexistent page

### DIFF
--- a/frontend/templates/auth/2fa_setup.html
+++ b/frontend/templates/auth/2fa_setup.html
@@ -353,7 +353,7 @@
             </div>
             
             <div class="button-group">
-                <a href="/profile/" class="btn btn-secondary">Cancel</a>
+                <a href="/settings#twoFactorSection" class="btn btn-secondary">Cancel</a>
                 <button onclick="nextStep()" class="btn btn-primary">Continue</button>
             </div>
         </div>
@@ -444,7 +444,7 @@
                 </ul>
             </div>
             
-            <a href="/profile/" class="btn btn-primary btn-block">Return to Profile</a>
+            <a href="/settings#twoFactorSection" class="btn btn-primary btn-block">Return to Settings</a>
         </div>
     </div>
 

--- a/frontend/templates/dashboard.html
+++ b/frontend/templates/dashboard.html
@@ -91,7 +91,7 @@
                 {% endif %}
             </p>
             {% if user.two_factor_enabled %}
-                <a href="/profile/#security" class="btn btn-success" aria-label="Manage two-factor authentication">
+                <a href="/settings#twoFactorSection" class="btn btn-success" aria-label="Manage two-factor authentication">
                     <iconify-icon icon="mdi:shield-check" aria-hidden="true"></iconify-icon>
                     Manage 2FA
                 </a>

--- a/src/api/fastapi/two_factor_auth.py
+++ b/src/api/fastapi/two_factor_auth.py
@@ -101,7 +101,7 @@ async def setup_page(
             return JSONResponse(
                 content={
                     "message": "Two-factor authentication is already enabled for your account.",
-                    "redirect": "/profile",
+                    "redirect": "/settings#twoFactorSection",
                 },
                 status_code=200,
             )

--- a/tests/unit/test_2fa_profile_link_target.py
+++ b/tests/unit/test_2fa_profile_link_target.py
@@ -1,0 +1,44 @@
+"""Regression test: 2FA setup's "Return to Profile"/"Cancel" links, and
+dashboard's "Manage two-factor authentication" link, must point at a real
+page.
+
+Root cause: /profile is not a registered route anywhere in this app (no
+frontend_router.py route, no template_system.py handler) — it 404s with
+FastAPI's default JSON {"detail":"Not Found"}, which is what a browser's
+devtools JSON viewer was showing users after completing 2FA setup and
+clicking "Return to Profile."
+
+The real page that actually hosts 2FA management is /settings, in the
+#twoFactorSection section (settings.html) — confirmed live via
+test_2fa_setup_link_target.py's sibling regression coverage of the same
+section.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+# Any href pointing at the nonexistent /profile page (with or without a
+# trailing slash or #fragment) is the regression this test guards against.
+DEAD_PROFILE_LINK_PATTERN = re.compile(r'href=["\']\/profile\/?(#[^"\']*)?["\']')
+
+REAL_DESTINATION = "/settings#twoFactorSection"
+
+
+class TestTwoFactorProfileLinkTarget:
+    def test_2fa_setup_page_links_to_real_settings_page(self):
+        html = (TEMPLATES_DIR / "auth" / "2fa_setup.html").read_text()
+        assert not DEAD_PROFILE_LINK_PATTERN.search(html), (
+            "auth/2fa_setup.html links to /profile, which is not a "
+            f"registered route — should link to {REAL_DESTINATION}"
+        )
+        assert REAL_DESTINATION in html
+
+    def test_dashboard_page_links_to_real_settings_page(self):
+        html = (TEMPLATES_DIR / "dashboard.html").read_text()
+        assert not DEAD_PROFILE_LINK_PATTERN.search(html), (
+            "dashboard.html links to /profile, which is not a registered "
+            f"route — should link to {REAL_DESTINATION}"
+        )
+        assert REAL_DESTINATION in html


### PR DESCRIPTION
## Summary

Found live during 2FA re-testing after #341: after successfully completing 2FA setup, clicking "Return to Profile" took the user to `/profile/`, which is not a registered route anywhere in this app — 404s with FastAPI's default JSON `{"detail":"Not Found"}`, rendered by the browser's devtools JSON viewer instead of a page.

The real page that hosts 2FA management is `/settings`, in the `#twoFactorSection` section (confirmed live by the existing `test_2fa_setup_link_target.py`). Fixed all three dead references:
- `auth/2fa_setup.html` — Cancel and Return-to-Profile buttons
- `dashboard.html` — Manage-2FA button
- `two_factor_auth.py`'s `/2fa/setup` JSON stub's `redirect` field (currently unused by any live path, fixed for consistency)

## Test plan

- [x] New `tests/unit/test_2fa_profile_link_target.py` — same static-content pattern as the existing `test_2fa_setup_link_target.py`. Verified RED (both dead `/profile` hrefs caught) before the fix, GREEN after.
- [x] Full `tests/unit/` suite: 89 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>