### PR TITLE
fix(admin): Create User form had no submit handler (#331)

### DIFF
--- a/frontend/templates/admin/create_user.html
+++ b/frontend/templates/admin/create_user.html
@@ -266,8 +266,10 @@
                 <h2>➕ Create New User</h2>
                 <p>Add a new user to the MVidarr system</p>
             </div>
-            
-            <form method="POST">
+
+            <div id="createUserError" class="alert alert-error" style="display: none;"></div>
+
+            <form id="createUserForm">
                 <div class="form-group">
                     <label for="username">Username <span class="required">*</span></label>
                     <input type="text" id="username" name="username" required 
@@ -429,7 +431,57 @@
 
         // Initialize role description
         document.getElementById('role').dispatchEvent(new Event('change'));
-        
+
+        // Form submission — POSTs JSON to the real, working
+        // /api/admin/users endpoint. Without this, the bare <form> above
+        // would native-POST to this page's own URL (/admin/users/create),
+        // which only has a GET route registered — see issue #331.
+        document.getElementById('createUserForm').addEventListener('submit', function (e) {
+            e.preventDefault();
+
+            const errorBox = document.getElementById('createUserError');
+            errorBox.style.display = 'none';
+
+            const password = document.getElementById('password').value;
+            const confirmPassword = document.getElementById('confirm_password').value;
+            if (password !== confirmPassword) {
+                errorBox.textContent = 'Passwords do not match';
+                errorBox.style.display = 'block';
+                return;
+            }
+
+            const payload = {
+                username: document.getElementById('username').value,
+                email: document.getElementById('email').value,
+                password: password,
+                role: document.getElementById('role').value,
+            };
+
+            const submitButton = e.target.querySelector('button[type="submit"]');
+            submitButton.disabled = true;
+
+            fetch('/api/admin/users', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            })
+                .then(async (response) => {
+                    const data = await response.json();
+                    if (response.ok && data.success) {
+                        window.location.href = '/admin/users';
+                        return;
+                    }
+                    errorBox.textContent = data.detail || data.message || 'Failed to create user';
+                    errorBox.style.display = 'block';
+                    submitButton.disabled = false;
+                })
+                .catch(function () {
+                    errorBox.textContent = 'Failed to create user — could not reach the server';
+                    errorBox.style.display = 'block';
+                    submitButton.disabled = false;
+                });
+        });
+
         // Theme management
         window.currentTheme = window.currentTheme || 'default';
         window.currentMode = window.currentMode || 'dark';

--- a/tests/unit/test_create_user_form_submit.py
+++ b/tests/unit/test_create_user_form_submit.py
@@ -1,0 +1,44 @@
+"""Regression test for #331: the admin "Create User" form had no submit
+handler and no form action, so submitting it POSTed to its own URL,
+/admin/users/create — a path that only has a GET route registered
+(frontend_router.py). No matching POST handler exists there.
+
+The real, working backend endpoint is POST /api/admin/users
+(src/api/fastapi/admin.py) — fully functional, correctly gated by
+require_admin_access, calling AuthService.create_user. It was just never
+called by this page.
+
+Same static-content-assertion approach as test_2fa_setup_link_target.py /
+test_2fa_profile_link_target.py: no browser needed to prove the page
+actually wires its form to the real endpoint.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestCreateUserFormSubmit:
+    def test_form_is_not_a_bare_native_post(self):
+        """A bare <form method="POST"> with no action and no JS handler
+        submits to the current URL (/admin/users/create — GET only, no
+        POST route). The form must either have a real action or be
+        intercepted by JS."""
+        html = (TEMPLATES_DIR / "admin" / "create_user.html").read_text()
+        assert (
+            'id="createUserForm"' in html
+        ), "form needs an id so JS can attach a submit handler to it"
+
+    def test_page_calls_the_real_create_user_endpoint(self):
+        html = (TEMPLATES_DIR / "admin" / "create_user.html").read_text()
+        assert "/api/admin/users" in html, (
+            "create_user.html never calls the real, working "
+            "POST /api/admin/users endpoint"
+        )
+
+    def test_submit_handler_prevents_default_native_post(self):
+        """Without preventDefault, even a correctly-fetch-wired handler
+        would still let the native POST fire, hitting the same dead
+        /admin/users/create route."""
+        html = (TEMPLATES_DIR / "admin" / "create_user.html").read_text()
+        assert "preventDefault" in html


### PR DESCRIPTION
Fixes #331.

## Summary

The admin dashboard's "Create User" page renders correctly (properly gated by `require_admin`), but its form was a bare `<form method="POST">` with no `action` and no JS submit handler. Submitting it native-POSTed to the current URL, `/admin/users/create` — which only has a `GET` route registered (`frontend_router.py`). No matching `POST` handler exists there, so nothing happened.

The real, working backend endpoint is `POST /api/admin/users` (`admin.py`) — fully functional, correctly gated, calls `AuthService.create_user`. It was just never called by this page.

Added a fetch-based JSON submit handler (matching the pattern already used on the login and 2FA setup pages), with client-side password-confirmation matching and inline error display.

## Test plan

- [x] New `tests/unit/test_create_user_form_submit.py` — same static-content-assertion pattern as `test_2fa_setup_link_target.py`: confirms the form has an id for JS to bind to, calls the real `/api/admin/users` endpoint, and prevents the native POST
- [x] Verified RED against pre-fix code (all 3 fail)
- [x] Full `tests/unit/` suite: 92 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>