### PR TITLE
fix(thumbnails): Wikipedia thumbnail URLs rewritten to an invalid width, breaking every download

### DIFF
--- a/src/services/wikipedia_service.py
+++ b/src/services/wikipedia_service.py
@@ -146,7 +146,11 @@ class WikipediaService:
                 "format": "json",
                 "titles": page_title,
                 "prop": "pageimages|pageimagesthumbnails",
-                "pithumbsize": 500,  # Request 500px thumbnail
+                # Ask the API for the size directly -- it rounds this to
+                # a width it can actually generate for the specific
+                # source image (see _enhance_thumbnail_url's removal
+                # below for why that matters).
+                "pithumbsize": 800,
                 "pilimit": 1,
             }
 
@@ -160,10 +164,18 @@ class WikipediaService:
 
                 for page_id, page_data in pages.items():
                     if "thumbnail" in page_data:
-                        thumbnail_url = page_data["thumbnail"]["source"]
-                        # Prefer larger images by modifying the URL
-                        thumbnail_url = self._enhance_thumbnail_url(thumbnail_url)
-                        return thumbnail_url
+                        # Return the URL exactly as Wikipedia's API
+                        # provided it. A previous version rewrote the
+                        # width segment to a hardcoded "/800px-" via
+                        # regex -- Wikimedia's thumb-serving proxy only
+                        # supports a fixed set of widths per image, and
+                        # rejects ones it never generated with HTTP 400
+                        # ("Use thumbnail sizes listed on..."). This
+                        # silently broke every Wikipedia-sourced
+                        # thumbnail download (#320 follow-up, live
+                        # incident 2026-08-13) even though the search
+                        # step reported success.
+                        return page_data["thumbnail"]["source"]
                     elif "pageimage" in page_data:
                         # Try to construct image URL from pageimage
                         image_title = page_data["pageimage"]
@@ -290,25 +302,6 @@ class WikipediaService:
                     return True
 
         return False
-
-    def _enhance_thumbnail_url(self, thumbnail_url):
-        """
-        Enhance thumbnail URL to get better quality image
-
-        Args:
-            thumbnail_url (str): Original thumbnail URL
-
-        Returns:
-            str: Enhanced thumbnail URL
-        """
-        # Try to increase image size by modifying URL parameters
-        if "thumb" in thumbnail_url and "/thumb/" in thumbnail_url:
-            # Try to get a larger version
-            enhanced_url = re.sub(r"/(\d+)px-", "/800px-", thumbnail_url)
-            if enhanced_url != thumbnail_url:
-                return enhanced_url
-
-        return thumbnail_url
 
 
 # Global service instance

--- a/tests/unit/test_wikipedia_thumbnail_url.py
+++ b/tests/unit/test_wikipedia_thumbnail_url.py
@@ -1,0 +1,96 @@
+"""Regression test for a live bug (2026-08-13): Wikipedia-sourced artist
+thumbnails were found by search but always failed to download, silently
+making #320's bulk/scan thumbnail features look like they found nothing.
+
+Root cause: _enhance_thumbnail_url() rewrote every thumbnail URL's width
+segment to a hardcoded "/800px-" via regex, regardless of whether
+Wikimedia's thumb-serving proxy actually supports that width for the
+specific source image. Wikimedia only serves a fixed set of valid widths
+per image (confirmed live: requesting the real API-computed width, e.g.
+960px, downloads fine with HTTP 200; the hardcoded 800px substitution
+gets HTTP 400 "Use thumbnail sizes listed on...").
+
+The correct way to request a larger thumbnail is via the API's own
+pithumbsize parameter, which Wikipedia itself rounds to a size it can
+actually generate — not by string-hacking the returned CDN URL
+afterward.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.services.wikipedia_service import WikipediaService
+
+
+class TestPageThumbnailDoesNotForceAnInvalidWidth:
+    def test_returns_the_api_provided_url_unmodified(self):
+        """The API-computed URL (whatever width Wikipedia decided to
+        generate) must be returned as-is -- not string-hacked into a
+        width Wikipedia never offered for this image."""
+        service = WikipediaService()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "query": {
+                "pages": {
+                    "123": {
+                        "thumbnail": {
+                            "source": (
+                                "https://upload.wikimedia.org/wikipedia/commons/thumb/"
+                                "d/d8/Linkin_Park.jpg/960px-Linkin_Park.jpg"
+                                "?utm_source=en.wikipedia.org&utm_campaign=api&utm_content=thumbnail"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.session, "get", return_value=mock_response):
+            url = service._get_page_thumbnail("Linkin Park")
+
+        assert "/960px-" in url
+        assert "/800px-" not in url
+
+    def test_requests_the_desired_size_via_the_api_parameter_not_url_rewriting(self):
+        service = WikipediaService()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"query": {"pages": {}}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            service.session, "get", return_value=mock_response
+        ) as mock_get:
+            service._get_page_thumbnail("Linkin Park")
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["pithumbsize"] >= 500
+
+    def test_a_500px_source_url_is_also_returned_unmodified(self):
+        """A smaller image than the requested pithumbsize is a normal,
+        valid Wikipedia response (not every image has a large source) --
+        must not be rewritten either."""
+        service = WikipediaService()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "query": {
+                "pages": {
+                    "123": {
+                        "thumbnail": {
+                            "source": (
+                                "https://upload.wikimedia.org/wikipedia/commons/thumb/"
+                                "a/b/Some_Band.jpg/500px-Some_Band.jpg"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.session, "get", return_value=mock_response):
+            url = service._get_page_thumbnail("Some Band")
+
+        assert "/500px-" in url


### PR DESCRIPTION
Live incident 2026-08-13, reported right after #320/#355 shipped: "no results from the general thumbnail search from the artists page or the individual artist's page." The search step was actually succeeding — the download step that follows it was silently failing for every Wikipedia-sourced result, which made the whole feature look broken.

## Root cause

`_enhance_thumbnail_url()` rewrote every thumbnail URL's width segment to a hardcoded `/800px-` via regex, regardless of whether Wikimedia's thumb-serving proxy actually supports that width for the specific source image. Confirmed live against a real failing case (Linkin Park): requesting the URL Wikipedia's own API computed (960px, via `pithumbsize`) downloads fine (HTTP 200); the hardcoded 800px substitution gets HTTP 400 ("Use thumbnail sizes listed on https://w.wiki/GHai") — Wikimedia only serves a fixed set of widths per image, and rejects ones it never generated.

## Fix

Request the desired size the correct way: via the API's own `pithumbsize` parameter (which Wikipedia itself rounds to a width it can actually generate), and return the API-provided URL exactly as given instead of string-hacking it afterward. Removed `_enhance_thumbnail_url` entirely — its only caller is gone and its premise (any numeric width is valid for any image) was the bug.

## Test plan

- [x] New `tests/unit/test_wikipedia_thumbnail_url.py` — 3 cases: the API-provided URL is returned unmodified (not rewritten to `/800px-`), `pithumbsize` is set correctly in the outgoing request, and a smaller (500px) API-provided URL is also left unmodified
- [x] Verified RED against pre-fix code (2 of 3 failed, exactly reproducing the `/800px-` rewrite)
- [x] Full `tests/unit/` suite: 154 passed, no regressions
- [x] Deployed live to the dev container; verified end-to-end against the exact two artists reported (Creedence Clearwater Revival, Linkin Park) — both now search AND download successfully, confirmed via direct `download_artist_thumbnail` calls returning real file paths instead of `None`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>