### PR TITLE
feat(auth): OAuth access restricted to admin-only, remove per-login role sync

### DIFF
--- a/src/services/oauth_service.py
+++ b/src/services/oauth_service.py
@@ -572,16 +572,19 @@ class OAuthService:
                         username = f"{base_username}_{counter}"
                         counter += 1
 
-                    # Determine user role based on provider
-                    user_role = UserRole.USER
-                    if provider_name == "authentik" and isinstance(
-                        self.providers[provider_name], AuthentikProvider
-                    ):
-                        groups = user_info.get("groups", [])
-                        roles = user_info.get("roles", [])
-                        user_role = self.providers[provider_name].map_groups_to_role(
-                            groups, roles
-                        )
+                    # Admin-only OAuth access policy (explicit product
+                    # decision, 2026-08-12): granular roles (USER/
+                    # MANAGER/READONLY) aren't well-defined enough yet
+                    # in this app to safely auto-assign via OAuth —
+                    # deferred, tiered self-service access to a later
+                    # version. Anyone trusted enough to pass the
+                    # oauth_allowed_emails allowlist above is trusted
+                    # enough to be a full admin for now.
+                    #
+                    # AuthentikProvider.map_groups_to_role still exists
+                    # for when that later version revisits granular
+                    # access, but is intentionally not called here.
+                    user_role = UserRole.ADMIN
 
                     # Create user
                     user = User(
@@ -626,20 +629,17 @@ class OAuthService:
                         }
                     )
 
-                    # Update role for Authentik users based on current groups
-                    if provider_name == "authentik" and isinstance(
-                        self.providers[provider_name], AuthentikProvider
-                    ):
-                        groups = user_info.get("groups", [])
-                        roles = user_info.get("roles", [])
-                        new_role = self.providers[provider_name].map_groups_to_role(
-                            groups, roles
-                        )
-                        if new_role != user.role:
-                            logger.info(
-                                f"Updated user role for {user.username}: {user.role.value} -> {new_role.value}"
-                            )
-                            user.role = new_role
+                    # Deliberately NOT syncing role from Authentik
+                    # groups here anymore. This exact mechanism — an
+                    # existing user's role silently overwritten based
+                    # on current group membership on every login — was
+                    # the live mechanism behind the privilege-escalation
+                    # incident fixed in #349 (even with the substring-
+                    # match bug fixed, an *exact*-match generic group
+                    # name would still have caused the same class of
+                    # surprise). Role changes for existing accounts are
+                    # an /admin/users decision now, not something that
+                    # happens implicitly on next login.
 
                 # Update last login
                 user.last_login = datetime.utcnow()

--- a/tests/unit/test_oauth_admin_only_signup.py
+++ b/tests/unit/test_oauth_admin_only_signup.py
@@ -1,0 +1,173 @@
+"""Tests for the "admin only" OAuth access policy (explicit product
+decision, 2026-08-12): granular roles (USER/MANAGER/READONLY) aren't
+well-defined enough yet in this app to safely auto-assign via OAuth.
+Anyone trusted enough to pass the oauth_allowed_emails allowlist is
+trusted enough to be a full admin — deferred, tiered self-service access
+to a later version.
+
+Also removes the per-login Authentik group-to-role sync for EXISTING
+users entirely — that exact mechanism (re-evaluating and overwriting an
+existing user's role on every login based on current Authentik group
+membership) was the live mechanism behind the privilege-escalation
+incident fixed in #349, and directly conflicts with "admin only until
+proper RBAC exists": role changes for existing accounts should only
+happen deliberately, via /admin/users, not silently on next login.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.database.connection import Base
+from src.database.models import User, UserRole, UserSession
+from src.services.oauth_service import AuthentikProvider, OAuthService
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, UserSession.__table__])
+    return sessionmaker(bind=engine)
+
+
+@contextmanager
+def _real_get_db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _patch_get_db(session_factory):
+    return patch(
+        "src.services.oauth_service.get_db",
+        lambda: _real_get_db(session_factory),
+    )
+
+
+def _allow_signup():
+    return patch(
+        "src.services.oauth_service.OAuthService._is_email_allowed_for_oauth_signup",
+        return_value=True,
+    )
+
+
+def _pin_password():
+    return patch(
+        "src.services.oauth_service.secrets.token_urlsafe",
+        return_value="Xk9#mQ7z!vR2wL",
+    )
+
+
+class TestNewOAuthAccountsAlwaysGetAdmin:
+    def test_new_google_account_gets_admin(self, session_factory):
+        service = OAuthService.__new__(OAuthService)
+
+        with _patch_get_db(session_factory), _allow_signup(), _pin_password():
+            user, _ = service._find_or_create_oauth_user(
+                "google",
+                {"email": "newperson@example.test", "id": "id-1"},
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user.role == UserRole.ADMIN
+
+    def test_new_github_account_gets_admin(self, session_factory):
+        service = OAuthService.__new__(OAuthService)
+
+        with _patch_get_db(session_factory), _allow_signup(), _pin_password():
+            user, _ = service._find_or_create_oauth_user(
+                "github",
+                {"email": "newperson2@example.test", "id": "id-2"},
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user.role == UserRole.ADMIN
+
+    def test_new_authentik_account_gets_admin_even_with_no_groups(
+        self, session_factory
+    ):
+        """The old behavior defaulted a group-less Authentik user to
+        READONLY via map_groups_to_role. Admin-only policy means new
+        accounts get ADMIN regardless of Authentik group membership."""
+        service = OAuthService.__new__(OAuthService)
+        service.providers = {
+            "authentik": AuthentikProvider(
+                {
+                    "client_id": "id",
+                    "client_secret": "secret",
+                    "redirect_uri": "https://example.test/callback",
+                    "base_url": "https://auth.example.test",
+                }
+            )
+        }
+
+        with _patch_get_db(session_factory), _allow_signup(), _pin_password():
+            user, _ = service._find_or_create_oauth_user(
+                "authentik",
+                {
+                    "email": "newperson3@example.test",
+                    "id": "id-3",
+                    "groups": [],
+                    "roles": [],
+                },
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user.role == UserRole.ADMIN
+
+
+class TestExistingUserRoleIsNeverAutoChangedOnLogin:
+    def test_authentik_login_does_not_promote_an_existing_user(self, session_factory):
+        """Regression pin for the exact live incident (#349): even with
+        the substring-match bug fixed, an exact-match Authentik group
+        must not silently change an existing account's role on login —
+        that decision belongs to /admin/users only."""
+        session = session_factory()
+        existing = User(
+            username="alreadyhere",
+            email="alreadyhere@example.test",
+            password="Sup3rSecret!",
+            role=UserRole.USER,
+        )
+        session.add(existing)
+        session.commit()
+        session.close()
+
+        service = OAuthService.__new__(OAuthService)
+        service.providers = {
+            "authentik": AuthentikProvider(
+                {
+                    "client_id": "id",
+                    "client_secret": "secret",
+                    "redirect_uri": "https://example.test/callback",
+                    "base_url": "https://auth.example.test",
+                }
+            )
+        }
+
+        with _patch_get_db(session_factory):
+            user, _ = service._find_or_create_oauth_user(
+                "authentik",
+                {
+                    "email": "alreadyhere@example.test",
+                    "id": "id-4",
+                    "groups": ["admins"],
+                    "roles": [],
+                },
+                ip_address="203.0.113.5",
+                user_agent="TestAgent/1.0",
+            )
+
+        assert user.role == UserRole.USER

--- a/tests/unit/test_oauth_callback_detached_instance.py
+++ b/tests/unit/test_oauth_callback_detached_instance.py
@@ -98,7 +98,12 @@ class TestOAuthCallbackSurvivesSessionClose:
         # line and auth.py's response-building code do next.
         assert user.username == "newperson"
         assert user.email == "newperson@example.test"
-        assert user.role == UserRole.USER
+        # New OAuth accounts are admin-only for now (see
+        # test_oauth_admin_only_signup.py) — role value here is
+        # incidental to what this test actually covers (attribute
+        # readability after the session closes), not asserting the
+        # role-assignment policy itself.
+        assert user.role == UserRole.ADMIN
         assert isinstance(user.id, int)
 
     def test_existing_user_attributes_are_readable_after_the_session_closes(


### PR DESCRIPTION
Explicit product decision (2026-08-12): granular roles (USER/MANAGER/READONLY) aren't well-defined enough yet in this app to safely auto-assign via OAuth signup — deferred, tiered self-service access to a later version. Anyone trusted enough to pass the `oauth_allowed_emails` allowlist (#350) is trusted enough to be a full admin for now.

## Summary

1. **New OAuth-created accounts (all providers) always get `UserRole.ADMIN`**, instead of the previous `USER` default (or Authentik group-mapped role). `AuthentikProvider.map_groups_to_role` still exists, ready for when granular access is revisited, but is intentionally not called from account creation anymore.

2. **Removed the per-login role sync for EXISTING users entirely.** Previously, every Authentik login re-evaluated and could silently overwrite an existing user's role based on current group membership — this exact mechanism was the live path behind the privilege-escalation incident fixed in #349. Even with that substring-match bug fixed, an *exact*-match generic group name could still cause the same class of surprise (e.g. someone added to an unrelated "admins"-named group elsewhere in a shared Authentik instance). Role changes for existing accounts are now only ever made deliberately, via `/admin/users`.

Cleaned up the two unintended accounts from the live incident directly in the dev database before landing this.

## Test plan

- [x] New `tests/unit/test_oauth_admin_only_signup.py` — 4 cases: new accounts get `ADMIN` across all three providers (including Authentik with zero group memberships, which previously defaulted to `READONLY`), and an existing user's role is NOT changed by an Authentik login carrying an exact-match "admins" group
- [x] Verified RED against pre-fix code (all 4 failed for the expected reasons)
- [x] Updated `test_oauth_callback_detached_instance.py`'s role assertion to match the new policy (that test covers session-attribute readability, not the role-assignment policy)
- [x] Full `tests/unit/` suite: 136 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>