### PR TITLE
fix(auth): disabling 2FA checked the wrong password store, and never actually worked (#334)

### DIFF
--- a/src/api/fastapi/two_factor_auth.py
+++ b/src/api/fastapi/two_factor_auth.py
@@ -19,7 +19,6 @@ from src.api.fastapi.auth_dependencies import (
 from src.database.connection import get_db_session
 from src.database.models import User
 from src.services.audit_service import AuditService
-from src.services.auth_service import AuthService
 from src.services.two_factor_service import TwoFactorService
 
 logger = logging.getLogger("mvidarr.fastapi.two_factor")
@@ -220,18 +219,14 @@ async def disable_two_factor(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
-        # Verify password
-        username = current_user.get("username", "admin")
-        auth_success, _, _, _, _ = AuthService.authenticate_user(
-            username, disable_request.password, "127.0.0.1", "FastAPI-2FA-Disable"
-        )
-
-        if not auth_success:
-            raise HTTPException(status_code=400, detail="Invalid password")
-
-        # Disable 2FA
+        # Disable 2FA. Password is verified inside disable_two_factor
+        # against SimpleAuthService — the live credential store — not
+        # here: a prior version of this endpoint duplicated that check
+        # against the wrong store (User.password_hash, #334) AND passed
+        # disable_request.token instead of .password to the service call
+        # below, so disabling 2FA never actually worked via this endpoint.
         success, message = TwoFactorService.disable_two_factor(
-            user.id, disable_request.token
+            user.id, disable_request.password
         )
 
         if success:

--- a/src/services/two_factor_service.py
+++ b/src/services/two_factor_service.py
@@ -207,11 +207,18 @@ class TwoFactorService:
                 if not user.two_factor_enabled:
                     return False, "Two-factor authentication is not enabled"
 
-                # Verify password (unless admin is disabling)
+                # Verify password (unless admin is disabling). Checked
+                # against SimpleAuthService — the live credential store the
+                # user actually logs in with — not User.password_hash,
+                # which is a separate, independently-writable column that
+                # can silently drift out of sync with it (#334).
                 if admin_user_id is None:
-                    from werkzeug.security import check_password_hash
+                    from src.services.simple_auth_service import SimpleAuthService
 
-                    if not check_password_hash(user.password_hash, password):
+                    auth_success, _ = SimpleAuthService.authenticate(
+                        user.username, password
+                    )
+                    if not auth_success:
                         AuditService.log_security_event(
                             "2fa_disable_failed",
                             "2FA disable attempt failed — incorrect password",

--- a/tests/unit/test_2fa_disable_password_store.py
+++ b/tests/unit/test_2fa_disable_password_store.py
@@ -1,0 +1,166 @@
+"""Regression tests for #334: disabling 2FA checked the wrong password
+store, and (found while fixing it) the endpoint didn't even pass a
+password through — it forwarded the request's optional `token` field to
+TwoFactorService.disable_two_factor's `password` parameter instead.
+
+Root cause: the live login system (SimpleAuthService) authenticates
+against `simple_auth_username`/`simple_auth_password` in the Settings
+table. `User.password_hash` is a separate, independently-writable column
+that the Settings > Credentials panel never updates — it can silently
+drift out of sync. TwoFactorService.disable_two_factor checked
+User.password_hash via werkzeug's check_password_hash, so a user who'd
+changed their real login password would have to supply their OLD
+password to turn off 2FA — or, combined with the argument-swap bug below,
+couldn't disable 2FA via this endpoint at all regardless of which
+password they typed.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.two_factor_auth import router
+from src.database.connection import Base, get_db_session
+from src.database.models import User, UserRole
+from src.services.two_factor_service import TwoFactorService
+
+
+@pytest.fixture
+def session_factory():
+    # StaticPool + check_same_thread=False: get_db_session is a sync
+    # generator dependency, dispatched to a worker thread by anyio while
+    # the async route handler runs on the event-loop thread — needed for
+    # TestDisableEndpointForwardsThePasswordField's TestClient requests.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[User.__table__])
+    return sessionmaker(bind=engine)
+
+
+@contextmanager
+def _fake_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()
+
+
+def _patch_get_db(session_factory):
+    return patch(
+        "src.services.two_factor_service.get_db",
+        lambda: _fake_get_db(session_factory),
+    )
+
+
+def _seed_user(session_factory, stale_password="OldSecret9!"):
+    """Seed a user whose User.password_hash is a password the user no
+    longer actually logs in with — simulating a credentials update that
+    only touched SimpleAuthService's store, not this row (see #334's
+    description of how the two stores drift apart)."""
+    session = session_factory()
+    user = User(
+        username="someone",
+        email="someone@test.local",
+        password=stale_password,
+        role=UserRole.USER,
+    )
+    user.two_factor_enabled = True
+    session.add(user)
+    session.commit()
+    user_id = user.id
+    session.close()
+    return user_id
+
+
+class TestServiceChecksLiveCredentialStore:
+    def test_current_real_password_disables_2fa(self, session_factory):
+        user_id = _seed_user(session_factory)
+
+        with _patch_get_db(session_factory), patch(
+            "src.services.simple_auth_service.SimpleAuthService.authenticate",
+            return_value=(True, "OK"),
+        ) as mock_auth:
+            success, message = TwoFactorService.disable_two_factor(
+                user_id, "CurrentSecret9!"
+            )
+
+        assert success is True
+        assert message == "Two-factor authentication disabled successfully"
+        # Confirms the check went through the live store, not
+        # check_password_hash(user.password_hash, ...).
+        mock_auth.assert_called_once_with("someone", "CurrentSecret9!")
+
+    def test_stale_user_password_hash_value_is_rejected(self, session_factory):
+        """The user's OLD password (still sitting in User.password_hash)
+        must NOT work — proving the check isn't silently falling back to
+        that stale column."""
+        user_id = _seed_user(session_factory, stale_password="OldSecret9!")
+
+        with _patch_get_db(session_factory), patch(
+            "src.services.simple_auth_service.SimpleAuthService.authenticate",
+            return_value=(False, "Invalid username or password"),
+        ):
+            success, message = TwoFactorService.disable_two_factor(
+                user_id, "OldSecret9!"
+            )
+
+        assert success is False
+        assert message == "Incorrect password"
+
+
+class TestDisableEndpointForwardsThePasswordField:
+    """Regression for the argument-swap bug found while fixing #334:
+    disable_two_factor(request) called
+    TwoFactorService.disable_two_factor(user.id, disable_request.token) —
+    the TOTP token field, not .password — so the service's password check
+    was always being handed the wrong value (or None)."""
+
+    def _make_client(self, session_factory, user_id):
+        app = FastAPI()
+        app.include_router(router)
+
+        def _override_db():
+            session = session_factory()
+            try:
+                yield session
+            finally:
+                session.close()
+
+        app.dependency_overrides[get_db_session] = _override_db
+        app.dependency_overrides[require_authentication] = lambda: {
+            "user_id": user_id,
+            "username": "someone",
+            "role": "USER",
+            "authenticated": True,
+        }
+        return TestClient(app)
+
+    def test_disable_call_receives_the_password_not_the_token(self, session_factory):
+        user_id = _seed_user(session_factory)
+        client = self._make_client(session_factory, user_id)
+
+        with patch(
+            "src.api.fastapi.two_factor_auth.TwoFactorService.disable_two_factor",
+            return_value=(True, "Two-factor authentication disabled successfully"),
+        ) as mock_disable:
+            response = client.post(
+                "/2fa/api/disable",
+                json={"password": "CurrentSecret9!", "token": "123456"},
+            )
+
+        assert response.status_code == 200
+        # The regression: this used to be called with the token
+        # ("123456") in the password slot.
+        mock_disable.assert_called_once_with(user_id, "CurrentSecret9!")

--- a/tests/unit/test_two_factor_service_audit_logging.py
+++ b/tests/unit/test_two_factor_service_audit_logging.py
@@ -126,10 +126,18 @@ class TestConfirmTwoFactorSetup:
 
 
 class TestDisableTwoFactor:
+    # disable_two_factor verifies the password via SimpleAuthService — the
+    # live credential store the user actually logs in with, not
+    # User.password_hash (see test_2fa_disable_password_store.py for the
+    # #334 regression coverage of that specific distinction). Patched here
+    # since these tests are only exercising the audit-logging fix.
     def test_correct_password_disables_2fa_and_returns_success(self, session_factory):
         user_id = _seed_user(session_factory, two_factor_enabled=True)
 
-        with _patch_get_db(session_factory):
+        with _patch_get_db(session_factory), patch(
+            "src.services.simple_auth_service.SimpleAuthService.authenticate",
+            return_value=(True, "OK"),
+        ):
             success, message = TwoFactorService.disable_two_factor(
                 user_id, "Sup3rSecret!"
             )
@@ -145,7 +153,10 @@ class TestDisableTwoFactor:
     def test_wrong_password_returns_failure_without_crashing(self, session_factory):
         user_id = _seed_user(session_factory, two_factor_enabled=True)
 
-        with _patch_get_db(session_factory):
+        with _patch_get_db(session_factory), patch(
+            "src.services.simple_auth_service.SimpleAuthService.authenticate",
+            return_value=(False, "Invalid username or password"),
+        ):
             success, message = TwoFactorService.disable_two_factor(
                 user_id, "WrongPassword!"
             )


### PR DESCRIPTION
Fixes #334.

## Summary

Two independent bugs in the same code path:

1. `TwoFactorService.disable_two_factor` verified the password against `User.password_hash` via `check_password_hash`. The live login system (`SimpleAuthService`) authenticates against `simple_auth_username`/`simple_auth_password` in the Settings table — a separate, independently-writable store that the Settings > Credentials panel actually updates. A user who changed their real login password would have to supply their **old** password to disable 2FA.
2. The endpoint had its own redundant pre-check against the *same* wrong store (`AuthService.authenticate_user`), then called `TwoFactorService.disable_two_factor(user.id, disable_request.token)` — passing the request's optional TOTP `token` field into the service's `password` parameter, not `.password`. So even with bug 1 fixed alone, this endpoint still would never work — it was not forwarding a password at all.

**Net effect**: there was no working way to disable 2FA through this endpoint, for any password. (No frontend currently calls this endpoint either — noting that gap separately rather than expanding this fix into building a UI for it.)

Fixed by removing the endpoint's redundant wrong-store pre-check, forwarding `disable_request.password` (not `.token`) to the service, and switching the service's internal check to `SimpleAuthService.authenticate`.

## Test plan

- [x] New `tests/unit/test_2fa_disable_password_store.py` — service-level test proving the live credential store is checked (not the stale `User.password_hash` column), plus an endpoint-level test proving the password field is what actually reaches the service call
- [x] Verified RED against pre-fix code for all 3 new tests
- [x] Updated `test_two_factor_service_audit_logging.py`'s two `disable_two_factor` tests to mock `SimpleAuthService` accordingly
- [x] Full `tests/unit/` suite: 92 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>