### PR TITLE
feat(videos): Recently Found one-click view (#316)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,17 +214,20 @@ curl -X POST http://localhost:5001/api/videos/123/extract-ffmpeg-metadata
 
 ## Development Workflow
 
-### Current Phase: v0.12.18 - Released
+### Current Phase: v0.12.19 - Released
 
-#### Versioning Policy (Updated 2026-07-05)
-- **Current Version**: 0.12.18 (Released 2026-07-05)
-- **Next Version**: 0.12.19 (Planning)
+#### Versioning Policy (Updated 2026-08-13)
+- **Current Version**: 0.12.19 (Released 2026-08-13)
+- **Next Version**: 0.12.20 (Planning)
 - **Versioning Standard**: SemVer 2.0.0
 - **Version Scheme**:
   - **0.x.y**: Pre-production development (current phase)
   - **1.0.0**: First production-ready release (future)
 
 #### Version History (Recent)
+- **v0.12.19** (2026-08-13): Recently Found Videos View
+  - ✅ Feature: "Recently Found" one-click view on Videos page (#316) — shows all videos sorted by date_added desc, regardless of status, via a new button + shareable deep-link URL (`?sort_by=date_added&sort_order=desc&status=`)
+  - ✅ Re-scoped from an "upcoming release calendar" after confirming no integrated data source (IMVDb, MusicBrainz, YouTube, Spotify, Last.fm) exposes reliable future release dates
 - **v0.12.18** (2026-07-05): Dependency Sweep (Dependabot PRs #269-274)
   - ✅ Dependency: fastapi 0.138.1 → 0.139.0, Pillow 12.2.0 → 12.3.0, opencv-python-headless >=4.13.0.92 → >=5.0.0.93
   - ✅ Dependency: click 8.1.7 → 8.4.2, tqdm 4.66.3 → 4.68.3
@@ -476,9 +479,9 @@ youtube_download_engine.download_video(quality=format_string)
 - **Primary Development**: All changes must be pushed to the `dev` branch
 - **Main Branch**: Changes can only be made to `main` after approval on `dev`
 - **Feature Branches**: Create feature branches from `dev`, merge back to `dev`
-- **Current Version**: v0.12.18 (Dependency Sweep — Dependabot PRs #269-274)
+- **Current Version**: v0.12.19 (Recently Found Videos View — #316)
 - **Development Focus**: Stability, security
-- **Next Version**: v0.12.19
+- **Next Version**: v0.12.20
 
 ### Code Development Process
 1. Create feature branch from `dev` branch

--- a/frontend/templates/videos.html
+++ b/frontend/templates/videos.html
@@ -4651,7 +4651,24 @@ function refreshVideoList() {
 // Initialize videos when page loads
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Videos page loaded, initializing...');
-    loadVideos();
+
+    // Deep-link support for the "Recently Found" view (#316) and any
+    // future URL that carries these three params. loadVideos() below
+    // ignores the filter dropdowns entirely (it fetches /api/videos
+    // with its own hardcoded sort/order), so a deep link must route
+    // through applyVideoFilters() instead, which does read them.
+    const deepLinkParams = new URLSearchParams(window.location.search);
+    const deepLinkSortBy = deepLinkParams.get('sort_by');
+    const deepLinkSortOrder = deepLinkParams.get('sort_order');
+
+    if (deepLinkSortBy && deepLinkSortOrder) {
+        document.getElementById('videoStatusFilter').value = deepLinkParams.get('status') || '';
+        document.getElementById('videoSortBy').value = deepLinkSortBy;
+        document.getElementById('videoSortOrder').value = deepLinkSortOrder;
+        applyVideoFilters();
+    } else {
+        loadVideos();
+    }
 });
 
 // Event delegation for video actions

--- a/frontend/templates/videos.html
+++ b/frontend/templates/videos.html
@@ -40,6 +40,10 @@
                     <iconify-icon icon="tabler:database-refresh" aria-hidden="true"></iconify-icon>
                     Enhanced Metadata
                 </button>
+                <button onclick="showRecentlyFound()" class="btn btn-secondary btn-sm" title="Show recently found videos, newest first" aria-label="Show recently found videos, newest first">
+                    <iconify-icon icon="tabler:clock" aria-hidden="true"></iconify-icon>
+                    Recently Found
+                </button>
             </div>
             
             <!-- Selection Controls -->

--- a/frontend/templates/videos.html
+++ b/frontend/templates/videos.html
@@ -211,6 +211,7 @@
             
             <div class="filter-actions" role="toolbar" aria-label="Filter actions">
                 <button onclick="clearAllVideoFilters()" class="btn btn-secondary" aria-label="Clear all active filters">Clear All</button>
+                <button onclick="showRecentlyFound()" class="btn btn-secondary" aria-label="Show recently found videos, newest first">Recently Found</button>
                 <button onclick="saveVideoSearchPreset()" class="btn btn-secondary" aria-label="Save current search as preset">Save Preset</button>
                 <button onclick="exportVideoSearchResults()" class="btn btn-info" aria-label="Export search results to file">Export Results</button>
             </div>
@@ -672,6 +673,19 @@ function clearAllVideoFilters() {
     searchActive = false;
     loadVideos();
     updateVideoFilterCount();
+}
+
+function showRecentlyFound() {
+    // One-click "what's new" view (#316). Re-scoped from an "upcoming
+    // release calendar" -- no integrated data source (IMVDb,
+    // MusicBrainz, YouTube, Spotify, Last.fm) exposes a reliable future
+    // release-date signal, so this surfaces what MVidarr has already
+    // discovered instead, sorted by date_added, newest first.
+    document.getElementById('videoStatusFilter').value = '';
+    document.getElementById('videoSortBy').value = 'date_added';
+    document.getElementById('videoSortOrder').value = 'desc';
+    history.pushState({}, '', '/videos?sort_by=date_added&sort_order=desc&status=');
+    applyVideoFilters();
 }
 
 function updateVideoFilterCount() {

--- a/tests/unit/test_recently_found_videos_ui.py
+++ b/tests/unit/test_recently_found_videos_ui.py
@@ -30,6 +30,16 @@ class TestRecentlyFoundButton:
         actions_bar = self.html[start:end]
         assert 'onclick="showRecentlyFound()"' in actions_bar
 
+    def test_always_visible_button_is_in_the_secondary_actions_bar(self):
+        # There are now two onclick="showRecentlyFound()" buttons: the
+        # original inside the (collapsed-by-default) filter panel, and this
+        # always-visible one in the secondary-actions bar, which requires no
+        # panel to be expanded to reach.
+        start = self.html.index('class="secondary-actions"')
+        end = self.html.index("</div>", start)
+        actions_bar = self.html[start:end]
+        assert 'onclick="showRecentlyFound()"' in actions_bar
+
     def test_show_recently_found_function_exists(self):
         assert "function showRecentlyFound()" in self.html
 

--- a/tests/unit/test_recently_found_videos_ui.py
+++ b/tests/unit/test_recently_found_videos_ui.py
@@ -1,0 +1,55 @@
+"""Regression/feature test for #316: 'Recently Found' one-click view on
+the Videos page (re-scoped from an 'upcoming release calendar' — no
+integrated data source exposes reliable future release dates; see
+docs/superpowers/specs/2026-08-13-recently-found-videos-design.md).
+
+Static-content-assertion approach, matching the pattern already
+established for this page's other template regression tests (e.g.
+test_oauth_settings_ui.py): confirms the button exists and wires to
+showRecentlyFound(), that showRecentlyFound() sets the three expected
+filter values and calls applyVideoFilters(), and that the page's load
+sequence reads sort_by/sort_order/status from the URL before the first
+render so the pushed URL is a real, reproducible deep link.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestRecentlyFoundButton:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "videos.html").read_text()
+
+    def test_button_exists_and_calls_show_recently_found(self):
+        assert 'onclick="showRecentlyFound()"' in self.html
+
+    def test_button_is_in_the_filter_actions_bar(self):
+        start = self.html.index('class="filter-actions"')
+        end = self.html.index("</div>", start)
+        actions_bar = self.html[start:end]
+        assert 'onclick="showRecentlyFound()"' in actions_bar
+
+    def test_show_recently_found_function_exists(self):
+        assert "function showRecentlyFound()" in self.html
+
+    def test_show_recently_found_sets_expected_filter_values(self):
+        start = self.html.index("function showRecentlyFound()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "getElementById('videoStatusFilter').value = ''" in body
+        assert "getElementById('videoSortBy').value = 'date_added'" in body
+        assert "getElementById('videoSortOrder').value = 'desc'" in body
+
+    def test_show_recently_found_pushes_a_shareable_url(self):
+        start = self.html.index("function showRecentlyFound()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "history.pushState(" in body
+        assert "/videos?sort_by=date_added&sort_order=desc&status=" in body
+
+    def test_show_recently_found_calls_apply_video_filters(self):
+        start = self.html.index("function showRecentlyFound()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "applyVideoFilters()" in body

--- a/tests/unit/test_recently_found_videos_ui.py
+++ b/tests/unit/test_recently_found_videos_ui.py
@@ -53,3 +53,24 @@ class TestRecentlyFoundButton:
         end = self.html.index("\n}", start)
         body = self.html[start:end]
         assert "applyVideoFilters()" in body
+
+    def test_page_load_reads_deep_link_params_before_first_render(self):
+        # Anchor on the unique comment immediately preceding the videos-init
+        # listener, not the listener's opening line alone -- the file has a
+        # second, unrelated `document.addEventListener('DOMContentLoaded', ...)`
+        # listener (search presets UI) earlier in the file with byte-identical
+        # opening text, which `.index()` would match first.
+        marker = self.html.index("// Initialize videos when page loads")
+        start = self.html.index(
+            "document.addEventListener('DOMContentLoaded', function() {", marker
+        )
+        end = self.html.index("});", start)
+        init_block = self.html[start:end]
+        assert "URLSearchParams(window.location.search)" in init_block
+        assert "get('sort_by')" in init_block
+        assert "get('sort_order')" in init_block
+        assert "applyVideoFilters()" in init_block, (
+            "deep-linked sort_by/sort_order must route through "
+            "applyVideoFilters(), not the unrelated loadVideos() call, "
+            "since loadVideos() ignores the filter dropdowns entirely"
+        )


### PR DESCRIPTION
## Summary

Adds a one-click "Recently Found" view to the Videos page, per #316 — re-scoped during design from an "upcoming release calendar" after confirming no integrated data source (IMVDb, MusicBrainz, YouTube, Spotify, Last.fm) exposes reliable future release dates. See `docs/superpowers/specs/2026-08-13-recently-found-videos-design.md` (not committed — `docs/superpowers/` is gitignored, matching prior session convention).

- Always-visible **"Recently Found"** button in the secondary action bar (Refresh/Thumbnails/Enhanced Metadata), plus the originally-planned button inside the filter panel.
- `showRecentlyFound()`: sets status/sort filters, pushes a shareable URL (`/videos?sort_by=date_added&sort_order=desc&status=`), calls the existing `applyVideoFilters()`.
- Page load now reads `sort_by`/`sort_order`/`status` from the URL and, when present, routes through `applyVideoFilters()` instead of the default `loadVideos()` — which ignores the filter dropdowns entirely — making the pushed URL a real, reproducible deep link. Default (no params) behavior is byte-for-byte unchanged.
- No backend/API/route/nav changes.

## Process

Built via `superpowers:subagent-driven-development` — 2 plan tasks (each with fresh implementer + task-scoped spec/quality review), then a final whole-branch review on Opus that caught the button being buried 2 collapsed panels deep (defeating the design's "one click" goal) and a missing CLAUDE.md entry. Both fixed in one follow-up commit, re-reviewed clean.

A pre-existing, unrelated bug found during final review — Videos-page pagination (Next/Prev) silently drops active filters/sort — was **not** fixed here (out of scope, affects the whole page). Filed as #357.

## Testing

- New: `tests/unit/test_recently_found_videos_ui.py` (8 static-content tests, matching the established `test_oauth_settings_ui.py` pattern)
- Full suite: 162 passed (4 pre-existing, unrelated files excluded — missing `yt-dlp` binary in the test venv, confirmed pre-existing via `git stash`)
- Manually deployed to the `mvidarr-dev` container and confirmed both buttons render with the correct handlers; both new/changed JS blocks pass `node --check`

## Docs

- `CLAUDE.md` updated with a `v0.12.19` version-history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)