### PR TITLE
feat(settings): admin UI to configure OAuth login providers (#336)

### DIFF
--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -321,6 +321,65 @@ input:checked + .slider:before {
             </div>
         </div>
 
+        <div class="settings-section" id="oauthProvidersSection">
+            <h2>🔗 OAuth Login Providers</h2>
+            <div class="form-help">
+                <small>Let users sign in via Authentik, Google, or GitHub instead of (or in addition to) a password. Leave a provider's fields blank to keep it disabled. Client secret fields are never pre-filled for security — leave one blank on save to keep the previously-saved value.</small>
+            </div>
+
+            <h3>Authentik</h3>
+            <div class="form-group">
+                <label for="oauth_authentik_base_url">Base URL:</label>
+                <input type="text" id="oauth_authentik_base_url" name="oauth_authentik_base_url" placeholder="https://auth.example.com">
+            </div>
+            <div class="form-group">
+                <label for="oauth_authentik_client_id">Client ID:</label>
+                <input type="text" id="oauth_authentik_client_id" name="oauth_authentik_client_id">
+            </div>
+            <div class="form-group">
+                <label for="oauth_authentik_client_secret">Client Secret:</label>
+                <input type="password" id="oauth_authentik_client_secret" name="oauth_authentik_client_secret" placeholder="Leave blank to keep the existing secret" autocomplete="new-password">
+                <small id="oauth_authentik_client_secret_status"></small>
+            </div>
+            <div class="form-group">
+                <label for="oauth_authentik_redirect_uri">Redirect URI:</label>
+                <input type="text" id="oauth_authentik_redirect_uri" name="oauth_authentik_redirect_uri" class="oauth-redirect-uri-input" data-provider="authentik">
+                <small>Typically <code class="oauth-redirect-uri-hint" data-provider="authentik">{origin}/api/auth/oauth/authentik/callback</code> — register this exact URL with the provider.</small>
+            </div>
+
+            <h3>Google</h3>
+            <div class="form-group">
+                <label for="oauth_google_client_id">Client ID:</label>
+                <input type="text" id="oauth_google_client_id" name="oauth_google_client_id">
+            </div>
+            <div class="form-group">
+                <label for="oauth_google_client_secret">Client Secret:</label>
+                <input type="password" id="oauth_google_client_secret" name="oauth_google_client_secret" placeholder="Leave blank to keep the existing secret" autocomplete="new-password">
+                <small id="oauth_google_client_secret_status"></small>
+            </div>
+            <div class="form-group">
+                <label for="oauth_google_redirect_uri">Redirect URI:</label>
+                <input type="text" id="oauth_google_redirect_uri" name="oauth_google_redirect_uri" class="oauth-redirect-uri-input" data-provider="google">
+                <small>Typically <code class="oauth-redirect-uri-hint" data-provider="google">{origin}/api/auth/oauth/google/callback</code> — register this exact URL with the provider.</small>
+            </div>
+
+            <h3>GitHub</h3>
+            <div class="form-group">
+                <label for="oauth_github_client_id">Client ID:</label>
+                <input type="text" id="oauth_github_client_id" name="oauth_github_client_id">
+            </div>
+            <div class="form-group">
+                <label for="oauth_github_client_secret">Client Secret:</label>
+                <input type="password" id="oauth_github_client_secret" name="oauth_github_client_secret" placeholder="Leave blank to keep the existing secret" autocomplete="new-password">
+                <small id="oauth_github_client_secret_status"></small>
+            </div>
+            <div class="form-group">
+                <label for="oauth_github_redirect_uri">Redirect URI:</label>
+                <input type="text" id="oauth_github_redirect_uri" name="oauth_github_redirect_uri" class="oauth-redirect-uri-input" data-provider="github">
+                <small>Typically <code class="oauth-redirect-uri-hint" data-provider="github">{origin}/api/auth/oauth/github/callback</code> — register this exact URL with the provider.</small>
+            </div>
+        </div>
+
 
         <div class="settings-section">
             <h2>Paths</h2>
@@ -2635,15 +2694,35 @@ document.addEventListener('DOMContentLoaded', function() {
 // Handle hash changes
 window.addEventListener('hashchange', initializeTab);
 
+// OAuth client secrets are never pre-filled into their input — a blank
+// secret field on save means "leave unchanged" (see settings.py's
+// OAUTH_SECRET_KEYS), so displaying the real value back to the browser
+// would be both a needless exposure and misleading (editing it without
+// clearing it first would look like a no-op but actually replaces it).
+const OAUTH_SECRET_SETTING_KEYS = [
+    'oauth_authentik_client_secret',
+    'oauth_google_client_secret',
+    'oauth_github_client_secret',
+];
+
 function loadSettings() {
     // Load regular settings
     fetch('/api/settings/')
         .then(response => response.json())
         .then(data => {
             const settings = data.settings;
-            
+
             // Populate form fields
             Object.keys(settings).forEach(key => {
+                if (OAUTH_SECRET_SETTING_KEYS.includes(key)) {
+                    const statusEl = document.getElementById(`${key}_status`);
+                    if (statusEl) {
+                        statusEl.textContent = settings[key].value
+                            ? '✓ Configured (leave blank to keep it)'
+                            : 'Not configured';
+                    }
+                    return;
+                }
                 const element = document.getElementById(key);
                 if (element) {
                     // Handle different input types correctly
@@ -2656,7 +2735,23 @@ function loadSettings() {
                     }
                 }
             });
-            
+
+            // Default OAuth redirect URI fields to this instance's real
+            // callback URL when nothing's been saved yet — the value is
+            // always {origin}/api/auth/oauth/{provider}/callback, so
+            // there's no reason to make admins type it themselves.
+            document.querySelectorAll('.oauth-redirect-uri-input').forEach((input) => {
+                const provider = input.dataset.provider;
+                const defaultUri = `${window.location.origin}/api/auth/oauth/${provider}/callback`;
+                if (!input.value) {
+                    input.value = defaultUri;
+                }
+            });
+            document.querySelectorAll('.oauth-redirect-uri-hint').forEach((hint) => {
+                const provider = hint.dataset.provider;
+                hint.textContent = `${window.location.origin}/api/auth/oauth/${provider}/callback`;
+            });
+
             // After settings are loaded, update the user credentials section visibility
             updateUserCredentialsSection();
 

--- a/src/api/fastapi/settings.py
+++ b/src/api/fastapi/settings.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from src.services.oauth_service import oauth_service
 from src.services.settings_service import SettingsService, settings
 from src.utils.logger import get_logger
 
@@ -20,6 +21,14 @@ logger = get_logger("mvidarr.fastapi.settings")
 
 # Create FastAPI router
 router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+# Never round-tripped back to the browser on load (see settings.html) —
+# a blank value on bulk update means "leave unchanged", not "clear it".
+OAUTH_SECRET_KEYS = {
+    "oauth_authentik_client_secret",
+    "oauth_google_client_secret",
+    "oauth_github_client_secret",
+}
 
 # ====================================
 # Authentication (Mock for now)
@@ -187,8 +196,17 @@ async def update_multiple_settings(
 ):
     """Update multiple settings at once"""
     try:
-        # Convert values to strings for the settings service
-        settings_data = {key: str(value) for key, value in bulk_update.settings.items()}
+        # Convert values to strings for the settings service. OAuth
+        # client secrets are deliberately never sent back to the browser
+        # on load (see settings.html), so a blank value here means
+        # "unchanged", not "clear it" — the settings page's single
+        # page-wide Save button would otherwise wipe a saved secret any
+        # time an admin saved an unrelated setting (#336).
+        settings_data = {
+            key: str(value)
+            for key, value in bulk_update.settings.items()
+            if not (key in OAUTH_SECRET_KEYS and not value)
+        }
 
         success = settings.set_multiple(settings_data)
 
@@ -744,6 +762,28 @@ async def _handle_bulk_special_updates(settings_data: Dict[str, Any]):
                 )
             except Exception as e:
                 logger.error(f"Failed to reload Scheduler V2 after bulk update: {e}")
+                # Continue with the response even if reload fails
+
+        # Auto-reload OAuth provider config if any oauth_ settings were
+        # updated (#336) — oauth_service loads its provider dict once at
+        # process start, so without this a saved client_id/secret would
+        # be invisible to the running app until it was restarted.
+        oauth_settings_updated = any(
+            key.startswith("oauth_") for key in settings_data.keys()
+        )
+        if oauth_settings_updated:
+            try:
+                updated_oauth_keys = [
+                    key for key in settings_data.keys() if key.startswith("oauth_")
+                ]
+                logger.info(
+                    f"Reloading OAuth provider config after bulk update of: {updated_oauth_keys}"
+                )
+                oauth_service.reload_settings()
+            except Exception as e:
+                logger.error(
+                    f"Failed to reload OAuth provider config after bulk update: {e}"
+                )
                 # Continue with the response even if reload fails
 
     except Exception as e:

--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -266,6 +266,19 @@ class OAuthService:
         self.providers = {}
         self._load_providers()
 
+    def reload_settings(self):
+        """Force reload of OAuth provider configuration from settings.
+
+        self.providers is only populated once, at process start
+        (__init__ -> _load_providers). Without this, an admin saving new
+        oauth_* settings via the UI would have no effect until the app
+        was restarted. Mirrors SpotifyService.reload_settings()'s role
+        in the same bulk-settings-update flow (#336).
+        """
+        self.providers = {}
+        self._load_providers()
+        logger.info("OAuth provider settings reloaded from database")
+
     def _load_providers(self):
         """Load OAuth providers from configuration"""
         try:

--- a/tests/unit/test_oauth_service_reload.py
+++ b/tests/unit/test_oauth_service_reload.py
@@ -1,0 +1,45 @@
+"""Regression test for #336: OAuthService loads its provider config once
+at process start (__init__ -> _load_providers) and never again — a
+provider newly configured via Settings would be invisible to the running
+app's login page until it was restarted, without an explicit reload."""
+
+from unittest.mock import patch
+
+from src.services.oauth_service import OAuthService
+
+
+class TestOAuthServiceReload:
+    def test_reload_settings_picks_up_a_newly_configured_provider(self):
+        service = OAuthService()
+        assert "github" not in service.get_available_providers()
+
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            side_effect=lambda key: {
+                "oauth_github_client_id": "id",
+                "oauth_github_client_secret": "secret",
+                "oauth_github_redirect_uri": "https://example.test/callback",
+            }.get(key),
+        ):
+            service.reload_settings()
+
+        assert "github" in service.get_available_providers()
+
+    def test_reload_settings_drops_a_provider_that_was_removed(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            side_effect=lambda key: {
+                "oauth_github_client_id": "id",
+                "oauth_github_client_secret": "secret",
+                "oauth_github_redirect_uri": "https://example.test/callback",
+            }.get(key),
+        ):
+            service = OAuthService()
+        assert "github" in service.get_available_providers()
+
+        with patch(
+            "src.services.settings_service.SettingsService.get", return_value=None
+        ):
+            service.reload_settings()
+
+        assert "github" not in service.get_available_providers()

--- a/tests/unit/test_oauth_settings_bulk_update.py
+++ b/tests/unit/test_oauth_settings_bulk_update.py
@@ -1,0 +1,117 @@
+"""Tests for #336: OAuth provider settings, saved via the bulk settings
+endpoint.
+
+Covers two behaviors added alongside the new admin UI:
+
+1. Blank oauth_*_client_secret values must NOT overwrite an already-saved
+   secret. The settings page has a single page-wide "Save" button that
+   PUTs every input's current value in one request — a client_secret
+   field left blank (because the admin was only editing an unrelated
+   setting, and the real secret is deliberately never round-tripped back
+   into the field on page load) would otherwise silently wipe the stored
+   secret on the next save.
+2. oauth_service is a module-level singleton that loads provider config
+   once at process start (OAuthService.__init__ -> _load_providers). A
+   bulk update touching any oauth_* key must reload it, the same way an
+   update touching spotify_* keys already reloads spotify_service — see
+   the sibling "Auto-reload Spotify service" block this mirrors.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_admin
+from src.api.fastapi.settings import router
+
+
+def _make_client():
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_admin] = lambda: {
+        "user_id": 1,
+        "username": "admin",
+        "role": "ADMIN",
+        "authenticated": True,
+    }
+    return TestClient(app)
+
+
+class TestBlankSecretDoesNotOverwrite:
+    def test_blank_oauth_client_secret_is_excluded_from_the_write(self):
+        client = _make_client()
+
+        with patch(
+            "src.api.fastapi.settings.settings.set_multiple", return_value=True
+        ) as mock_set_multiple, patch(
+            "src.api.fastapi.settings.oauth_service.reload_settings"
+        ):
+            response = client.put(
+                "/api/settings/bulk",
+                json={
+                    "settings": {
+                        "oauth_authentik_client_id": "new-client-id",
+                        "oauth_authentik_client_secret": "",
+                    }
+                },
+            )
+
+        assert response.status_code == 200
+        written = mock_set_multiple.call_args[0][0]
+        assert written["oauth_authentik_client_id"] == "new-client-id"
+        assert "oauth_authentik_client_secret" not in written
+
+    def test_non_blank_oauth_client_secret_is_written_normally(self):
+        client = _make_client()
+
+        with patch(
+            "src.api.fastapi.settings.settings.set_multiple", return_value=True
+        ) as mock_set_multiple, patch(
+            "src.api.fastapi.settings.oauth_service.reload_settings"
+        ):
+            response = client.put(
+                "/api/settings/bulk",
+                json={
+                    "settings": {
+                        "oauth_authentik_client_secret": "a-real-secret",
+                    }
+                },
+            )
+
+        assert response.status_code == 200
+        written = mock_set_multiple.call_args[0][0]
+        assert written["oauth_authentik_client_secret"] == "a-real-secret"
+
+
+class TestOAuthServiceReloadedAfterBulkUpdate:
+    def test_oauth_key_update_triggers_reload(self):
+        client = _make_client()
+
+        with patch(
+            "src.api.fastapi.settings.settings.set_multiple", return_value=True
+        ), patch(
+            "src.api.fastapi.settings.oauth_service.reload_settings"
+        ) as mock_reload:
+            client.put(
+                "/api/settings/bulk",
+                json={"settings": {"oauth_google_client_id": "abc"}},
+            )
+
+        mock_reload.assert_called_once()
+
+    def test_unrelated_key_update_does_not_trigger_reload(self):
+        client = _make_client()
+
+        with patch(
+            "src.api.fastapi.settings.settings.set_multiple", return_value=True
+        ), patch(
+            "src.api.fastapi.settings.oauth_service.reload_settings"
+        ) as mock_reload:
+            client.put(
+                "/api/settings/bulk",
+                json={"settings": {"ui_theme": "dark"}},
+            )
+
+        mock_reload.assert_not_called()

--- a/tests/unit/test_oauth_settings_ui.py
+++ b/tests/unit/test_oauth_settings_ui.py
@@ -1,0 +1,68 @@
+"""Regression test for #336: no admin UI existed to configure OAuth
+provider credentials — the entire feature was settings-table-driven with
+zero corresponding fields on the Settings page (oauth_service.py's
+_load_providers() reads nine oauth_* keys that settings.html never
+exposed at all).
+
+Same static-content-assertion approach as the other template regression
+tests in this suite (e.g. test_2fa_setup_link_target.py): confirms the
+real setting keys oauth_service.py actually reads are present as form
+fields, and that client secrets are excluded from the page's generic
+settings-load loop (see settings.py's OAUTH_SECRET_KEYS for the matching
+backend-side "blank means unchanged" behavior this depends on).
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+# Exactly the keys OAuthService._load_providers() reads.
+REAL_OAUTH_SETTING_KEYS = [
+    "oauth_authentik_base_url",
+    "oauth_authentik_client_id",
+    "oauth_authentik_client_secret",
+    "oauth_authentik_redirect_uri",
+    "oauth_google_client_id",
+    "oauth_google_client_secret",
+    "oauth_google_redirect_uri",
+    "oauth_github_client_id",
+    "oauth_github_client_secret",
+    "oauth_github_redirect_uri",
+]
+
+OAUTH_SECRET_KEYS = [
+    "oauth_authentik_client_secret",
+    "oauth_google_client_secret",
+    "oauth_github_client_secret",
+]
+
+
+class TestOAuthSettingsUI:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_every_real_oauth_setting_key_has_a_form_field(self):
+        for key in REAL_OAUTH_SETTING_KEYS:
+            assert f'name="{key}"' in self.html, (
+                f"settings.html has no input for {key}, which "
+                "OAuthService._load_providers() reads"
+            )
+
+    def test_client_secret_fields_are_password_type(self):
+        for key in OAUTH_SECRET_KEYS:
+            assert f'id="{key}" name="{key}"' in self.html
+            # Confirm it's specifically a password-type input, not just
+            # present anywhere in the key's name substring match.
+            start = self.html.index(f'id="{key}"')
+            tag = self.html[max(0, start - 40) : start + 100]
+            assert 'type="password"' in tag
+
+    def test_client_secrets_are_excluded_from_the_generic_load_loop(self):
+        assert "OAUTH_SECRET_SETTING_KEYS" in self.html
+        for key in OAUTH_SECRET_KEYS:
+            assert f"'{key}'" in self.html
+
+    def test_redirect_uri_defaults_match_the_real_callback_route(self):
+        # The real route is /api/auth/oauth/{provider}/callback
+        # (src/api/fastapi/auth.py's oauth_callback).
+        assert "/api/auth/oauth/${provider}/callback" in self.html


### PR DESCRIPTION
Fixes #336.

## Summary

OAuth login itself was fully implemented and correctly wired (login page shows provider buttons when configured, CSRF state binding already fixed in the v1.0.0 auth cluster), but provider configuration was 100% settings-table-driven with zero admin UI. The only way to configure a provider was direct DB manipulation or a raw authenticated API call.

Added an "OAuth Login Providers" section to the Settings page covering all three providers `OAuthService` already supports — Authentik (base URL, client ID/secret, redirect URI), Google, and GitHub (client ID/secret, redirect URI each) — wired to the existing, already-authenticated `PUT /api/settings/bulk` endpoint via the page's normal global Save button (no new save plumbing needed).

Three things needed fixing alongside just adding the fields:

1. **Client secrets are never sent back to the browser on load** (a status line shows "Configured" / "Not configured" instead) — but the page has a single page-wide Save button that PUTs every field's current value in one request, so a blank secret field would otherwise wipe the stored secret the next time an admin saved anything else on the page. `settings.py` now treats a blank `oauth_*_client_secret` as "leave unchanged," not "clear it."
2. **`oauth_service` is a module-level singleton** that loads its provider config once at process start (`OAuthService.__init__` -> `_load_providers`). Saving new credentials via this UI would have had no effect until the app was restarted. Added `OAuthService.reload_settings()`, triggered automatically on bulk updates touching any `oauth_*` key — mirrors the existing `spotify_service.reload_settings()` auto-reload for `spotify_*` keys in the same endpoint.
3. **Redirect URI fields default** to this instance's real callback URL (`{origin}/api/auth/oauth/{provider}/callback`, the actual route in `auth.py`) instead of making admins type it themselves.

## Test plan

- [x] New `tests/unit/test_oauth_settings_ui.py` — static-content assertions (same pattern as `test_2fa_setup_link_target.py`) confirming every real setting key `OAuthService._load_providers()` reads has a form field, secrets are password-type and excluded from the generic load loop, and redirect URI defaults match the real callback route
- [x] New `tests/unit/test_oauth_settings_bulk_update.py` — blank secret excluded from the write, non-blank secret written normally, `oauth_` key update triggers reload, unrelated key update does not
- [x] New `tests/unit/test_oauth_service_reload.py` — `reload_settings()` picks up a newly-configured provider and drops a removed one
- [x] Verified RED against pre-fix code for all 10 new tests
- [x] Full `tests/unit/` suite: 105 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>