### PR TITLE
fix(auth): OAuth callback returned raw JSON instead of redirecting into the app

### DIFF
--- a/src/api/fastapi/auth.py
+++ b/src/api/fastapi/auth.py
@@ -521,23 +521,15 @@ async def oauth_callback(
 
             log_oauth_login_success(user, provider)
 
-            from fastapi.responses import JSONResponse
+            # This endpoint is only ever reached via a real, top-level
+            # browser navigation — the OAuth provider's own server-side
+            # redirect after the user authorizes, not a fetch()/XHR call
+            # from MVidarr's frontend JS. Returning JSON here (as this
+            # used to) left a successful login showing the user a raw
+            # JSON blob instead of landing them back in the app.
+            from fastapi.responses import RedirectResponse
 
-            response_data = {
-                "success": True,
-                "message": "OAuth login successful",
-                "user": {
-                    "id": user.id,
-                    "username": user.username,
-                    "email": user.email,
-                    "role": user.role.value,
-                    "can_admin": user.can_access_admin(),
-                    "can_modify": user.can_modify_content(),
-                    "can_delete": user.can_delete_content(),
-                },
-            }
-
-            response = JSONResponse(content=response_data)
+            response = RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
             is_https = request.headers.get("x-forwarded-proto") == "https"
             response.set_cookie(
                 key="session_token",

--- a/tests/unit/test_oauth_callback_redirect.py
+++ b/tests/unit/test_oauth_callback_redirect.py
@@ -1,0 +1,92 @@
+"""Regression test: GET /api/auth/oauth/{provider}/callback returned raw
+JSON on a successful login instead of redirecting into the app.
+
+This endpoint is only ever reached via a real, top-level browser
+navigation — the OAuth provider's own server-side redirect after the
+user authorizes, not a fetch()/XHR call from MVidarr's own frontend JS
+(confirmed: nothing in frontend/templates calls this URL). Returning
+JSONResponse meant a successful login left the user staring at a raw
+JSON blob (visible via Firefox's built-in JSON viewer) instead of being
+dropped back into the app — reported live 2026-08-12 testing Google
+OAuth: "acts like it is starting to work then returns" JSON.
+
+The session_token cookie WAS being set correctly either way — this was
+purely a wrong response type for a navigation-triggered endpoint, not a
+failure to authenticate.
+"""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth import router
+
+
+def _make_client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class _FakeUser:
+    id = 1
+    username = "oauth_test_user"
+    email = "test@example.com"
+
+    class _Role:
+        value = "USER"
+
+    role = _Role()
+
+    def can_access_admin(self):
+        return False
+
+    def can_modify_content(self):
+        return True
+
+    def can_delete_content(self):
+        return False
+
+
+class _FakeSession:
+    pass
+
+
+class TestOAuthCallbackRedirectsOnSuccess:
+    def test_successful_callback_redirects_instead_of_returning_json(self):
+        client = _make_client()
+        client.cookies.set("oauth_state", "abc123")
+
+        with patch(
+            "src.api.fastapi.auth.oauth_service.handle_oauth_callback",
+            return_value=(True, "OK", _FakeUser(), _FakeSession()),
+        ), patch(
+            "src.api.fastapi.auth.SessionStore.create_session",
+            return_value="a-real-session-token",
+        ):
+            response = client.get(
+                "/api/auth/oauth/authentik/callback?code=fake&state=abc123",
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"] == "/"
+
+    def test_successful_callback_still_sets_the_session_cookie(self):
+        client = _make_client()
+        client.cookies.set("oauth_state", "abc123")
+
+        with patch(
+            "src.api.fastapi.auth.oauth_service.handle_oauth_callback",
+            return_value=(True, "OK", _FakeUser(), _FakeSession()),
+        ), patch(
+            "src.api.fastapi.auth.SessionStore.create_session",
+            return_value="a-real-session-token",
+        ):
+            response = client.get(
+                "/api/auth/oauth/authentik/callback?code=fake&state=abc123",
+                follow_redirects=False,
+            )
+
+        assert response.cookies.get("session_token") == "a-real-session-token"


### PR DESCRIPTION
Found live testing Google OAuth right after #346: login "acts like it is starting to work then returns" a raw JSON blob instead of landing back in the app.

## Root cause

`GET /api/auth/oauth/{provider}/callback` is only ever reached via a real, top-level browser navigation — the OAuth provider's own server-side redirect after the user authorizes it, not a `fetch()`/XHR call from MVidarr's own frontend JS (confirmed: nothing in `frontend/templates` calls this URL). It returned a `JSONResponse` on success, so a successful login left the browser just displaying the JSON body (via Firefox's built-in JSON viewer) instead of navigating into the app. The `session_token` cookie was being set correctly either way — this was purely a wrong response type for a navigation-triggered endpoint, not a failed login.

## Fix

Redirect to `/` (302) with the same `session_token` cookie, instead of returning JSON.

## Test plan

- [x] New `tests/unit/test_oauth_callback_redirect.py` — confirms a successful callback redirects to `/` instead of returning JSON, and still sets the session cookie
- [x] Verified RED against pre-fix code
- [x] No regressions in `test_oauth_service_state.py` (existing CSRF/cookie coverage for this same endpoint)
- [x] Full `tests/unit/` suite: 110 passed, no regressions
- [x] Deployed live to the dev container, health check green

## Not in this PR

Authentik OAuth is separately timing out — confirmed via `docker exec mvidarr-dev curl` that the container cannot reach `auth.prefect42.com` at all (DNS resolves, TCP connection times out). That's a network/firewall reachability issue between the container and the external Authentik server, not an application bug — flagging separately rather than "fixing" it here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>