### PR TITLE
feat(auth): OAuth new-account signup allowlist

### DIFF
--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -327,6 +327,12 @@ input:checked + .slider:before {
                 <small>Let users sign in via Authentik, Google, or GitHub instead of (or in addition to) a password. Leave a provider's fields blank to keep it disabled. Client secret fields are never pre-filled for security — leave one blank on save to keep the previously-saved value.</small>
             </div>
 
+            <div class="form-group">
+                <label for="oauth_allowed_emails">New Account Signup Allowlist:</label>
+                <input type="text" id="oauth_allowed_emails" name="oauth_allowed_emails" placeholder="you@example.com, @yourcompany.com">
+                <small>Comma separated. Each entry is either an exact email address, or <code>@domain.com</code> to allow anyone at that domain. This only gates <strong>new</strong> accounts — anyone who already has a MVidarr account can still sign in via OAuth regardless of this list. Leave empty to block all new OAuth signups (existing accounts are unaffected).</small>
+            </div>
+
             <h3>Authentik</h3>
             <div class="form-group">
                 <label for="oauth_authentik_base_url">Base URL:</label>

--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -3,6 +3,7 @@ OAuth authentication service for MVidarr
 Supports multiple OAuth providers including Authentik, Google, GitHub, etc.
 """
 
+import re
 import secrets
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
@@ -447,6 +448,49 @@ class OAuthService:
             logger.error(f"Error handling OAuth callback: {e}")
             return False, "OAuth authentication failed", None, None
 
+    @staticmethod
+    def _is_email_allowed_for_oauth_signup(email: Optional[str]) -> bool:
+        """
+        Check whether a brand-new OAuth account is allowed to be
+        auto-created for this email, per the oauth_allowed_emails
+        setting. Only gates NEW account creation — see the call site in
+        _find_or_create_oauth_user for why existing users always bypass
+        this check.
+
+        Entries in the setting are comma- or newline-separated, each
+        either:
+        - an exact email address ("friend@example.com"), or
+        - a domain wildcard ("@example.com" — matches any address at
+          that domain; must match the domain exactly, not as a
+          substring, so "@mycompany.com" does not also match
+          "@notmycompany.com")
+
+        An unset/empty setting denies ALL new signups (fail closed) —
+        the self-hosted-appropriate default until an admin explicitly
+        opts specific people in.
+        """
+        if not email:
+            return False
+
+        from src.services.settings_service import SettingsService
+
+        raw = SettingsService.get("oauth_allowed_emails", "")
+        if not raw or not raw.strip():
+            return False
+
+        email_lower = email.strip().lower()
+        for entry in re.split(r"[,\n]", raw):
+            entry = entry.strip().lower()
+            if not entry:
+                continue
+            if entry.startswith("@"):
+                if email_lower.endswith(entry):
+                    return True
+            elif email_lower == entry:
+                return True
+
+        return False
+
     def _find_or_create_oauth_user(
         self,
         provider_name: str,
@@ -485,8 +529,34 @@ class OAuthService:
                 if not user and username:
                     user = session.query(User).filter_by(username=username).first()
 
-                # Create new user if not found
+                # Create new user if not found. Gated on an allowlist —
+                # without this, ANY account that can complete a
+                # configured provider's consent screen gets a brand-new
+                # MVidarr account auto-created with zero approval step
+                # (confirmed live, 2026-08-12: two unintended
+                # self-registrations during OAuth testing). This check
+                # only applies to genuinely NEW accounts — an OAuth
+                # login matching an EXISTING user (found by email/
+                # username just above) is always allowed, since that
+                # account was already created intentionally.
                 if not user:
+                    if not self._is_email_allowed_for_oauth_signup(email):
+                        logger.warning(
+                            f"OAuth signup denied for unauthorized email: "
+                            f"{email} (provider: {provider_name})"
+                        )
+                        from src.services.audit_service import AuditService
+
+                        AuditService.log_security_event(
+                            "oauth_signup_denied",
+                            "OAuth signup denied — email not on the allowlist",
+                            additional_data={
+                                "provider": provider_name,
+                                "email": email,
+                            },
+                        )
+                        return None, None
+
                     # Generate username if not provided
                     if not username:
                         username = (

--- a/tests/unit/test_oauth_allowlist_ui.py
+++ b/tests/unit/test_oauth_allowlist_ui.py
@@ -1,0 +1,26 @@
+"""Regression test: settings.html must expose oauth_allowed_emails as a
+real, savable field — otherwise the allowlist backend added alongside it
+has no way to be configured except direct DB/API access, the same class
+of gap #336 existed for (see test_oauth_settings_ui.py).
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestOAuthAllowlistUI:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_allowlist_field_exists(self):
+        assert 'name="oauth_allowed_emails"' in self.html
+
+    def test_allowlist_field_is_a_real_input_not_a_textarea(self):
+        """settings.html's generic save collector is
+        querySelectorAll('input, select') — a <textarea> here would
+        silently never be saved."""
+        start = self.html.index('name="oauth_allowed_emails"')
+        tag_start = self.html.rindex("<", 0, start)
+        tag = self.html[tag_start : start + 40]
+        assert tag.startswith("<input")

--- a/tests/unit/test_oauth_callback_detached_instance.py
+++ b/tests/unit/test_oauth_callback_detached_instance.py
@@ -78,6 +78,12 @@ class TestOAuthCallbackSurvivesSessionClose:
         with _patch_get_db(session_factory), patch(
             "src.services.oauth_service.secrets.token_urlsafe",
             return_value="Xk9#mQ7z!vR2wL",
+        ), patch(
+            # New-account creation is gated by an allowlist (#336
+            # follow-up) — irrelevant to what this test covers, so
+            # allow the email through unconditionally.
+            "src.services.oauth_service.OAuthService._is_email_allowed_for_oauth_signup",
+            return_value=True,
         ):
             user, user_session = service._find_or_create_oauth_user(
                 "google",

--- a/tests/unit/test_oauth_signup_allowlist.py
+++ b/tests/unit/test_oauth_signup_allowlist.py
@@ -1,0 +1,211 @@
+"""Tests for the OAuth new-account signup allowlist.
+
+Before this: any Google/GitHub/Authentik account that could complete
+that provider's consent screen got a brand-new MVidarr account
+auto-created on the spot, with no allowlist or approval step — a real
+gap for a self-hosted app confirmed live 2026-08-12 (two unintended
+accounts self-registered during OAuth testing).
+
+Design, per explicit decision: the allowlist gates only NEW account
+creation. An OAuth login that matches an EXISTING user (by email or
+username) is always allowed regardless of the allowlist — that account
+was already created intentionally, not something this check needs to
+second-guess. An unset/empty allowlist denies ALL new signups
+(fail closed).
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.database.connection import Base
+from src.database.models import User, UserRole, UserSession
+from src.services.oauth_service import OAuthService
+
+
+class TestIsEmailAllowedForOAuthSignup:
+    def test_empty_allowlist_denies_everything(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get", return_value=""
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("anyone@example.com")
+                is False
+            )
+
+    def test_exact_email_match_is_allowed(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="friend@example.com, other@example.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("friend@example.com")
+                is True
+            )
+
+    def test_email_not_in_list_is_denied(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="friend@example.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("stranger@example.com")
+                is False
+            )
+
+    def test_domain_wildcard_allows_any_address_at_that_domain(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="@mycompany.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("anyone@mycompany.com")
+                is True
+            )
+
+    def test_domain_wildcard_does_not_match_a_different_domain(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="@mycompany.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("someone@evil.com")
+                is False
+            )
+
+    def test_domain_wildcard_does_not_match_as_a_substring_of_a_longer_domain(self):
+        """@mycompany.com must not match notmycompany.com — regression
+        for the exact same class of bug as the role-mapping substring
+        match (#349): must not use loose substring containment."""
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="@mycompany.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup(
+                    "someone@notmycompany.com"
+                )
+                is False
+            )
+
+    def test_matching_is_case_insensitive(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="Friend@Example.com",
+        ):
+            assert (
+                OAuthService._is_email_allowed_for_oauth_signup("friend@example.com")
+                is True
+            )
+
+    def test_none_email_is_denied(self):
+        with patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="@mycompany.com",
+        ):
+            assert OAuthService._is_email_allowed_for_oauth_signup(None) is False
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, UserSession.__table__])
+    return sessionmaker(bind=engine)
+
+
+@contextmanager
+def _real_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _patch_get_db(session_factory):
+    return patch(
+        "src.services.oauth_service.get_db",
+        lambda: _real_get_db(session_factory),
+    )
+
+
+class TestFindOrCreateOAuthUserRespectsAllowlist:
+    def test_denies_new_account_for_email_not_on_allowlist(self, session_factory):
+        service = OAuthService.__new__(OAuthService)
+
+        with _patch_get_db(session_factory), patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="",
+        ):
+            user, user_session = service._find_or_create_oauth_user(
+                "google",
+                {"email": "uninvited@example.com", "id": "provider-id"},
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user is None
+        assert user_session is None
+
+        session = session_factory()
+        assert (
+            session.query(User).filter_by(email="uninvited@example.com").first() is None
+        )
+        session.close()
+
+    def test_creates_new_account_for_email_on_allowlist(self, session_factory):
+        service = OAuthService.__new__(OAuthService)
+
+        with _patch_get_db(session_factory), patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="invited@example.com",
+        ), patch(
+            "src.services.oauth_service.secrets.token_urlsafe",
+            return_value="Xk9#mQ7z!vR2wL",
+        ):
+            user, user_session = service._find_or_create_oauth_user(
+                "google",
+                {"email": "invited@example.com", "id": "provider-id"},
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user is not None
+        assert user.email == "invited@example.com"
+
+    def test_existing_user_can_still_log_in_regardless_of_allowlist(
+        self, session_factory
+    ):
+        session = session_factory()
+        existing = User(
+            username="alreadyhere",
+            email="alreadyhere@example.com",
+            password="Sup3rSecret!",
+            role=UserRole.USER,
+        )
+        session.add(existing)
+        session.commit()
+        session.close()
+
+        service = OAuthService.__new__(OAuthService)
+
+        with _patch_get_db(session_factory), patch(
+            "src.services.settings_service.SettingsService.get",
+            return_value="",
+        ):
+            user, user_session = service._find_or_create_oauth_user(
+                "google",
+                {"email": "alreadyhere@example.com", "id": "provider-id"},
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user is not None
+        assert user.username == "alreadyhere"


### PR DESCRIPTION
Follow-up to #345/#349. Any Google/GitHub/Authentik account that could complete a configured provider's consent screen got a brand-new MVidarr account auto-created on the spot, with no allowlist or approval step — confirmed live 2026-08-12: two unintended self-registrations happened during OAuth testing (one of which was also hit by the separate role-mapping privilege escalation fixed in #349).

## Summary

Added `oauth_allowed_emails`: a Settings page field of comma-separated exact emails and/or `@domain.com` wildcards. Only gates **new** account creation — an OAuth login matching an EXISTING user (by email or username) is always allowed regardless, since that account was already created intentionally (by an admin or a prior legitimate signup), not something this check needs to second-guess. An unset/empty allowlist denies ALL new signups (fail closed) — the appropriate default for a self-hosted app until an admin explicitly opts specific people in.

Seeded the live dev setting with the real admin account's email so the field isn't blank and is editable going forward from Settings.

## Test plan

- [x] New `tests/unit/test_oauth_signup_allowlist.py` — 11 cases: exact match, domain wildcard (including the domain-suffix-is-not-a-substring-match case — same bug class as #349's role-mapping fix), case-insensitivity, empty-denies-all, and the full `_find_or_create_oauth_user` integration (denies new account, allows listed new account, always allows existing account)
- [x] New `tests/unit/test_oauth_allowlist_ui.py` — confirms the field exists as a real `<input>` (not a `<textarea>`, which the page's generic save collector — `querySelectorAll('input, select')` — silently never saves)
- [x] Updated `test_oauth_callback_detached_instance.py`'s new-user test to mock the allowlist permissive — it covers a different, unrelated fix (DetachedInstanceError) and would otherwise now fail on the new gate
- [x] Full `tests/unit/` suite: 132 passed, no regressions
- [x] Deployed live to the dev container, health check green; seeded setting verified in the database

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>