### PR TITLE
fix(settings): move OAuth signup allowlist into its own section (#366)

### DIFF
--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -327,12 +327,6 @@ input:checked + .slider:before {
                 <small>Let users sign in via Authentik, Google, or GitHub instead of (or in addition to) a password. Leave a provider's fields blank to keep it disabled. Client secret fields are never pre-filled for security — leave one blank on save to keep the previously-saved value.</small>
             </div>
 
-            <div class="form-group">
-                <label for="oauth_allowed_emails">New Account Signup Allowlist:</label>
-                <input type="text" id="oauth_allowed_emails" name="oauth_allowed_emails" placeholder="you@example.com, @yourcompany.com">
-                <small>Comma separated. Each entry is either an exact email address, or <code>@domain.com</code> to allow anyone at that domain. This only gates <strong>new</strong> accounts — anyone who already has a MVidarr account can still sign in via OAuth regardless of this list. Leave empty to block all new OAuth signups (existing accounts are unaffected).</small>
-            </div>
-
             <h3>Authentik</h3>
             <div class="form-group">
                 <label for="oauth_authentik_base_url">Base URL:</label>
@@ -383,6 +377,15 @@ input:checked + .slider:before {
                 <label for="oauth_github_redirect_uri">Redirect URI:</label>
                 <input type="text" id="oauth_github_redirect_uri" name="oauth_github_redirect_uri" class="oauth-redirect-uri-input" data-provider="github">
                 <small>Typically <code class="oauth-redirect-uri-hint" data-provider="github">{origin}/api/auth/oauth/github/callback</code> — register this exact URL with the provider.</small>
+            </div>
+        </div>
+
+        <div class="settings-section" id="oauthAllowlistSection">
+            <h2>✅ OAuth New Account Signup Allowlist</h2>
+            <div class="form-group">
+                <label for="oauth_allowed_emails">New Account Signup Allowlist:</label>
+                <input type="text" id="oauth_allowed_emails" name="oauth_allowed_emails" placeholder="you@example.com, @yourcompany.com">
+                <small>Comma separated. Each entry is either an exact email address, or <code>@domain.com</code> to allow anyone at that domain. This only gates <strong>new</strong> accounts — anyone who already has a MVidarr account can still sign in via OAuth regardless of this list. Leave empty to block all new OAuth signups (existing accounts are unaffected).</small>
             </div>
         </div>
 

--- a/tests/unit/test_oauth_allowlist_own_section.py
+++ b/tests/unit/test_oauth_allowlist_own_section.py
@@ -1,0 +1,55 @@
+"""Regression test for #366: the OAuth new-account signup allowlist field
+used to live inside #oauthProvidersSection, mixed in with the per-provider
+(Authentik/Google/GitHub) config fields -- two distinct concerns (which
+providers are enabled vs. who's allowed to sign up through them) sharing
+one settings-section frame.
+
+This confirms the allowlist now has its own settings-section, positioned
+after (not inside) #oauthProvidersSection.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestOAuthAllowlistOwnSection:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_allowlist_field_is_outside_the_oauth_providers_section(self):
+        providers_start = self.html.index('id="oauthProvidersSection"')
+        providers_section_start = self.html.rindex("<div", 0, providers_start)
+        # Find this section's closing </div> by matching the next sibling
+        # settings-section opening tag, same convention as the rest of
+        # this file's flat (non-nested) settings-section blocks.
+        next_section = self.html.index(
+            'class="settings-section"', providers_section_start + 10
+        )
+        providers_section_html = self.html[providers_section_start:next_section]
+
+        assert 'name="oauth_allowed_emails"' not in providers_section_html, (
+            "the allowlist field must not be inside #oauthProvidersSection "
+            "-- it belongs in its own section"
+        )
+
+    def test_allowlist_has_its_own_settings_section_immediately_after(self):
+        providers_start = self.html.index('id="oauthProvidersSection"')
+        next_section = self.html.index(
+            'class="settings-section"', providers_start
+        )
+        allowlist_section_end = self.html.index(
+            'class="settings-section"', next_section + 10
+        )
+        allowlist_section_html = self.html[next_section:allowlist_section_end]
+
+        assert 'name="oauth_allowed_emails"' in allowlist_section_html
+
+    def test_allowlist_field_still_a_real_input(self):
+        # Matches test_oauth_allowlist_ui.py's existing check -- settings.html's
+        # generic save collector is querySelectorAll('input, select'), so a
+        # <textarea> would silently never be saved.
+        start = self.html.index('name="oauth_allowed_emails"')
+        tag_start = self.html.rindex("<", 0, start)
+        tag = self.html[tag_start : start + 40]
+        assert tag.startswith("<input")


### PR DESCRIPTION
## Summary

Splits the "New Account Signup Allowlist" field out of `#oauthProvidersSection` into its own `#oauthAllowlistSection`, positioned right after the OAuth Login Providers section — two distinct concerns (which providers are enabled/configured vs. who's allowed to sign up through them) no longer share one settings-section frame.

Pure markup relocation — `oauth_allowed_emails`'s id/name, the backend save-path (`settings.py`'s bulk-update handling), and all JS behavior are unchanged.

## Testing

New `tests/unit/test_oauth_allowlist_own_section.py` (3 tests) confirms the field is outside `#oauthProvidersSection` and has its own section immediately after. Full suite: 178 passed. Deployed to `mvidarr-dev` and confirmed the new section renders correctly.

Closes #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)