### PR TITLE
feat(thumbnails): live Spotify/Last.fm artist thumbnail sources, de-duplicate the three drifting search cascades

### DIFF
--- a/src/api/fastapi/artists_bulk.py
+++ b/src/api/fastapi/artists_bulk.py
@@ -960,9 +960,10 @@ async def bulk_thumbnail_scan(
     rather than scanning all artists at once.
     """
     try:
+        from src.services.artist_thumbnail_search_service import (
+            search_artist_thumbnails,
+        )
         from src.services.thumbnail_service import ThumbnailService
-        from src.services.wikipedia_service import wikipedia_service
-        from src.services.youtube_search_service import youtube_search_service
 
         if not request.artist_ids:
             raise HTTPException(status_code=400, detail="No artist IDs provided")
@@ -985,32 +986,20 @@ async def bulk_thumbnail_scan(
                     logger.debug(f"Artist {artist.name} already has thumbnail")
                     continue
 
-                thumbnail_url = None
-
-                # Try Wikipedia first
-                try:
-                    wikipedia_url = wikipedia_service.search_artist_thumbnail(
-                        artist.name
+                # Same shared cascade as the single-artist search
+                # endpoint (#320) — Spotify, Last.fm, cached metadata,
+                # Wikipedia, YouTube, in that priority order.
+                # stop_at_first_result=True: a bulk scan wants one good
+                # hit per artist, not every source queried for all of
+                # them.
+                results = search_artist_thumbnails(
+                    artist.name, artist=artist, stop_at_first_result=True
+                )
+                thumbnail_url = results[0]["url"] if results else None
+                if thumbnail_url:
+                    logger.info(
+                        f"Found {results[0]['source']} thumbnail for {artist.name}"
                     )
-                    if wikipedia_url:
-                        thumbnail_url = wikipedia_url
-                        logger.info(f"Found Wikipedia thumbnail for {artist.name}")
-                except Exception as e:
-                    logger.debug(f"Wikipedia search failed for {artist.name}: {e}")
-
-                # Try YouTube if Wikipedia didn't work
-                if not thumbnail_url:
-                    try:
-                        youtube_url = (
-                            youtube_search_service.search_artist_channel_thumbnail(
-                                artist.name
-                            )
-                        )
-                        if youtube_url:
-                            thumbnail_url = youtube_url
-                            logger.info(f"Found YouTube thumbnail for {artist.name}")
-                    except Exception as e:
-                        logger.debug(f"YouTube search failed for {artist.name}: {e}")
 
                 # Download and save thumbnail
                 if thumbnail_url:

--- a/src/api/fastapi/artists_models.py
+++ b/src/api/fastapi/artists_models.py
@@ -234,7 +234,13 @@ class MergeArtistsRequest(BaseModel):
 class ThumbnailSearchRequest(BaseModel):
     """Request model for searching artist thumbnails"""
 
-    source: str = Field("auto", pattern="^(auto|wikipedia|youtube|imvdb)$")
+    # "imvdb" was previously an allowed value with no matching handler
+    # branch — always silently returned zero results. Replaced with the
+    # sources the search cascade actually implements (#320):
+    # artist_thumbnail_search_service.search_artist_thumbnails.
+    source: str = Field(
+        "auto", pattern="^(auto|spotify|lastfm|metadata|wikipedia|youtube)$"
+    )
     query: Optional[str] = None
 
 

--- a/src/api/fastapi/artists_thumbnails.py
+++ b/src/api/fastapi/artists_thumbnails.py
@@ -36,8 +36,8 @@ from src.api.fastapi.auth_dependencies import (
 )
 from src.database.connection import get_db_session
 from src.database.models import Artist
+from src.services.artist_thumbnail_search_service import search_artist_thumbnails
 from src.services.thumbnail_service import ThumbnailService, thumbnail_service
-from src.services.wikipedia_service import wikipedia_service
 from src.services.youtube_search_service import youtube_search_service
 
 # Router configuration
@@ -55,48 +55,13 @@ logger = logging.getLogger("mvidarr.api.fastapi.artists_thumbnails")
 # ========================================================================================
 # HELPER FUNCTIONS
 # ========================================================================================
-
-
-def _is_placeholder_url(url: str) -> bool:
-    """Check if URL is a known placeholder image"""
-    if not url:
-        return True
-
-    url_lower = url.lower()
-
-    # Known placeholder patterns
-    placeholder_patterns = [
-        # Last.fm placeholder images
-        "2a96cbd8b46e442fc41c2b86b821562f.png",
-        "lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f",
-        # Generic placeholders
-        "placeholder",
-        "default",
-        "generic",
-        "no-image",
-        "blank",
-        "missing",
-        "unavailable",
-        "coming-soon",
-        "avatar-default",
-        "profile-default",
-        "default_artist",
-        "artist_placeholder",
-        "music_placeholder",
-        "album_default",
-        "cover_default",
-        # Common placeholder files
-        "grey.gif",
-        "transparent.png",
-        "1x1.png",
-        "spacer.gif",
-        "default.jpg",
-        "default.png",
-        "placeholder.jpg",
-        "placeholder.png",
-    ]
-
-    return any(pattern in url_lower for pattern in placeholder_patterns)
+#
+# Placeholder-URL detection used to be duplicated here (this module),
+# in ThumbnailService, and a third time as an inline closure a few
+# hundred lines below — three divergent copies, one of them missing
+# patterns the other two had. Consolidated to
+# thumbnail_service.is_placeholder_url() (#320); nothing in this file
+# defines its own copy anymore.
 
 
 async def _get_artist_thumbnail_impl(
@@ -432,7 +397,13 @@ async def search_artist_thumbnail(
     current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
-    """Search for artist thumbnail from various sources"""
+    """Search for artist thumbnail from various sources.
+
+    Delegates to artist_thumbnail_search_service.search_artist_thumbnails
+    (#320) — the single shared cascade also used by bulk_thumbnail_scan,
+    replacing what used to be ~180 lines of inline, duplicated source
+    logic here.
+    """
     try:
         artist = session.query(Artist).filter(Artist.id == artist_id).first()
 
@@ -441,156 +412,9 @@ async def search_artist_thumbnail(
 
         search_query = search_request.query or artist.name
 
-        # Search for thumbnails based on source
-        thumbnail_results = []
-
-        if search_request.source in ["auto", "wikipedia"]:
-            try:
-                logger.info(f"Searching Wikipedia for thumbnails: {search_query}")
-
-                # Try multiple search variations for better Wikipedia matches
-                search_terms = [search_query]
-
-                # Add common variations for known problematic cases
-                if search_query.upper() == "REM":
-                    search_terms.extend(["R.E.M.", "R.E.M. band", "REM band"])
-                elif "." not in search_query and len(search_query.split()) == 1:
-                    # For single-word artists, try adding "band" or "musician"
-                    search_terms.extend(
-                        [f"{search_query} band", f"{search_query} musician"]
-                    )
-
-                wikipedia_url = None
-                for term in search_terms:
-                    logger.debug(f"Trying Wikipedia search term: {term}")
-                    wikipedia_url = wikipedia_service.search_artist_thumbnail(term)
-                    if wikipedia_url:
-                        logger.info(
-                            f"Wikipedia search successful with term '{term}': {wikipedia_url}"
-                        )
-                        break
-
-                if wikipedia_url:
-                    thumbnail_results.append(
-                        {
-                            "source": "wikipedia",
-                            "url": wikipedia_url,
-                            "title": f"{search_query} - Wikipedia",
-                            "description": f"Wikipedia thumbnail for {search_query}",
-                        }
-                    )
-                else:
-                    logger.info(
-                        f"No Wikipedia thumbnail found for any variation of: {search_query}"
-                    )
-            except Exception as e:
-                logger.warning(f"Wikipedia thumbnail search failed: {e}")
-
-        if search_request.source in ["auto", "youtube"]:
-            try:
-                logger.info(f"Searching YouTube for thumbnails: {search_query}")
-                youtube_url = youtube_search_service.search_artist_channel_thumbnail(
-                    search_query
-                )
-                logger.info(f"YouTube search result: {youtube_url}")
-                if youtube_url:
-                    thumbnail_results.append(
-                        {
-                            "source": "youtube",
-                            "url": youtube_url,
-                            "title": f"{search_query} - YouTube Channel",
-                            "channel": search_query,
-                        }
-                    )
-            except Exception as e:
-                logger.warning(f"YouTube thumbnail search failed: {e}")
-
-        # Check for existing metadata images (Spotify, Last.fm, etc.)
-        if search_request.source in ["auto", "spotify", "lastfm", "metadata"]:
-            try:
-                logger.info(f"Checking existing metadata images for: {search_query}")
-                if artist.imvdb_metadata:
-                    metadata = artist.imvdb_metadata
-                    images = metadata.get("images", [])
-
-                    # Helper function to check if image is a placeholder
-                    def is_placeholder_image(url):
-                        if not url:
-                            return True
-                        placeholder_patterns = [
-                            "2a96cbd8b46e442fc41c2b86b821562f.png",
-                            "4128a6eb29f94943c9d206c08e625904",
-                            "c6f59c1e5e7240a4c0d427abd71f3dbb",
-                            "placeholder",
-                            "default",
-                            "generic",
-                            "no-image",
-                        ]
-                        return any(
-                            pattern in url.lower() for pattern in placeholder_patterns
-                        )
-
-                    # Process Last.fm/metadata images
-                    valid_images = []
-                    for img in images:
-                        img_url = None
-                        img_size = "unknown"
-
-                        # Handle different image formats
-                        if isinstance(img, dict):
-                            img_url = img.get("#text") or img.get("url")
-                            img_size = img.get("size", "unknown")
-                        elif isinstance(img, str):
-                            img_url = img
-
-                        # Skip placeholder images
-                        if img_url and not is_placeholder_image(img_url):
-                            valid_images.append(
-                                {
-                                    "url": img_url,
-                                    "size": img_size,
-                                    "source": (
-                                        "lastfm" if "lastfm" in img_url else "metadata"
-                                    ),
-                                }
-                            )
-
-                    # Add valid images to results (prefer larger sizes)
-                    size_priority = {
-                        "mega": 5,
-                        "extralarge": 4,
-                        "large": 3,
-                        "medium": 2,
-                        "small": 1,
-                        "": 0,
-                        "unknown": 0,
-                    }
-                    valid_images.sort(
-                        key=lambda x: size_priority.get(x["size"], 0), reverse=True
-                    )
-
-                    for img in valid_images[:3]:  # Limit to top 3 images
-                        thumbnail_results.append(
-                            {
-                                "source": img["source"],
-                                "url": img["url"],
-                                "title": f"{search_query} - {img['source'].title()} Image ({img['size']})",
-                                "size": img["size"],
-                            }
-                        )
-
-                    if valid_images:
-                        logger.info(
-                            f"Found {len(valid_images)} valid metadata images for {search_query}"
-                        )
-                    else:
-                        logger.debug(
-                            f"No valid (non-placeholder) metadata images found for {search_query}"
-                        )
-                else:
-                    logger.debug(f"No metadata available for {search_query}")
-            except Exception as e:
-                logger.warning(f"Metadata image retrieval failed: {e}")
+        thumbnail_results = search_artist_thumbnails(
+            search_query, artist=artist, source_filter=search_request.source
+        )
 
         # Log summary for debugging
         if thumbnail_results:
@@ -719,76 +543,30 @@ async def scan_missing_thumbnails(
                     f"Searching thumbnails for artist: {artist_name} (ID: {artist_id})"
                 )
 
-                thumbnail_url = None
+                # Same shared cascade as the other two thumbnail-search
+                # endpoints (#320) — Spotify, Last.fm, cached metadata,
+                # Wikipedia, YouTube, in that priority order.
+                # stop_at_first_result=True matches this loop's original
+                # "try in order until one works" semantics.
+                #
+                # The previous first source here was an unauthenticated
+                # Google Images HTML-scrape (fragile, against Google's
+                # ToS, and already abandoned by the frontend's own
+                # search UI — see artist_detail.html's searchThumbnail
+                # Google branch, which returns an empty result on
+                # purpose "since this is just for development"). Not
+                # carried forward; Spotify is both more reliable and a
+                # real, sanctioned API.
+                results = search_artist_thumbnails(
+                    artist_name, stop_at_first_result=True
+                )
+                thumbnail_url = results[0]["url"] if results else None
+                if thumbnail_url:
+                    logger.info(
+                        f"Found {results[0]['source']} thumbnail for {artist_name}: {thumbnail_url}"
+                    )
 
-                # Try multiple sources for thumbnails
-                # 1. Try Google Images first (most variety)
-                try:
-                    import re
-                    from urllib.parse import quote
-
-                    image_query = f"{artist_name} musician artist photo"
-                    encoded_query = quote(image_query)
-                    search_url = f"https://www.google.com/search?q={encoded_query}&tbm=isch&safe=off"
-
-                    headers = {
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-                    }
-
-                    import requests
-
-                    response = requests.get(search_url, headers=headers, timeout=10)
-                    if response.status_code == 200:
-                        # Extract image URLs from the page
-                        image_pattern = r'"(https?://[^"]*\.(?:jpg|jpeg|png))"'
-                        matches = re.findall(image_pattern, response.text)
-
-                        # Filter results - skip Google's own domains and tiny images
-                        for match in matches[:10]:
-                            if (
-                                "gstatic.com" not in match
-                                and "google.com" not in match
-                                and not _is_placeholder_url(match)
-                            ):
-                                thumbnail_url = match
-                                logger.info(
-                                    f"Found Google Images thumbnail for {artist_name}: {thumbnail_url}"
-                                )
-                                break
-                except Exception as e:
-                    logger.debug(f"Google Images search failed for {artist_name}: {e}")
-
-                # 2. Try Wikipedia if Google didn't work
-                if not thumbnail_url:
-                    try:
-                        wikipedia_url = wikipedia_service.search_artist_thumbnail(
-                            artist_name
-                        )
-                        if wikipedia_url and not _is_placeholder_url(wikipedia_url):
-                            thumbnail_url = wikipedia_url
-                            logger.info(
-                                f"Found Wikipedia thumbnail for {artist_name}: {wikipedia_url}"
-                            )
-                    except Exception as e:
-                        logger.debug(f"Wikipedia search failed for {artist_name}: {e}")
-
-                # 3. Try YouTube channel thumbnail if others didn't work
-                if not thumbnail_url:
-                    try:
-                        from src.services.youtube_search_service import (
-                            search_artist_channel_thumbnail,
-                        )
-
-                        youtube_url = search_artist_channel_thumbnail(artist_name)
-                        if youtube_url and not _is_placeholder_url(youtube_url):
-                            thumbnail_url = youtube_url
-                            logger.info(
-                                f"Found YouTube thumbnail for {artist_name}: {youtube_url}"
-                            )
-                    except Exception as e:
-                        logger.debug(f"YouTube search failed for {artist_name}: {e}")
-
-                # 3. If we found a thumbnail, download and set it
+                # If we found a thumbnail, download and set it
                 if thumbnail_url:
                     try:
                         from src.services.thumbnail_service import ThumbnailService

--- a/src/services/artist_thumbnail_search_service.py
+++ b/src/services/artist_thumbnail_search_service.py
@@ -1,0 +1,236 @@
+"""
+Unified artist thumbnail source search.
+
+Consolidates what were two separate, drifting cascades — the
+single-artist thumbnail search endpoint (Wikipedia -> YouTube -> cached
+metadata images) and the bulk-scan endpoint (Wikipedia -> YouTube only,
+no metadata fallback at all) — into one shared function and one
+priority order (#320).
+
+#320 reported IMVDb as "limited" and Wikipedia as "not always
+reliable," asking for MusicBrainz/Last.fm/Spotify to be tried first
+instead. Spotify and Last.fm are added here as real, live image
+sources, ahead of Wikipedia. MusicBrainz is deliberately NOT a source:
+confirmed by reading musicbrainz_service.py's actual methods before
+assuming otherwise, its API provides metadata and cross-service links
+(genres, relations, release data), not artist photography — there is
+no MusicBrainz-hosted artist image to fetch.
+
+Note on Last.fm specifically: its artist.getInfo image field has, for
+years, mostly returned a fixed set of gray placeholder images rather
+than real artist photos — this is why the placeholder-URL filtering
+below (shared with thumbnail_service.py, not a second copy of it)
+matters as much for Last.fm as it does for Wikipedia/YouTube scraping.
+Spotify remains the most reliable of the three explicitly-requested
+sources.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from src.database.models import Artist
+from src.services.lastfm_service import lastfm_service
+from src.services.spotify_service import spotify_service
+from src.services.thumbnail_service import thumbnail_service
+from src.services.wikipedia_service import wikipedia_service
+from src.services.youtube_search_service import youtube_search_service
+
+logger = logging.getLogger("mvidarr.services.artist_thumbnail_search")
+
+# Priority order for "auto" mode.
+_AUTO_SOURCE_ORDER = ["spotify", "lastfm", "metadata", "wikipedia", "youtube"]
+
+_METADATA_SIZE_PRIORITY = {
+    "mega": 5,
+    "extralarge": 4,
+    "large": 3,
+    "medium": 2,
+    "small": 1,
+    "": 0,
+    "unknown": 0,
+}
+
+
+def _search_spotify(artist_name: str, artist: Optional[Artist]) -> List[Dict[str, Any]]:
+    if not spotify_service.enabled:
+        return []
+    try:
+        response = spotify_service.search_artist(artist_name, limit=1)
+        items = (response or {}).get("artists", {}).get("items", [])
+        if not items:
+            return []
+        images = items[0].get("images", []) or []
+        return [
+            {
+                "source": "spotify",
+                "url": img["url"],
+                "title": f"{artist_name} - Spotify",
+                "size": f"{img.get('width')}x{img.get('height')}",
+            }
+            for img in images
+            if img.get("url") and not thumbnail_service.is_placeholder_url(img["url"])
+        ]
+    except Exception as e:
+        logger.warning(f"Spotify thumbnail search failed for {artist_name}: {e}")
+        return []
+
+
+def _search_lastfm(artist_name: str, artist: Optional[Artist]) -> List[Dict[str, Any]]:
+    if not lastfm_service.enabled:
+        return []
+    try:
+        info = lastfm_service.get_artist_info(artist_name)
+        results = []
+        for img in info.get("image", []) or []:
+            url = img.get("#text") if isinstance(img, dict) else None
+            if url and not thumbnail_service.is_placeholder_url(url):
+                size = img.get("size", "unknown")
+                results.append(
+                    {
+                        "source": "lastfm",
+                        "url": url,
+                        "title": f"{artist_name} - Last.fm ({size})",
+                        "size": size,
+                    }
+                )
+        return results
+    except Exception as e:
+        logger.warning(f"Last.fm thumbnail search failed for {artist_name}: {e}")
+        return []
+
+
+def _search_cached_metadata(
+    artist_name: str, artist: Optional[Artist]
+) -> List[Dict[str, Any]]:
+    """Images IMVDb already cached (typically sourced from Last.fm) on
+    a prior enrichment pass — a useful fallback when the live Spotify/
+    Last.fm sources above are unconfigured or disabled."""
+    if not artist or not artist.imvdb_metadata:
+        return []
+
+    metadata = artist.imvdb_metadata
+    images = metadata.get("images", []) if isinstance(metadata, dict) else []
+
+    valid = []
+    for img in images:
+        if isinstance(img, dict):
+            url = img.get("#text") or img.get("url")
+            size = img.get("size", "unknown")
+        elif isinstance(img, str):
+            url, size = img, "unknown"
+        else:
+            continue
+
+        if url and not thumbnail_service.is_placeholder_url(url):
+            source = "lastfm" if "lastfm" in url else "metadata"
+            valid.append(
+                {
+                    "source": source,
+                    "url": url,
+                    "title": f"{artist_name} - {source.title()} Image ({size})",
+                    "size": size,
+                }
+            )
+
+    valid.sort(key=lambda r: _METADATA_SIZE_PRIORITY.get(r["size"], 0), reverse=True)
+    return valid[:3]
+
+
+def _search_wikipedia(
+    artist_name: str, artist: Optional[Artist]
+) -> List[Dict[str, Any]]:
+    try:
+        search_terms = [artist_name]
+        if artist_name.upper() == "REM":
+            search_terms.extend(["R.E.M.", "R.E.M. band", "REM band"])
+        elif "." not in artist_name and len(artist_name.split()) == 1:
+            search_terms.extend([f"{artist_name} band", f"{artist_name} musician"])
+
+        for term in search_terms:
+            url = wikipedia_service.search_artist_thumbnail(term)
+            if url and not thumbnail_service.is_placeholder_url(url):
+                return [
+                    {
+                        "source": "wikipedia",
+                        "url": url,
+                        "title": f"{artist_name} - Wikipedia",
+                        "description": f"Wikipedia thumbnail for {artist_name}",
+                    }
+                ]
+        return []
+    except Exception as e:
+        logger.warning(f"Wikipedia thumbnail search failed for {artist_name}: {e}")
+        return []
+
+
+def _search_youtube(artist_name: str, artist: Optional[Artist]) -> List[Dict[str, Any]]:
+    try:
+        url = youtube_search_service.search_artist_channel_thumbnail(artist_name)
+        if url and not thumbnail_service.is_placeholder_url(url):
+            return [
+                {
+                    "source": "youtube",
+                    "url": url,
+                    "title": f"{artist_name} - YouTube Channel",
+                    "channel": artist_name,
+                }
+            ]
+        return []
+    except Exception as e:
+        logger.warning(f"YouTube thumbnail search failed for {artist_name}: {e}")
+        return []
+
+
+_SOURCE_SEARCHERS: Dict[
+    str, Callable[[str, Optional[Artist]], List[Dict[str, Any]]]
+] = {
+    "spotify": _search_spotify,
+    "lastfm": _search_lastfm,
+    "metadata": _search_cached_metadata,
+    "wikipedia": _search_wikipedia,
+    "youtube": _search_youtube,
+}
+
+
+def search_artist_thumbnails(
+    artist_name: str,
+    artist: Optional[Artist] = None,
+    source_filter: str = "auto",
+    stop_at_first_result: bool = False,
+) -> List[Dict[str, Any]]:
+    """
+    Search configured thumbnail sources for an artist.
+
+    Args:
+        artist_name: Name to search for.
+        artist: The Artist row, if available — enables the cached-
+            metadata fallback source. Optional; pass None for a search
+            with no associated database row yet.
+        source_filter: "auto" tries every source in priority order
+            (spotify, lastfm, metadata, wikipedia, youtube), skipping
+            any that are unconfigured. Any other value restricts the
+            search to just that one named source.
+        stop_at_first_result: If True, stop after the first source that
+            returns at least one result, instead of gathering results
+            from every source. Use for automated/bulk scans where one
+            good hit per artist is enough; leave False for interactive
+            search UIs that let a user pick among multiple options.
+
+    Returns:
+        A list of {"source", "url", "title", ...} dicts, most-preferred
+        source first. Known placeholder images (dead Last.fm/Wikipedia/
+        YouTube defaults) are already filtered out.
+    """
+    sources = _AUTO_SOURCE_ORDER if source_filter == "auto" else [source_filter]
+
+    results: List[Dict[str, Any]] = []
+    for source in sources:
+        searcher = _SOURCE_SEARCHERS.get(source)
+        if not searcher:
+            continue
+        source_results = searcher(artist_name, artist)
+        results.extend(source_results)
+        if stop_at_first_result and source_results:
+            break
+
+    return results

--- a/src/services/thumbnail_service.py
+++ b/src/services/thumbnail_service.py
@@ -79,7 +79,7 @@ class ThumbnailService:
 
         logger.debug(f"Thumbnails directory ensured: {self.thumbnails_dir}")
 
-    def _is_placeholder_url(self, url: str) -> bool:
+    def is_placeholder_url(self, url: str) -> bool:
         """Check if URL is a known placeholder image"""
         if not url:
             return True
@@ -352,7 +352,7 @@ class ThumbnailService:
             ThumbnailValidationError: If image validation fails
         """
         # Additional safety check - don't download known placeholders
-        if self._is_placeholder_url(url):
+        if self.is_placeholder_url(url):
             msg = f"URL is a known placeholder image: {url}"
             logger.info(
                 f"Refusing to download placeholder thumbnail for {artist_name}: {url}"

--- a/tests/unit/test_artist_thumbnail_search_service.py
+++ b/tests/unit/test_artist_thumbnail_search_service.py
@@ -1,0 +1,227 @@
+"""Tests for the unified artist thumbnail source search (#320).
+
+Consolidates what were two separate, drifting cascades — the
+single-artist search endpoint and the bulk-scan endpoint — into one
+shared function with one priority order, and adds live Spotify/Last.fm
+image lookups ahead of Wikipedia (previously the only real image
+source tried; #320 reported it "is not always reliable").
+
+MusicBrainz is deliberately NOT a source here: its API provides
+metadata and cross-service links, not artist photography — there is no
+MusicBrainz-hosted artist image to fetch, confirmed by reading
+musicbrainz_service.py's actual methods before assuming otherwise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.services.artist_thumbnail_search_service import search_artist_thumbnails
+
+
+def _artist(imvdb_metadata=None):
+    return SimpleNamespace(imvdb_metadata=imvdb_metadata)
+
+
+class TestAutoModePriorityOrder:
+    def test_spotify_result_appears_before_wikipedia(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = True
+            mock_spotify.search_artist.return_value = {
+                "artists": {
+                    "items": [
+                        {
+                            "images": [
+                                {
+                                    "url": "https://spotify.example/img.jpg",
+                                    "width": 640,
+                                    "height": 640,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+            mock_lastfm.enabled = False
+            mock_wikipedia.search_artist_thumbnail.return_value = (
+                "https://wikipedia.example/img.jpg"
+            )
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist")
+
+        sources = [r["source"] for r in results]
+        assert sources.index("spotify") < sources.index("wikipedia")
+
+    def test_unconfigured_sources_are_silently_skipped(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = False
+            mock_lastfm.enabled = False
+            mock_wikipedia.search_artist_thumbnail.return_value = None
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist")
+
+        assert results == []
+        mock_spotify.search_artist.assert_not_called()
+
+    def test_a_failing_source_does_not_prevent_others_from_running(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = True
+            mock_spotify.search_artist.side_effect = RuntimeError("Spotify down")
+            mock_lastfm.enabled = False
+            mock_wikipedia.search_artist_thumbnail.return_value = (
+                "https://wikipedia.example/img.jpg"
+            )
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist")
+
+        assert any(r["source"] == "wikipedia" for r in results)
+
+
+class TestSourceFilter:
+    def test_restricting_to_a_single_source_skips_the_others(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_wikipedia.search_artist_thumbnail.return_value = (
+                "https://wikipedia.example/img.jpg"
+            )
+
+            results = search_artist_thumbnails("Some Artist", source_filter="wikipedia")
+
+        assert [r["source"] for r in results] == ["wikipedia"]
+        mock_youtube.search_artist_channel_thumbnail.assert_not_called()
+
+
+class TestStopAtFirstResult:
+    def test_stops_after_the_first_source_with_results(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm:
+            mock_spotify.enabled = True
+            mock_spotify.search_artist.return_value = {
+                "artists": {
+                    "items": [
+                        {
+                            "images": [
+                                {
+                                    "url": "https://spotify.example/img.jpg",
+                                    "width": 640,
+                                    "height": 640,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+            mock_lastfm.enabled = True
+
+            results = search_artist_thumbnails("Some Artist", stop_at_first_result=True)
+
+        assert [r["source"] for r in results] == ["spotify"]
+        mock_lastfm.get_artist_info.assert_not_called()
+
+
+class TestPlaceholderFiltering:
+    def test_known_lastfm_placeholder_is_excluded_from_spotify_and_lastfm_results(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = True
+            mock_spotify.search_artist.return_value = {"artists": {"items": []}}
+            mock_lastfm.enabled = True
+            mock_lastfm.get_artist_info.return_value = {
+                "image": [
+                    {
+                        "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+                        "size": "large",
+                    }
+                ]
+            }
+            mock_wikipedia.search_artist_thumbnail.return_value = None
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist")
+
+        assert results == []
+
+
+class TestCachedMetadataFallback:
+    def test_falls_back_to_cached_imvdb_metadata_images(self):
+        artist = _artist(
+            imvdb_metadata={
+                "images": [{"#text": "https://cached.example/img.jpg", "size": "large"}]
+            }
+        )
+
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = False
+            mock_lastfm.enabled = False
+            mock_wikipedia.search_artist_thumbnail.return_value = None
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist", artist=artist)
+
+        assert any(r["url"] == "https://cached.example/img.jpg" for r in results)
+
+    def test_no_artist_row_means_no_cached_metadata_results(self):
+        with patch(
+            "src.services.artist_thumbnail_search_service.spotify_service"
+        ) as mock_spotify, patch(
+            "src.services.artist_thumbnail_search_service.lastfm_service"
+        ) as mock_lastfm, patch(
+            "src.services.artist_thumbnail_search_service.wikipedia_service"
+        ) as mock_wikipedia, patch(
+            "src.services.artist_thumbnail_search_service.youtube_search_service"
+        ) as mock_youtube:
+            mock_spotify.enabled = False
+            mock_lastfm.enabled = False
+            mock_wikipedia.search_artist_thumbnail.return_value = None
+            mock_youtube.search_artist_channel_thumbnail.return_value = None
+
+            results = search_artist_thumbnails("Some Artist", artist=None)
+
+        assert results == []


### PR DESCRIPTION
Fixes #320.

#320 reported IMVDb as "limited" and Wikipedia as "not always reliable," asking that MusicBrainz/Last.fm/Spotify be tried first instead.

## Summary

New `src/services/artist_thumbnail_search_service.py` replaces **three** separate, independently-drifting thumbnail search cascades that had accumulated across the codebase:

- `artists_thumbnails.py`'s `search_artist_thumbnail` (interactive, single-artist): Wikipedia -> YouTube -> cached IMVDb metadata images
- `artists_bulk.py`'s `bulk_thumbnail_scan` (selected-artist bulk): Wikipedia -> YouTube only, no metadata fallback at all
- `artists_thumbnails.py`'s `scan_missing_thumbnails` (scan-all): an unauthenticated Google Images HTML scrape -> Wikipedia -> YouTube

All three now share one function and one priority order: **Spotify, Last.fm, cached IMVDb-sourced metadata images, Wikipedia, YouTube.**

### Notes on source capabilities (checked before assuming)

- **MusicBrainz is deliberately NOT a source.** Read `musicbrainz_service.py`'s real methods first — its API provides metadata and cross-service links (genres, relations, release dates), not artist photography. There is no MusicBrainz-hosted artist image to fetch.
- **Last.fm**'s `artist.getInfo` image field has, for years, mostly returned a fixed set of gray placeholder images rather than real photos — filtered by the same placeholder-URL check as every other source here, so this rarely produces real results in practice. **Spotify** is the more reliable of the two real live sources added.
- The **Google Images scrape** dropped from `scan_missing_thumbnails` was already effectively abandoned: the frontend's own search UI (`artist_detail.html`) stopped calling its equivalent, returning an empty result on purpose "since this is just for development." Scraping Google's HTML search results is also fragile and against its ToS. Not carried forward.

### Also consolidated / fixed along the way

- Three divergent copies of placeholder-URL detection (`ThumbnailService`, a module-level function in `artists_thumbnails.py`, and an inline closure a few hundred lines below it in the same file — the closure was missing two Last.fm placeholder-hash patterns the other two copies had) down to one: `ThumbnailService.is_placeholder_url` (made public; was `_is_placeholder_url`).
- `ThumbnailSearchRequest.source` allowed `"imvdb"` as a valid value, but no handler branch ever matched it — silently always returned zero results. Replaced with the sources actually implemented: `auto|spotify|lastfm|metadata|wikipedia|youtube`.

## Test plan

- [x] New `tests/unit/test_artist_thumbnail_search_service.py` — 8 cases: priority order (Spotify before Wikipedia), unconfigured sources silently skipped, one source failing doesn't block the others, single-source filtering, `stop_at_first_result` short-circuiting, placeholder filtering (the exact live Last.fm placeholder hash), and the cached-metadata fallback (present/absent artist row)
- [x] Verified RED (module didn't exist) before implementing
- [x] Full `tests/unit/` suite: 151 passed, no regressions
- [x] Verified real import resolution inside the app (not just `ast.parse`) and a live end-to-end cascade call inside the running dev container against a real artist name, confirming graceful fallthrough when Spotify is disabled
- [x] Deployed live to the dev container, health check green, no errors in `fastapi_error.log` after restart

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>