### PR TITLE
fix(auth): Authentik OAuth role-mapping privilege escalation via substring match

### DIFF
--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -131,23 +131,25 @@ class AuthentikProvider(OAuthProvider):
     def map_groups_to_role(self, groups: list, roles: list = None) -> UserRole:
         """Map Authentik groups/roles to MVidarr user role"""
         # Default role mapping - can be configured
-        admin_groups = ["mvidarr_admin", "admins", "administrators"]
-        manager_groups = ["mvidarr_manager", "managers", "moderators"]
-        user_groups = ["mvidarr_user", "users"]
+        admin_groups = {"mvidarr_admin", "admins", "administrators"}
+        manager_groups = {"mvidarr_manager", "managers", "moderators"}
+        user_groups = {"mvidarr_user", "users"}
 
-        # Check all groups and roles
-        all_memberships = groups + (roles or [])
+        # Exact match only (case-insensitive) — NOT substring. A prior
+        # version used `admin_group in membership_lower`, so any group
+        # merely CONTAINING "admin"/"manager"/"user" granted that role:
+        # confirmed live, Authentik's own built-in "authentik Admins"
+        # group (for administering Authentik itself, unrelated to
+        # MVidarr) silently promoted a member to MVidarr ADMIN, since
+        # "admins" in "authentik admins" is True.
+        all_memberships = {m.lower() for m in groups + (roles or [])}
 
-        for membership in all_memberships:
-            membership_lower = membership.lower()
-            if any(admin_group in membership_lower for admin_group in admin_groups):
-                return UserRole.ADMIN
-            elif any(
-                manager_group in membership_lower for manager_group in manager_groups
-            ):
-                return UserRole.MANAGER
-            elif any(user_group in membership_lower for user_group in user_groups):
-                return UserRole.USER
+        if all_memberships & admin_groups:
+            return UserRole.ADMIN
+        elif all_memberships & manager_groups:
+            return UserRole.MANAGER
+        elif all_memberships & user_groups:
+            return UserRole.USER
 
         # Default to readonly if no matching groups
         return UserRole.READONLY

--- a/tests/unit/test_oauth_role_mapping.py
+++ b/tests/unit/test_oauth_role_mapping.py
@@ -1,0 +1,61 @@
+"""Regression test for a live privilege-escalation incident (2026-08-12):
+AuthentikProvider.map_groups_to_role used substring matching
+(`admin_group in membership_lower`) instead of exact matching, so any
+Authentik group whose name merely CONTAINS "admin"/"manager"/"user" as a
+substring granted that MVidarr role — completely disconnected from
+whether the group was ever intended to control MVidarr access.
+
+Confirmed live: a user in Authentik's own built-in "authentik Admins"
+group (the group for administering Authentik itself, unrelated to
+MVidarr) logged into MVidarr via Authentik OAuth and was silently
+promoted from USER to ADMIN, because "admins" in "authentik admins" is
+True. For any Authentik instance shared across multiple apps, this is a
+real privilege-escalation path: any generically-named group containing
+these substrings ("IT Admins", "Site Administrators", "Team Managers",
+"Existing Users", etc.) grants that role to everyone in it.
+"""
+
+from src.database.models import UserRole
+from src.services.oauth_service import AuthentikProvider
+
+_PROVIDER_CONFIG = {
+    "client_id": "id",
+    "client_secret": "secret",
+    "redirect_uri": "https://example.test/callback",
+    "base_url": "https://auth.example.test",
+}
+
+
+class TestAuthentikRoleMappingUsesExactMatch:
+    def setup_method(self):
+        self.provider = AuthentikProvider(_PROVIDER_CONFIG)
+
+    def test_unrelated_group_containing_admin_substring_does_not_grant_admin(self):
+        """The exact real-world case: Authentik's own built-in
+        administrative group, unrelated to MVidarr."""
+        role = self.provider.map_groups_to_role(["authentik Admins"], [])
+        assert role != UserRole.ADMIN
+
+    def test_unrelated_group_containing_manager_substring_does_not_grant_manager(self):
+        role = self.provider.map_groups_to_role(["Team Managers"], [])
+        assert role != UserRole.MANAGER
+
+    def test_unrelated_group_containing_user_substring_does_not_grant_user(self):
+        role = self.provider.map_groups_to_role(["Existing Users Legacy"], [])
+        assert role != UserRole.USER
+
+    def test_exact_admin_group_name_still_grants_admin(self):
+        role = self.provider.map_groups_to_role(["admins"], [])
+        assert role == UserRole.ADMIN
+
+    def test_exact_mvidarr_admin_group_name_still_grants_admin(self):
+        role = self.provider.map_groups_to_role(["mvidarr_admin"], [])
+        assert role == UserRole.ADMIN
+
+    def test_exact_match_is_case_insensitive(self):
+        role = self.provider.map_groups_to_role(["Administrators"], [])
+        assert role == UserRole.ADMIN
+
+    def test_no_matching_group_falls_back_to_readonly(self):
+        role = self.provider.map_groups_to_role(["marketing-team"], [])
+        assert role == UserRole.READONLY


### PR DESCRIPTION
Live incident 2026-08-12: a test account was silently promoted from `USER` to `ADMIN` logging into MVidarr via Authentik OAuth — nothing in this repo ever intended to grant that.

## Root cause

```python
if any(admin_group in membership_lower for admin_group in admin_groups):
```

`AuthentikProvider.map_groups_to_role` checked whether any of `["mvidarr_admin", "admins", "administrators"]` was a **substring** of each of the user's Authentik group names, not an exact match. Authentik's own built-in group for administering Authentik itself is commonly named something like "authentik Admins" — unrelated to MVidarr access control. `"admins" in "authentik admins".lower()` is `True`, so anyone in that group (very plausibly including whoever set up the Authentik instance) got auto-promoted to MVidarr `ADMIN` the moment they logged in via Authentik OAuth.

Same flaw applied to the manager/user checks — any generically-named group merely *containing* "manager" or "user" ("Team Managers", "Existing Users", etc.) granted that MVidarr role too. For any Authentik instance shared across multiple apps, or using conventional generic group names, this was a real privilege-escalation path, not a theoretical one.

## Fix

Exact match (case-insensitive), via set intersection instead of substring containment.

Confirmed and reverted the live consequence directly in the dev database (one account's role: `ADMIN` -> `USER`) before landing this fix.

## Test plan

- [x] New `tests/unit/test_oauth_role_mapping.py` — 7 cases: the exact privilege-escalation shape (group containing the substring, not equal to it) for admin/manager/user, confirming exact matches still work, case-insensitivity preserved, and the no-match `READONLY` fallback
- [x] Verified RED against pre-fix code (3 failures — exactly the privilege-escalation cases; the 4 legitimate-match cases already passed)
- [x] Full `tests/unit/` suite: 119 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>