### PR TITLE
fix(auth): OAuth providers permanently disabled after restart despite valid saved settings

### DIFF
--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -321,12 +321,39 @@ class OAuthService:
         except Exception as e:
             logger.error(f"Error loading OAuth providers: {e}")
 
+    def _ensure_providers_loaded(self):
+        """Retry loading if no providers are currently configured.
+
+        OAuthService is a module-level singleton constructed at Python
+        import time — before fastapi_app.py finishes initializing the
+        database connection. A load attempted during that window
+        silently fails (SettingsService.get() returns "" for every
+        oauth_* key) and, without this, self.providers would stay
+        permanently empty for the rest of the process's life — no
+        automatic retry, no error surfaced anywhere a user would see it.
+        Confirmed via fastapi_error.log during a real incident
+        (2026-08-12): "Database not initialized" immediately followed by
+        "Setting 'oauth_authentik_base_url' not found" for settings that
+        were, in fact, already saved.
+
+        Retrying here whenever providers is empty is cheap
+        (SettingsService caches its own DB reads after the first
+        successful query) and self-heals the very next time this is
+        called after the database is actually ready — e.g. the next
+        login page render — with no need for an admin to re-save
+        settings or restart again.
+        """
+        if not self.providers:
+            self._load_providers()
+
     def get_provider(self, provider_name: str) -> Optional[OAuthProvider]:
         """Get OAuth provider by name"""
+        self._ensure_providers_loaded()
         return self.providers.get(provider_name)
 
     def get_available_providers(self) -> Dict[str, str]:
         """Get list of available OAuth providers"""
+        self._ensure_providers_loaded()
         return {name: provider.name for name, provider in self.providers.items()}
 
     def initiate_oauth_flow(
@@ -563,6 +590,7 @@ class OAuthService:
 
     def is_oauth_enabled(self) -> bool:
         """Check if any OAuth providers are configured"""
+        self._ensure_providers_loaded()
         return len(self.providers) > 0
 
     # get_oauth_login_urls() was removed: it discarded the CSRF state that

--- a/tests/unit/test_oauth_service_boot_race.py
+++ b/tests/unit/test_oauth_service_boot_race.py
@@ -1,0 +1,95 @@
+"""Regression test for a live incident (2026-08-12): after saving OAuth
+settings via the new #336 UI and restarting the app, the login page
+showed no OAuth provider buttons at all — even though the settings were
+genuinely saved to the database.
+
+Root cause: oauth_service is a module-level singleton
+(src/services/oauth_service.py's `oauth_service = OAuthService()`),
+constructed once at Python import time — which happens before
+fastapi_app.py finishes initializing the database connection.
+SettingsService.load_cache() correctly detects this
+("Database not initialized") and deliberately avoids marking its own
+cache as loaded, so IT retries successfully on the next call. But
+OAuthService.__init__ -> _load_providers() only ever runs once: every
+SettingsService.get(oauth_*) call during that one doomed attempt returns
+"" (not found), so self.providers is permanently left {} for the rest
+of the process's life. Confirmed via fastapi_error.log: "Failed to load
+settings cache: Database not initialized" immediately followed by
+"Setting 'oauth_authentik_base_url' not found" etc. for all nine oauth_*
+keys, on a restart that happened after those exact settings were
+already committed to the database.
+"""
+
+from unittest.mock import patch
+
+from src.services.oauth_service import OAuthService
+
+_VALID_AUTHENTIK_SETTINGS = {
+    "oauth_authentik_base_url": "https://auth.example.com",
+    "oauth_authentik_client_id": "client-id",
+    "oauth_authentik_client_secret": "client-secret",
+    "oauth_authentik_redirect_uri": "https://mvidarr.example.com/api/auth/oauth/authentik/callback",
+}
+
+
+class TestOAuthServiceSurvivesTheBootRace:
+    def test_construction_during_the_db_not_ready_race_does_not_permanently_break_it(
+        self,
+    ):
+        # Simulate exactly what the logs showed: every setting lookup
+        # fails during __init__ because the database isn't initialized
+        # yet at Python import time.
+        with patch(
+            "src.services.settings_service.SettingsService.get", return_value=""
+        ):
+            service = OAuthService()
+
+        assert service.get_available_providers() == {}
+
+        # The database is now genuinely ready and the settings are
+        # genuinely saved (matching the real post-restart state) — but
+        # nothing has explicitly called reload_settings(). A real login
+        # page render just calls get_available_providers().
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            side_effect=lambda key, default=None: _VALID_AUTHENTIK_SETTINGS.get(
+                key, default
+            ),
+        ):
+            assert "authentik" in service.get_available_providers()
+
+    def test_get_provider_also_self_heals(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get", return_value=""
+        ):
+            service = OAuthService()
+
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            side_effect=lambda key, default=None: _VALID_AUTHENTIK_SETTINGS.get(
+                key, default
+            ),
+        ):
+            assert service.get_provider("authentik") is not None
+
+    def test_is_oauth_enabled_also_self_heals(self):
+        """The actual gate the login page checks first
+        (template_system.py: `if oauth_service.is_oauth_enabled():
+        oauth_providers = oauth_service.get_available_providers()`) — if
+        this alone doesn't self-heal, get_available_providers() is never
+        even called and the login page shows no OAuth section at all,
+        regardless of what get_available_providers() itself would return.
+        """
+        with patch(
+            "src.services.settings_service.SettingsService.get", return_value=""
+        ):
+            service = OAuthService()
+        assert service.is_oauth_enabled() is False
+
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            side_effect=lambda key, default=None: _VALID_AUTHENTIK_SETTINGS.get(
+                key, default
+            ),
+        ):
+            assert service.is_oauth_enabled() is True


### PR DESCRIPTION
Follow-up to #345. Found live testing right after that PR: configured Authentik OAuth via the new settings UI, clicked "Restart Application," and the login page lost the OAuth option entirely — even though the settings were genuinely saved.

## Root cause

`oauth_service` is a module-level singleton, constructed once at Python import time — before `fastapi_app.py` finishes initializing the database connection. A load attempted during that window silently fails (`SettingsService.get()` returns `""` for every `oauth_*` key because `db_manager` is still `None`) and leaves `self.providers` permanently empty for the rest of the process's life, with no automatic retry.

`fastapi_error.log` for the exact restart in question:
```
ERROR - Failed to load settings cache: Database not initialized
WARNING - Setting 'oauth_authentik_base_url' not found and no default provided
(repeated for all 9 oauth_* keys, plus lastfm_api_key/secret, plex_token —
the same boot-order race hits every module-level singleton that eagerly
loads settings at import time)
```

`SettingsService.load_cache()` itself already handles this correctly — it deliberately avoids marking its own cache "loaded" on this failure, so it retries successfully on the next call. But `OAuthService` never made a next call: `_load_providers()` only ever ran once, at `__init__`.

## Fix

Retry whenever `self.providers` is empty, at each of the three real call sites a live request actually uses (`is_oauth_enabled`, `get_provider`, `get_available_providers`) — self-healing the very next time the login page renders after the database is actually ready, with no admin action required. `reload_settings()` (added in #345 for the settings-save path) is unaffected.

## Test plan

- [x] New `tests/unit/test_oauth_service_boot_race.py` — reproduces the exact failure mode from the logs and confirms all three entry points recover on the next call once real settings are available, without an explicit `reload_settings()` call
- [x] Verified RED against pre-fix code specifically for `is_oauth_enabled` — the actual gate the login page checks first; a self-heal in `get_available_providers()` alone would not have been enough, since `template_system.py` never calls it unless `is_oauth_enabled()` is already true
- [x] Full `tests/unit/` suite: 108 passed, no regressions
- [x] Deployed live to the dev container: restarted, then curled `/auth/login` and confirmed the Authentik button renders immediately post-restart — previously reproduced the reported bug at this exact step

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>