### PR TITLE
fix(auth): OAuth callback failure paths returned raw JSON instead of a proper error page

### DIFF
--- a/frontend/templates/auth/login.html
+++ b/frontend/templates/auth/login.html
@@ -321,6 +321,17 @@
         });
 
         document.getElementById('username').focus();
+
+        // Surface OAuth failures redirected back here with
+        // ?oauth_error=... (see auth.py's oauth_callback, #353) —
+        // without this, a failed OAuth login would just land on a
+        // blank login page with no explanation.
+        const oauthError = new URLSearchParams(window.location.search).get('oauth_error');
+        if (oauthError) {
+            showError(oauthError);
+            const cleanUrl = window.location.pathname;
+            window.history.replaceState({}, document.title, cleanUrl);
+        }
     </script>
 </body>
 </html>

--- a/src/api/fastapi/auth.py
+++ b/src/api/fastapi/auth.py
@@ -484,28 +484,39 @@ async def oauth_callback(
     error: Optional[str] = None,
 ):
     """Handle OAuth callback"""
+    # This endpoint is only ever reached via a real, top-level browser
+    # navigation — the OAuth provider's own server-side redirect after
+    # the user authorizes (or denies) access, not a fetch()/XHR call
+    # from MVidarr's frontend JS. Every failure path below redirects to
+    # the login page with a readable reason instead of returning a raw
+    # JSON error body, which previously left the user staring at a JSON
+    # blob (#353 — same root cause as #347's success-path fix).
+    from fastapi.responses import RedirectResponse
+
+    def _oauth_error_redirect(reason: str) -> RedirectResponse:
+        from urllib.parse import quote
+
+        return RedirectResponse(
+            url=f"/auth/login?oauth_error={quote(reason)}",
+            status_code=status.HTTP_302_FOUND,
+        )
+
     try:
         if error:
             log_oauth_login_failed(provider, f"OAuth provider error: {error}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=f"OAuth error: {error}"
-            )
+            return _oauth_error_redirect(f"OAuth error: {error}")
 
         if not code or not state:
             log_oauth_login_failed(provider, "Missing authorization code or state")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Missing authorization code or state",
-            )
+            return _oauth_error_redirect("Missing authorization code or state")
 
         cookie_state = request.cookies.get("oauth_state")
         if not cookie_state or cookie_state != state:
             log_oauth_login_failed(
                 provider, "State parameter mismatch - possible CSRF attack"
             )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid state parameter - possible CSRF attack",
+            return _oauth_error_redirect(
+                "Invalid state parameter - possible CSRF attack"
             )
 
         ip_address = request.client.host if request.client else "unknown"
@@ -521,14 +532,6 @@ async def oauth_callback(
 
             log_oauth_login_success(user, provider)
 
-            # This endpoint is only ever reached via a real, top-level
-            # browser navigation — the OAuth provider's own server-side
-            # redirect after the user authorizes, not a fetch()/XHR call
-            # from MVidarr's frontend JS. Returning JSON here (as this
-            # used to) left a successful login showing the user a raw
-            # JSON blob instead of landing them back in the app.
-            from fastapi.responses import RedirectResponse
-
             response = RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
             is_https = request.headers.get("x-forwarded-proto") == "https"
             response.set_cookie(
@@ -543,19 +546,15 @@ async def oauth_callback(
             return response
         else:
             log_oauth_login_failed(provider, message)
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail=message
-            )
+            return _oauth_error_redirect(message)
 
-    except HTTPException:
-        raise
     except Exception as e:
+        # Deliberately generic — unlike the branches above, `e` is not
+        # a message this codebase generated, so its text must not leak
+        # into a redirect URL the user's browser will show.
         logger.error(f"OAuth callback error: {e}")
         log_oauth_login_failed(provider, str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="OAuth authentication failed",
-        )
+        return _oauth_error_redirect("OAuth authentication failed")
 
 
 # ====================================

--- a/tests/unit/test_oauth_callback_error_redirect.py
+++ b/tests/unit/test_oauth_callback_error_redirect.py
@@ -1,0 +1,103 @@
+"""Regression test for #353: every failure path in
+GET /api/auth/oauth/{provider}/callback returned a raw JSONResponse
+(via HTTPException) instead of redirecting into the app.
+
+This endpoint is only ever reached via a real, top-level browser
+navigation — the OAuth provider's own server-side redirect after the
+user authorizes (or denies) access, not a fetch()/XHR call from
+MVidarr's own frontend JS (confirmed: nothing in frontend/templates
+calls this URL). PR #347 already fixed the SUCCESS path for the same
+reason; this covers the failure paths, which #347 didn't touch.
+
+All failures now redirect to /auth/login?oauth_error=<message> instead.
+"""
+
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth import router
+
+
+def _make_client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _oauth_error(response):
+    location = response.headers["location"]
+    query = parse_qs(urlparse(location).query)
+    return query.get("oauth_error", [None])[0]
+
+
+class TestOAuthCallbackFailuresRedirectInsteadOfReturningJson:
+    def test_provider_error_redirects_to_login(self):
+        client = _make_client()
+        response = client.get(
+            "/api/auth/oauth/google/callback?error=access_denied",
+            follow_redirects=False,
+        )
+
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"].startswith("/auth/login?")
+        assert _oauth_error(response) is not None
+
+    def test_missing_code_and_state_redirects_to_login(self):
+        client = _make_client()
+        response = client.get("/api/auth/oauth/google/callback", follow_redirects=False)
+
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"].startswith("/auth/login?")
+
+    def test_state_mismatch_redirects_to_login(self):
+        client = _make_client()
+        client.cookies.set("oauth_state", "wrong-value")
+        response = client.get(
+            "/api/auth/oauth/google/callback?code=fake&state=abc123",
+            follow_redirects=False,
+        )
+
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"].startswith("/auth/login?")
+
+    def test_signup_denied_redirects_with_the_real_reason(self):
+        """The exact case reported live: a user not on the OAuth
+        allowlist (#350) gets a real, readable reason instead of a
+        JSON blob."""
+        client = _make_client()
+        client.cookies.set("oauth_state", "abc123")
+
+        with patch(
+            "src.api.fastapi.auth.oauth_service.handle_oauth_callback",
+            return_value=(False, "Failed to create or find user", None, None),
+        ):
+            response = client.get(
+                "/api/auth/oauth/google/callback?code=fake&state=abc123",
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (302, 303, 307)
+        assert _oauth_error(response) == "Failed to create or find user"
+
+    def test_unexpected_exception_redirects_with_a_generic_message(self):
+        """Internal exception details must not leak into the redirect
+        (matches the pre-existing 500 branch's generic message)."""
+        client = _make_client()
+        client.cookies.set("oauth_state", "abc123")
+
+        with patch(
+            "src.api.fastapi.auth.oauth_service.handle_oauth_callback",
+            side_effect=RuntimeError("some internal detail"),
+        ):
+            response = client.get(
+                "/api/auth/oauth/google/callback?code=fake&state=abc123",
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (302, 303, 307)
+        error = _oauth_error(response)
+        assert error is not None
+        assert "some internal detail" not in error

--- a/tests/unit/test_oauth_error_display.py
+++ b/tests/unit/test_oauth_error_display.py
@@ -1,0 +1,21 @@
+"""Regression test for #353: the login page must actually display the
+oauth_error query param that auth.py's oauth_callback now redirects
+failures to — the backend fix alone is silent without this.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestOAuthErrorDisplay:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "auth" / "login.html").read_text()
+
+    def test_reads_the_oauth_error_query_param(self):
+        assert "oauth_error" in self.html
+
+    def test_displays_it_via_the_existing_error_element_not_innerhtml(self):
+        # showError() uses .textContent — confirm the oauth_error
+        # value is routed through it, not injected as raw HTML.
+        assert "showError(oauthError)" in self.html

--- a/tests/unit/test_oauth_service_state.py
+++ b/tests/unit/test_oauth_service_state.py
@@ -7,6 +7,7 @@ was replaced.
 """
 
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -56,21 +57,29 @@ class TestOAuthLoginSetsCookie:
 
 
 class TestOAuthCallbackValidatesCookie:
+    # Failure responses redirect to /auth/login?oauth_error=... rather
+    # than returning a JSON error body — see test_oauth_callback_error_
+    # redirect.py's module docstring (#353) for why: this endpoint is
+    # only ever reached via a real browser navigation, not a fetch()/XHR
+    # call, so a JSON body just showed the user a raw JSON blob.
     def test_callback_rejects_missing_cookie(self):
         client = _make_client()
         response = client.get(
-            "/api/auth/oauth/authentik/callback?code=fake&state=abc123"
+            "/api/auth/oauth/authentik/callback?code=fake&state=abc123",
+            follow_redirects=False,
         )
-        assert response.status_code == 400
-        assert "state" in response.json()["detail"].lower()
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"].startswith("/auth/login?oauth_error=")
 
     def test_callback_rejects_mismatched_cookie(self):
         client = _make_client()
         client.cookies.set("oauth_state", "different-value")
         response = client.get(
-            "/api/auth/oauth/authentik/callback?code=fake&state=abc123"
+            "/api/auth/oauth/authentik/callback?code=fake&state=abc123",
+            follow_redirects=False,
         )
-        assert response.status_code == 400
+        assert response.status_code in (302, 303, 307)
+        assert response.headers["location"].startswith("/auth/login?oauth_error=")
 
     def test_callback_accepts_matching_cookie(self):
         client = _make_client()
@@ -81,16 +90,20 @@ class TestOAuthCallbackValidatesCookie:
             return_value=(False, "Failed to obtain access token", None, None),
         ):
             response = client.get(
-                "/api/auth/oauth/authentik/callback?code=fake&state=abc123"
+                "/api/auth/oauth/authentik/callback?code=fake&state=abc123",
+                follow_redirects=False,
             )
 
-        # Cookie matched, so the request proceeds past the CSRF check into
-        # the actual OAuth exchange (which fails here for an unrelated,
-        # mocked reason — 401, not 400). Asserting the exact status pins
-        # "got past the CSRF gate, failed for the downstream reason"
-        # rather than a looser check that would also pass on unrelated
-        # failures.
-        assert response.status_code == 401
+        # Cookie matched, so the request proceeds past the CSRF check
+        # into the actual OAuth exchange (which fails here for an
+        # unrelated, mocked reason). Still a redirect, but carrying the
+        # downstream failure's message — pins "got past the CSRF gate,
+        # failed for the downstream reason" rather than a looser check
+        # that would also pass on the CSRF failure itself.
+        assert response.status_code in (302, 303, 307)
+        location = response.headers["location"]
+        query = parse_qs(urlparse(location).query)
+        assert query["oauth_error"][0] == "Failed to obtain access token"
 
 
 def test_handle_oauth_callback_passes_ip_and_user_agent_through():


### PR DESCRIPTION
Fixes #353.

PR #347 fixed the SUCCESS path of `GET /api/auth/oauth/{provider}/callback` returning raw `JSONResponse` instead of redirecting into the app — every FAILURE path in that same handler still did. This endpoint is only ever reached via a real, top-level browser navigation (the OAuth provider's own server-side redirect after the user authorizes or denies access), not a `fetch()`/XHR call from MVidarr's frontend JS, so any failure left the user staring at a raw JSON blob instead of a page explaining what happened.

Concretely reported: a user not on the `oauth_allowed_emails` allowlist (#350) landed on `{"detail":"Failed to create or find user"}` instead of a login page with a readable reason.

## Fix

All five failure branches (provider-returned error, missing code/state, CSRF state mismatch, `handle_oauth_callback` failure, unexpected exception) now redirect to `/auth/login?oauth_error=<reason>` instead of raising `HTTPException`. `login.html` reads that query param on load and displays it via the existing `showError()` (`.textContent`, not `innerHTML`) — the same pattern already used for password-login failures — then strips it from the URL via `history.replaceState` so a refresh doesn't re-show it. The unexpected-exception branch deliberately uses a generic message rather than `str(e)`, since that text isn't something this codebase generated.

## Test plan

- [x] New `tests/unit/test_oauth_callback_error_redirect.py` — 5 cases covering every failure branch, confirming a redirect (not JSON) and that the real reason is carried through (or genuinely internal exception text is NOT, for the generic-exception case)
- [x] New `tests/unit/test_oauth_error_display.py` — confirms `login.html` actually reads and displays `oauth_error` via the safe `.textContent` path
- [x] Updated `test_oauth_service_state.py`'s three existing CSRF/cookie tests to match the new redirect-based response shape
- [x] Verified RED against pre-fix code
- [x] Full `tests/unit/` suite: 143 passed, no regressions
- [x] Deployed live to the dev container, health check green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>