### PR TITLE
fix(videos): pagination controls no longer drop active filters (#357)

### DIFF
--- a/frontend/templates/videos.html
+++ b/frontend/templates/videos.html
@@ -531,9 +531,18 @@ function debounceVideoFilters() {
 }
 
 // Video filtering functions - previously missing
-function applyVideoFilters() {
+function applyVideoFilters(page = 1, resetPage = true) {
     console.log('Applying video filters...');
-    
+
+    // Marks that a filtered/search view is active, so the pagination
+    // controls below route back through here (with limit/offset) instead
+    // of falling through to loadVideos() -- which fetches /api/videos
+    // with its own hardcoded sort/no filters and would otherwise silently
+    // discard every filter here on Next/Prev/goToPage/page-size-change
+    // (#357).
+    searchActive = true;
+    currentPage = resetPage ? 1 : page;
+
     // Get all filter values
     const filters = {
         q: document.getElementById('videoSearchInput').value,  // Add the main search query
@@ -553,17 +562,22 @@ function applyVideoFilters() {
         sort_by: document.getElementById('videoSortBy').value,
         sort_order: document.getElementById('videoSortOrder').value
     };
-    
+
     // Build query parameters
     const params = new URLSearchParams();
-    
+
     // Add non-empty filters
     for (const [key, value] of Object.entries(filters)) {
         if (value && value.trim() !== '') {
             params.append(key, value);
         }
     }
-    
+
+    // Pagination -- without these, every page past the first silently
+    // dropped back to the unfiltered default (#357).
+    params.append('limit', pageSize);
+    params.append('offset', (currentPage - 1) * pageSize);
+
     // Make API call to search/filter videos
     // Add cache busting to ensure fresh data
     params.append('_t', Date.now());
@@ -4336,7 +4350,15 @@ window.addEventListener('click', function(event) {
 
 function nextPage() {
     if (currentPage < totalPages) {
-        loadVideos(currentPage + 1, pageSize);
+        // A filtered/search view (#357) must page through
+        // applyVideoFilters(), not loadVideos() -- the latter ignores
+        // every active filter and re-fetches an unfiltered, title-sorted
+        // page instead.
+        if (searchActive) {
+            applyVideoFilters(currentPage + 1, false);
+        } else {
+            loadVideos(currentPage + 1, pageSize);
+        }
         // Scroll to top
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }
@@ -4344,7 +4366,11 @@ function nextPage() {
 
 function previousPage() {
     if (currentPage > 1) {
-        loadVideos(currentPage - 1, pageSize);
+        if (searchActive) {
+            applyVideoFilters(currentPage - 1, false);
+        } else {
+            loadVideos(currentPage - 1, pageSize);
+        }
         // Scroll to top
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }
@@ -4353,7 +4379,11 @@ function previousPage() {
 function goToPage(page) {
     const pageNum = parseInt(page);
     if (pageNum >= 1 && pageNum <= totalPages && pageNum !== currentPage) {
-        loadVideos(pageNum, pageSize);
+        if (searchActive) {
+            applyVideoFilters(pageNum, false);
+        } else {
+            loadVideos(pageNum, pageSize);
+        }
         // Scroll to top
         window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
@@ -4368,7 +4398,11 @@ function changePageSize(newSize) {
     if (size !== pageSize) {
         pageSize = size;
         // Reset to page 1 when changing page size
-        loadVideos(1, pageSize, true);
+        if (searchActive) {
+            applyVideoFilters(1, true);
+        } else {
+            loadVideos(1, pageSize, true);
+        }
         // Scroll to top
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }

--- a/tests/unit/test_videos_pagination_respects_filters.py
+++ b/tests/unit/test_videos_pagination_respects_filters.py
@@ -1,0 +1,86 @@
+"""Regression test for #357: Videos page pagination (Next/Prev/goToPage/
+page-size) silently dropped any active filter or sort, because those
+controls all called loadVideos(...) -- a completely separate fetch to
+/api/videos with hardcoded sort:'title', order:'asc' and no filter
+params at all -- instead of the filter-aware applyVideoFilters(), which
+fetches /api/videos/search with the real filter state but never sent
+limit/offset in the first place.
+
+Result: apply any filter (e.g. #316's "Recently Found" button) and click
+Next, and you silently land on an unfiltered, alphabetically-sorted
+page 2.
+
+Fix: applyVideoFilters() now accepts (page, resetPage), sends limit/
+offset derived from currentPage/pageSize, and sets the previously-dead
+`searchActive` flag (declared but never read before this fix -- only
+ever set to false in clearAllVideoFilters()). The four pagination
+control functions now check searchActive and route through
+applyVideoFilters() instead of loadVideos() whenever a filtered view is
+active.
+
+Matches the static-content-assertion approach already established this
+session for template changes.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestVideosPaginationRespectsFilters:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "videos.html").read_text()
+
+    def _function_body(self, signature_prefix):
+        start = self.html.index(signature_prefix)
+        end = self.html.index("\n}", start)
+        return self.html[start:end]
+
+    def test_apply_video_filters_marks_search_active(self):
+        body = self._function_body("function applyVideoFilters(")
+        assert "searchActive = true" in body
+
+    def test_apply_video_filters_sends_limit_and_offset(self):
+        body = self._function_body("function applyVideoFilters(")
+        assert "params.append('limit'" in body or 'params.append("limit"' in body
+        assert "params.append('offset'" in body or 'params.append("offset"' in body
+
+    def test_apply_video_filters_accepts_a_page_argument(self):
+        # Pagination controls need to request a specific page without
+        # resetting back to page 1.
+        assert (
+            "function applyVideoFilters(page = 1, resetPage = true)" in self.html
+        )
+
+    def test_next_page_routes_through_apply_video_filters_when_search_active(self):
+        body = self._function_body("function nextPage(")
+        assert "searchActive" in body
+        assert "applyVideoFilters(" in body
+        assert "loadVideos(" in body  # still the fallback for the unfiltered case
+
+    def test_previous_page_routes_through_apply_video_filters_when_search_active(self):
+        body = self._function_body("function previousPage(")
+        assert "searchActive" in body
+        assert "applyVideoFilters(" in body
+        assert "loadVideos(" in body
+
+    def test_go_to_page_routes_through_apply_video_filters_when_search_active(self):
+        body = self._function_body("function goToPage(")
+        assert "searchActive" in body
+        assert "applyVideoFilters(" in body
+        assert "loadVideos(" in body
+
+    def test_change_page_size_routes_through_apply_video_filters_when_search_active(
+        self,
+    ):
+        body = self._function_body("function changePageSize(")
+        assert "searchActive" in body
+        assert "applyVideoFilters(" in body
+        assert "loadVideos(" in body
+
+    def test_clear_all_filters_still_sets_search_active_false(self):
+        # Pre-existing behavior (the only prior write to searchActive) --
+        # must survive this fix so a cleared filter set correctly falls
+        # back to plain loadVideos()-driven pagination again.
+        body = self._function_body("function clearAllVideoFilters(")
+        assert "searchActive = false" in body


### PR DESCRIPTION
## Summary

`nextPage()`/`previousPage()`/`goToPage()`/`changePageSize()` all called `loadVideos(...)` unconditionally — a fetch to `/api/videos` with hardcoded `sort:'title', order:'asc'` and zero filter params, completely separate from `applyVideoFilters()`'s fetch to `/api/videos/search`. Any active filter/sort/search (including #316's "Recently Found" deep link) was silently dropped the moment Next/Prev/goToPage/page-size was used — you'd land on an unfiltered, alphabetically-sorted page 2 with no indication anything changed.

Root cause of the missing plumbing: `searchActive` was declared and written (only ever set to `false`, in `clearAllVideoFilters()`) but never actually *read* anywhere — dead state that looks like it was meant to gate exactly this behavior and never got wired up.

## Fix

- `applyVideoFilters(page = 1, resetPage = true)` now accepts a page argument, sends `limit`/`offset` derived from `currentPage`/`pageSize` (previously never sent at all), and sets `searchActive = true`.
- The four pagination control functions now check `searchActive` and route through `applyVideoFilters()` instead of `loadVideos()` whenever a filtered view is active, falling back to the prior `loadVideos()`-driven behavior otherwise (unfiltered default view is untouched).
- No backend changes — `/api/videos/search` already accepts `limit`/`offset` and returns `pagination.total`, matching what `updatePagination()` already expects.
- Every pre-existing call site of `applyVideoFilters()` (13 `onchange` handlers, `showRecentlyFound()`, the #316 deep-link init) calls it with no arguments, so the new defaults (`page=1, resetPage=true`) preserve their exact prior behavior.

## Testing

New `tests/unit/test_videos_pagination_respects_filters.py` (8 tests). Full suite: 186 passed, including the #316 regression tests (confirming no interaction breakage between the two features). Deployed to `mvidarr-dev` and confirmed the deployed file matches source exactly.

Closes #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)