### PR TITLE
feat(webhooks): native Discord and Apprise notification providers (#315)

### DIFF
--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -198,6 +198,13 @@ input:checked + .slider:before {
                         <span>Blacklist</span>
                     </button>
                 </li>
+                <li>
+                    <button class="settings-tab-btn" onclick="window.location.href='/webhooks'"
+                            aria-label="Go to the Webhooks and Notifications page">
+                        <iconify-icon icon="tabler:bell" class="tab-icon" aria-hidden="true"></iconify-icon>
+                        <span>Webhooks &amp; Notifications</span>
+                    </button>
+                </li>
             </ul>
 
             <!-- Advanced Mode Toggle -->

--- a/frontend/templates/webhooks.html
+++ b/frontend/templates/webhooks.html
@@ -742,12 +742,14 @@ function loadStats() {
 function showAddWebhookForm() {
     document.getElementById('formTitle').textContent = 'Add New Webhook';
     document.getElementById('webhookForm').style.display = 'block';
+    updateWebhookFormForProviderType();
     document.getElementById('webhookUrl').focus();
 }
 
 function hideWebhookForm() {
     document.getElementById('webhookForm').style.display = 'none';
     document.getElementById('webhookConfigForm').reset();
+    updateWebhookFormForProviderType();
     document.getElementById('validationErrors').style.display = 'none';
 }
 

--- a/frontend/templates/webhooks.html
+++ b/frontend/templates/webhooks.html
@@ -487,12 +487,25 @@
     <div id="webhookForm" class="form-section" style="display: none;">
         <h3 id="formTitle">Add New Webhook</h3>
         <form id="webhookConfigForm">
+            <div class="form-group">
+                <label for="webhookProviderType">Type</label>
+                <select id="webhookProviderType" onchange="updateWebhookFormForProviderType()">
+                    <option value="generic">Generic (custom HTTP webhook)</option>
+                    <option value="discord">Discord</option>
+                    <option value="apprise">Apprise</option>
+                </select>
+            </div>
+
             <div class="form-grid">
                 <div class="form-group">
-                    <label for="webhookUrl">Webhook URL *</label>
+                    <label for="webhookUrl" id="webhookUrlLabel">Webhook URL *</label>
                     <input type="url" id="webhookUrl" required placeholder="https://example.com/webhook">
+                    <small id="webhookUrlHint" style="display: none;">
+                        Apprise URL string, e.g. <code>tgram://bottoken/ChatID</code> --
+                        see <a href="https://github.com/caronc/apprise#popular-notification-services" target="_blank" rel="noopener">Apprise's supported services</a>.
+                    </small>
                 </div>
-                <div class="form-group">
+                <div class="form-group" id="webhookSecretGroup">
                     <label for="webhookSecret">Secret (optional)</label>
                     <input type="password" id="webhookSecret" placeholder="Secret for signature verification">
                 </div>
@@ -523,7 +536,7 @@
                 </div>
             </div>
             
-            <div class="form-group">
+            <div class="form-group" id="customHeadersGroup">
                 <label for="customHeaders">Custom Headers (JSON format)</label>
                 <textarea id="customHeaders" placeholder='{"Authorization": "Bearer token", "X-Custom-Header": "value"}'></textarea>
             </div>
@@ -773,10 +786,44 @@ function validateWebhook() {
     });
 }
 
+function updateWebhookFormForProviderType() {
+    const providerType = document.getElementById('webhookProviderType').value;
+    const urlInput = document.getElementById('webhookUrl');
+    const urlLabel = document.getElementById('webhookUrlLabel');
+    const urlHint = document.getElementById('webhookUrlHint');
+    const secretGroup = document.getElementById('webhookSecretGroup');
+    const customHeadersGroup = document.getElementById('customHeadersGroup');
+
+    if (providerType === 'apprise') {
+        // Apprise URLs (tgram://..., discord://webhook_id/token, etc.)
+        // aren't standard http(s) URLs -- an HTML5 type="url" input
+        // would reject some of them client-side before the form ever
+        // reaches the API's own (permissive-for-apprise) validation.
+        urlInput.type = 'text';
+        urlLabel.textContent = 'Apprise URL *';
+        urlHint.style.display = 'block';
+        secretGroup.style.display = 'none';
+        customHeadersGroup.style.display = 'none';
+    } else if (providerType === 'discord') {
+        urlInput.type = 'url';
+        urlLabel.textContent = 'Discord Webhook URL *';
+        urlHint.style.display = 'none';
+        // Discord webhooks don't use HMAC signatures.
+        secretGroup.style.display = 'none';
+        customHeadersGroup.style.display = 'none';
+    } else {
+        urlInput.type = 'url';
+        urlLabel.textContent = 'Webhook URL *';
+        urlHint.style.display = 'none';
+        secretGroup.style.display = '';
+        customHeadersGroup.style.display = '';
+    }
+}
+
 function getFormData() {
     const selectedEvents = Array.from(document.querySelectorAll('#eventTypesSelector input:checked'))
         .map(checkbox => checkbox.value);
-    
+
     let headers = {};
     const customHeadersText = document.getElementById('customHeaders').value.trim();
     if (customHeadersText) {
@@ -786,7 +833,7 @@ function getFormData() {
             headers = {};
         }
     }
-    
+
     return {
         url: document.getElementById('webhookUrl').value,
         secret: document.getElementById('webhookSecret').value,
@@ -794,7 +841,8 @@ function getFormData() {
         enabled: document.getElementById('webhookEnabled').checked,
         max_retries: parseInt(document.getElementById('maxRetries').value),
         timeout: parseInt(document.getElementById('timeout').value),
-        headers: headers
+        headers: headers,
+        provider_type: document.getElementById('webhookProviderType').value
     };
 }
 

--- a/frontend/templates/webhooks.html
+++ b/frontend/templates/webhooks.html
@@ -555,6 +555,11 @@
     <div class="test-section">
         <h3>Test Webhook</h3>
         <div class="test-controls">
+            <select id="testWebhookProviderType" class="form-control">
+                <option value="generic">Generic (custom HTTP webhook)</option>
+                <option value="discord">Discord</option>
+                <option value="apprise">Apprise</option>
+            </select>
             <input type="url" id="testWebhookUrl" placeholder="Webhook URL to test" class="form-control">
             <input type="password" id="testWebhookSecret" placeholder="Secret (optional)" class="form-control">
             <button onclick="testWebhook()" class="btn btn-warning">Test Webhook</button>
@@ -690,21 +695,40 @@ function loadWebhooks() {
         });
 }
 
+// Escapes HTML special characters for safe interpolation into innerHTML
+// text/attribute content (e.g. webhook.url, which is stored verbatim --
+// see WebhookEndpointRequest.url in src/api/fastapi/webhooks.py -- and
+// could otherwise carry a stored-XSS payload).
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// Same as escapeHtml, but also escapes single quotes. Use this wherever
+// a value is interpolated inside a single-quoted JS string literal that
+// itself sits inside a double-quoted HTML attribute, e.g.
+// onclick="fn('${escapeHtmlAttr(value)}')" -- escapeHtml alone leaves a
+// bare `'` free to break out of the JS string literal.
+function escapeHtmlAttr(text) {
+    return escapeHtml(text).replace(/'/g, '&#39;');
+}
+
 function displayWebhooks(webhooks) {
     const container = document.getElementById('webhooksList');
     container.innerHTML = '';
-    
+
     webhooks.forEach(webhook => {
         const webhookDiv = document.createElement('div');
         webhookDiv.className = 'webhook-item';
-        
-        const eventsHtml = webhook.events.length > 0 
-            ? webhook.events.map(event => `<span class="event-tag">${event}</span>`).join('')
+
+        const eventsHtml = webhook.events.length > 0
+            ? webhook.events.map(event => `<span class="event-tag">${escapeHtml(event)}</span>`).join('')
             : '<span class="event-tag">All Events</span>';
-        
+
         webhookDiv.innerHTML = `
             <div class="webhook-info">
-                <div class="webhook-url">${webhook.url}</div>
+                <div class="webhook-url">${escapeHtml(webhook.url)}</div>
                 <div class="webhook-details">
                     Retries: ${webhook.max_retries} | Timeout: ${webhook.timeout}s
                     ${webhook.secret ? ' | Secret: Configured' : ''}
@@ -716,8 +740,8 @@ function displayWebhooks(webhooks) {
                 <span>${webhook.enabled ? 'Enabled' : 'Disabled'}</span>
             </div>
             <div class="webhook-actions">
-                <button onclick="editWebhook('${webhook.url}')" class="btn btn-sm btn-primary">Edit</button>
-                <button onclick="deleteWebhook('${webhook.url}')" class="btn btn-sm btn-danger">Delete</button>
+                <button onclick="editWebhook('${escapeHtmlAttr(webhook.url)}')" class="btn btn-sm btn-primary">Edit</button>
+                <button onclick="deleteWebhook('${escapeHtmlAttr(webhook.url)}')" class="btn btn-sm btn-danger">Delete</button>
             </div>
         `;
         container.appendChild(webhookDiv);
@@ -1012,20 +1036,24 @@ function testWebhook() {
         },
         body: JSON.stringify({
             url: url,
-            secret: secret
+            secret: secret,
+            provider_type: document.getElementById('testWebhookProviderType').value
         })
     })
     .then(response => response.json())
     .then(data => {
         const result = data.test_result;
-        
+
         if (result.success) {
+            const statusCode = result.status_code != null ? result.status_code : 'N/A';
+            const responseTime = result.response_time != null ? result.response_time.toFixed(2) : 'N/A';
+            const responseText = result.response_text != null ? result.response_text : 'N/A';
             resultsDiv.innerHTML = `
                 <div class="test-success">
                     <h4>✅ Test Successful</h4>
-                    <p>Status Code: ${result.status_code}</p>
-                    <p>Response Time: ${result.response_time}s</p>
-                    <p>Response: ${result.response_text}</p>
+                    <p>Status Code: ${statusCode}</p>
+                    <p>Response Time: ${responseTime}s</p>
+                    <p>Response: ${escapeHtml(responseText)}</p>
                 </div>
             `;
         } else {

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ requests==2.34.2  # Security: CVE-2026-25645 predictable temp file creation fix
 urllib3==2.7.0  # Security: CVE-2026-44431 sensitive-header forwarding fix, CVE-2026-44432 decompression-bomb fix
 httpx==0.28.1
 aiohttp==3.14.3  # Security: CVE-2026-69244 OOB heap read in C parser error path, CVE-2026-69243 WS upgrade request smuggling, CVE-2026-59881 WS decompression without negotiated permessage-deflate fixes; also carries CVE-2026-22815/34513-34520/34525, CVE-2026-34993, CVE-2026-47265 fixes
+apprise==1.12.0  # Notification fan-out for Discord/Slack/Telegram/ntfy/email/etc. (#315)
 
 # Image Processing
 Pillow==12.3.0  # Security: CVE-2026-25990 PSD fix, CVE-2026-40192 FITS GZIP decompression bomb fix

--- a/src/api/fastapi/frontend_router.py
+++ b/src/api/fastapi/frontend_router.py
@@ -280,6 +280,16 @@ async def lastfm_manager(request: Request, user=Depends(require_authentication))
         raise HTTPException(status_code=500, detail="Failed to load Last.fm page")
 
 
+@frontend_router.get("/webhooks", response_class=HTMLResponse, name="webhooks_manager")
+async def webhooks_manager(request: Request, user=Depends(require_authentication)):
+    """Webhooks & Notifications page (authentication required)"""
+    try:
+        return await template_routes.webhooks(request)
+    except Exception as e:
+        logger.error(f"Error rendering Webhooks page: {e}")
+        raise HTTPException(status_code=500, detail="Failed to load Webhooks page")
+
+
 @frontend_router.get("/lidarr", response_class=HTMLResponse, name="lidarr_manager")
 async def lidarr_manager(request: Request, user=Depends(require_authentication)):
     """Lidarr Manager page (authentication required)"""

--- a/src/api/fastapi/template_system.py
+++ b/src/api/fastapi/template_system.py
@@ -682,6 +682,16 @@ class FastAPITemplateRoutes:
             "lastfm.html", request, context
         )
 
+    async def webhooks(self, request: Request) -> HTMLResponse:
+        """Webhook/notification management page (Discord, Apprise, generic)"""
+        context = {
+            "page_title": "Webhooks & Notifications",
+            "page_description": "Manage outbound webhooks, Discord, and Apprise notifications",
+        }
+        return await self.template_system.render_response(
+            "webhooks.html", request, context
+        )
+
     async def lidarr(self, request: Request) -> HTMLResponse:
         """Lidarr Manager page"""
         context = {

--- a/src/api/fastapi/webhooks.py
+++ b/src/api/fastapi/webhooks.py
@@ -5,6 +5,7 @@ Migrated from Flask src/api/webhooks.py - Event-driven notification webhooks
 
 import logging
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field, HttpUrl, validator
@@ -37,7 +38,21 @@ router = APIRouter(
 class WebhookEndpointRequest(BaseModel):
     """Webhook endpoint creation request"""
 
-    url: HttpUrl = Field(..., description="Webhook URL endpoint")
+    # Declared FIRST, before url: pydantic's @validator only sees fields
+    # in `values` that were declared (and already validated) earlier in
+    # the class body. validate_url below reads values["provider_type"],
+    # so provider_type must be declared above url or that lookup always
+    # misses and silently falls back to the "generic" default.
+    provider_type: str = Field(
+        default="generic",
+        pattern="^(generic|discord|apprise)$",
+        description="Payload format/delivery mechanism for this endpoint",
+    )
+    # Plain str, not HttpUrl: Apprise endpoints use non-HTTP URL schemes
+    # (e.g. "tgram://bottoken/ChatID", "discord://webhook_id/token") that
+    # HttpUrl would reject outright. Real URL-shape validation for
+    # generic/discord happens in validate_url below instead.
+    url: str = Field(..., min_length=1, description="Webhook URL or Apprise URL string")
     secret: Optional[str] = Field(
         None, max_length=256, description="Secret for webhook verification"
     )
@@ -65,6 +80,20 @@ class WebhookEndpointRequest(BaseModel):
                 raise ValueError(f"Invalid event type: {event_str}")
         return v
 
+    @validator("url")
+    def validate_url(cls, v, values):
+        """Apprise URLs are not standard HTTP(S) URLs -- only require
+        real URL shape for generic/discord, which are always plain HTTP(S)
+        webhook endpoints."""
+        provider_type = values.get("provider_type", "generic")
+        if provider_type != "apprise":
+            parsed = urlparse(v)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise ValueError(
+                    "url must be a valid http(s) URL for generic/discord endpoints"
+                )
+        return v
+
 
 class WebhookEndpointUpdate(BaseModel):
     """Webhook endpoint update request"""
@@ -75,6 +104,7 @@ class WebhookEndpointUpdate(BaseModel):
     max_retries: Optional[int] = Field(None, ge=0, le=10)
     timeout: Optional[int] = Field(None, ge=1, le=300)
     headers: Optional[Dict[str, str]] = None
+    provider_type: Optional[str] = Field(None, pattern="^(generic|discord|apprise)$")
 
     @validator("events")
     def validate_events(cls, v):
@@ -91,10 +121,22 @@ class WebhookEndpointUpdate(BaseModel):
 class WebhookTestRequest(BaseModel):
     """Webhook test request"""
 
-    url: HttpUrl = Field(..., description="Webhook URL to test")
+    provider_type: str = Field(default="generic", pattern="^(generic|discord|apprise)$")
+    url: str = Field(..., min_length=1, description="Webhook URL or Apprise URL string")
     secret: Optional[str] = Field(
         None, max_length=256, description="Secret for verification"
     )
+
+    @validator("url")
+    def validate_url(cls, v, values):
+        provider_type = values.get("provider_type", "generic")
+        if provider_type != "apprise":
+            parsed = urlparse(v)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise ValueError(
+                    "url must be a valid http(s) URL for generic/discord endpoints"
+                )
+        return v
 
 
 class WebhookTriggerRequest(BaseModel):
@@ -202,6 +244,7 @@ async def create_webhook(
             max_retries=webhook_request.max_retries,
             timeout=webhook_request.timeout,
             headers=webhook_request.headers,
+            provider_type=webhook_request.provider_type,
         )
 
         success = webhook_service.add_endpoint(endpoint)
@@ -305,7 +348,9 @@ async def test_webhook(
         )
 
         result = webhook_service.test_endpoint(
-            str(test_request.url), test_request.secret
+            str(test_request.url),
+            test_request.secret,
+            provider_type=test_request.provider_type,
         )
 
         return {"test_result": result, "url": str(test_request.url)}

--- a/src/api/fastapi/webhooks.py
+++ b/src/api/fastapi/webhooks.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
+from src.services.apprise_notification_service import redact_apprise_url
 from src.services.webhook_service import (
     WebhookEndpoint,
     WebhookEventType,
@@ -92,6 +93,10 @@ class WebhookEndpointRequest(BaseModel):
                 raise ValueError(
                     "url must be a valid http(s) URL for generic/discord endpoints"
                 )
+            if any(char in v for char in ("<", ">", '"', "'")):
+                raise ValueError(
+                    "url must not contain '<', '>', '\"', or \"'\" characters"
+                )
         return v
 
 
@@ -136,6 +141,10 @@ class WebhookTestRequest(BaseModel):
                 raise ValueError(
                     "url must be a valid http(s) URL for generic/discord endpoints"
                 )
+            if any(char in v for char in ("<", ">", '"', "'")):
+                raise ValueError(
+                    "url must not contain '<', '>', '\"', or \"'\" characters"
+                )
         return v
 
 
@@ -159,7 +168,11 @@ class WebhookTriggerRequest(BaseModel):
 class WebhookValidationRequest(BaseModel):
     """Webhook validation request"""
 
-    url: Optional[HttpUrl] = None
+    # Declared FIRST, before url -- same ordering requirement as
+    # WebhookEndpointRequest above: pydantic's @validator only sees
+    # earlier-declared fields via `values`.
+    provider_type: str = Field(default="generic", pattern="^(generic|discord|apprise)$")
+    url: Optional[str] = None
     secret: Optional[str] = Field(None, max_length=256)
     events: Optional[List[str]] = None
     enabled: Optional[bool] = None
@@ -227,8 +240,13 @@ async def create_webhook(
     try:
         user_id = current_user.get("user_id", 1)
 
+        log_url = (
+            redact_apprise_url(webhook_request.url)
+            if webhook_request.provider_type == "apprise"
+            else webhook_request.url
+        )
         logger.info(
-            f"Creating webhook endpoint for URL '{webhook_request.url}' by user {current_user.get('username')}"
+            f"Creating webhook endpoint for URL '{log_url}' by user {current_user.get('username')}"
         )
 
         # Convert event strings to enum values
@@ -343,8 +361,13 @@ async def test_webhook(
     try:
         user_id = current_user.get("user_id", 1)
 
+        log_url = (
+            redact_apprise_url(test_request.url)
+            if test_request.provider_type == "apprise"
+            else test_request.url
+        )
         logger.info(
-            f"Testing webhook endpoint '{test_request.url}' for user {current_user.get('username')}"
+            f"Testing webhook endpoint '{log_url}' for user {current_user.get('username')}"
         )
 
         result = webhook_service.test_endpoint(
@@ -377,10 +400,16 @@ async def validate_webhook(
         validation_errors = []
         data = validation_request.dict()
 
-        # Validate URL
-        if "url" not in data or data["url"] is None:
+        # Validate URL. Apprise URLs aren't http(s) -- they're arbitrary
+        # Apprise service URL strings (tgram://, discord://, mailto://,
+        # ...) -- so only enforce the http(s)-prefix check for
+        # generic/discord; an Apprise URL is valid as long as it's
+        # non-empty.
+        if "url" not in data or data["url"] is None or not str(data["url"]):
             validation_errors.append("URL is required")
-        elif not str(data["url"]).startswith(("http://", "https://")):
+        elif validation_request.provider_type != "apprise" and not str(
+            data["url"]
+        ).startswith(("http://", "https://")):
             validation_errors.append("URL must start with http:// or https://")
 
         # Validate event types

--- a/src/services/apprise_notification_service.py
+++ b/src/services/apprise_notification_service.py
@@ -15,8 +15,6 @@ are simple enough that a shared abstraction isn't worth the coupling
 yet.
 """
 
-import apprise
-
 from src.services.webhook_models import WebhookEvent, WebhookEventType
 from src.utils.logger import get_logger
 
@@ -43,7 +41,7 @@ _TITLES = {
 }
 
 
-def _redact_apprise_url(apprise_url: str) -> str:
+def redact_apprise_url(apprise_url: str) -> str:
     """Apprise URLs embed their credential directly in the URL string by
     design (e.g. tgram://<bot_token>/<chat_id>, discord://<id>/<token>,
     mailto://user:password@host). Log only the scheme so a delivery
@@ -81,14 +79,24 @@ def _body_for(event: WebhookEvent) -> str:
 def send_apprise_notification(apprise_url: str, event: WebhookEvent) -> bool:
     """Deliver a webhook event via Apprise. Never raises -- returns False
     on any failure so the caller's retry loop can treat it the same way
-    as a failed HTTP request."""
+    as a failed HTTP request.
+
+    `apprise` is imported here rather than at module scope so that a
+    missing/broken `apprise` install only breaks Apprise delivery (an
+    ImportError caught below, same as any other failure) instead of
+    taking down the entire FastAPI app at boot -- webhook_service.py
+    imports this module unconditionally, and the API layer imports
+    webhook_service.
+    """
     try:
+        import apprise
+
         notifier = apprise.Apprise()
         notifier.add(apprise_url)
         result = notifier.notify(title=_title_for(event), body=_body_for(event))
         return bool(result)
     except Exception as e:
         logger.warning(
-            f"Apprise notification failed for {_redact_apprise_url(apprise_url)}: {e}"
+            f"Apprise notification failed for {redact_apprise_url(apprise_url)}: {e}"
         )
         return False

--- a/src/services/apprise_notification_service.py
+++ b/src/services/apprise_notification_service.py
@@ -17,7 +17,7 @@ yet.
 
 import apprise
 
-from src.services.webhook_service import WebhookEvent, WebhookEventType
+from src.services.webhook_models import WebhookEvent, WebhookEventType
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.apprise_notification")

--- a/src/services/apprise_notification_service.py
+++ b/src/services/apprise_notification_service.py
@@ -1,0 +1,82 @@
+"""
+Apprise notification delivery for MVidarr webhook events (#315).
+
+Thin wrapper around the `apprise` library, which owns delivery to
+whatever service the endpoint's URL string targets (Slack, Telegram,
+ntfy, email, Discord-via-Apprise, ~100 others). MVidarr's own
+retry/backoff loop in webhook_service.py still wraps a call to this
+function, so a transient failure still gets MVidarr-level retries even
+though Apprise's own .notify() call is fire-and-forget.
+
+Reuses the same title logic as discord_notification_formatter.py but
+kept as a small local copy rather than a shared import -- Apprise needs
+a plain title/body string pair, not a Discord embed dict, and the two
+are simple enough that a shared abstraction isn't worth the coupling
+yet.
+"""
+
+import apprise
+
+from src.services.webhook_service import WebhookEvent, WebhookEventType
+from src.utils.logger import get_logger
+
+logger = get_logger("mvidarr.services.apprise_notification")
+
+_TITLES = {
+    WebhookEventType.ARTIST_ADDED: "Artist Added",
+    WebhookEventType.ARTIST_UPDATED: "Artist Updated",
+    WebhookEventType.ARTIST_DELETED: "Artist Deleted",
+    WebhookEventType.VIDEO_ADDED: "Video Added",
+    WebhookEventType.VIDEO_UPDATED: "Video Updated",
+    WebhookEventType.VIDEO_DELETED: "Video Deleted",
+    WebhookEventType.VIDEO_DOWNLOADED: "Video Downloaded",
+    WebhookEventType.VIDEO_DOWNLOAD_FAILED: "Video Download Failed",
+    WebhookEventType.DOWNLOAD_STARTED: "Download Started",
+    WebhookEventType.DOWNLOAD_COMPLETED: "Download Completed",
+    WebhookEventType.DOWNLOAD_FAILED: "Download Failed",
+    WebhookEventType.PLAYLIST_SYNC_STARTED: "Playlist Sync Started",
+    WebhookEventType.PLAYLIST_SYNC_COMPLETED: "Playlist Sync Completed",
+    WebhookEventType.EXTERNAL_IMPORT_STARTED: "External Import Started",
+    WebhookEventType.EXTERNAL_IMPORT_COMPLETED: "External Import Completed",
+    WebhookEventType.SYSTEM_HEALTH_CHANGED: "System Health Changed",
+    WebhookEventType.SYSTEM_ERROR: "System Error",
+}
+
+
+def _title_for(event: WebhookEvent) -> str:
+    return _TITLES.get(event.event_type, event.event_type.value)
+
+
+def _body_for(event: WebhookEvent) -> str:
+    data = event.data or {}
+
+    title = data.get("title")
+    artist_name = data.get("artist_name")
+    if title and artist_name:
+        return f"{title} by {artist_name}"
+    if title:
+        return str(title)
+
+    name = data.get("name")
+    if name:
+        return str(name)
+
+    message = data.get("message")
+    if message:
+        return str(message)
+
+    return _title_for(event)
+
+
+def send_apprise_notification(apprise_url: str, event: WebhookEvent) -> bool:
+    """Deliver a webhook event via Apprise. Never raises -- returns False
+    on any failure so the caller's retry loop can treat it the same way
+    as a failed HTTP request."""
+    try:
+        notifier = apprise.Apprise()
+        notifier.add(apprise_url)
+        result = notifier.notify(title=_title_for(event), body=_body_for(event))
+        return bool(result)
+    except Exception as e:
+        logger.warning(f"Apprise notification failed for {apprise_url}: {e}")
+        return False

--- a/src/services/apprise_notification_service.py
+++ b/src/services/apprise_notification_service.py
@@ -43,6 +43,16 @@ _TITLES = {
 }
 
 
+def _redact_apprise_url(apprise_url: str) -> str:
+    """Apprise URLs embed their credential directly in the URL string by
+    design (e.g. tgram://<bot_token>/<chat_id>, discord://<id>/<token>,
+    mailto://user:password@host). Log only the scheme so a delivery
+    failure doesn't write a live, usable credential into observability
+    output."""
+    scheme = apprise_url.split("://", 1)[0] if "://" in apprise_url else "unknown"
+    return f"{scheme}://***"
+
+
 def _title_for(event: WebhookEvent) -> str:
     return _TITLES.get(event.event_type, event.event_type.value)
 
@@ -78,5 +88,7 @@ def send_apprise_notification(apprise_url: str, event: WebhookEvent) -> bool:
         result = notifier.notify(title=_title_for(event), body=_body_for(event))
         return bool(result)
     except Exception as e:
-        logger.warning(f"Apprise notification failed for {apprise_url}: {e}")
+        logger.warning(
+            f"Apprise notification failed for {_redact_apprise_url(apprise_url)}: {e}"
+        )
         return False

--- a/src/services/discord_notification_formatter.py
+++ b/src/services/discord_notification_formatter.py
@@ -1,0 +1,89 @@
+"""
+Discord embed formatter for MVidarr webhook events (#315).
+
+Pure functions only -- no network I/O here. _deliver_webhook() in
+webhook_service.py calls format_discord_embed() to build the payload,
+then does the actual HTTP POST itself (same retry/backoff/SSRF-validated
+path already used for generic webhooks -- a Discord webhook URL is a
+normal HTTPS URL).
+
+No thumbnail/poster art: self-hosted MVidarr instances often have no
+publicly reachable URL for Discord's servers to fetch an image from.
+"""
+
+from src.services.webhook_service import WebhookEvent, WebhookEventType
+
+# Discord embed colors (decimal, as Discord's API expects) by outcome.
+_COLOR_GREEN = 0x2ECC71  # success: added/downloaded/completed
+_COLOR_RED = 0xE74C3C  # failure: failed/error
+_COLOR_BLUE = 0x3498DB  # neutral/in-progress: started/updated/changed
+
+_TITLES = {
+    WebhookEventType.ARTIST_ADDED: "Artist Added",
+    WebhookEventType.ARTIST_UPDATED: "Artist Updated",
+    WebhookEventType.ARTIST_DELETED: "Artist Deleted",
+    WebhookEventType.VIDEO_ADDED: "Video Added",
+    WebhookEventType.VIDEO_UPDATED: "Video Updated",
+    WebhookEventType.VIDEO_DELETED: "Video Deleted",
+    WebhookEventType.VIDEO_DOWNLOADED: "Video Downloaded",
+    WebhookEventType.VIDEO_DOWNLOAD_FAILED: "Video Download Failed",
+    WebhookEventType.DOWNLOAD_STARTED: "Download Started",
+    WebhookEventType.DOWNLOAD_COMPLETED: "Download Completed",
+    WebhookEventType.DOWNLOAD_FAILED: "Download Failed",
+    WebhookEventType.PLAYLIST_SYNC_STARTED: "Playlist Sync Started",
+    WebhookEventType.PLAYLIST_SYNC_COMPLETED: "Playlist Sync Completed",
+    WebhookEventType.EXTERNAL_IMPORT_STARTED: "External Import Started",
+    WebhookEventType.EXTERNAL_IMPORT_COMPLETED: "External Import Completed",
+    WebhookEventType.SYSTEM_HEALTH_CHANGED: "System Health Changed",
+    WebhookEventType.SYSTEM_ERROR: "System Error",
+}
+
+
+def _color_for(event_type: WebhookEventType) -> int:
+    value = event_type.value
+    if value.endswith("_failed") or "failed" in value or "error" in value:
+        return _COLOR_RED
+    if (
+        value.endswith("downloaded")
+        or value.endswith("completed")
+        or value.endswith("added")
+    ):
+        return _COLOR_GREEN
+    return _COLOR_BLUE
+
+
+def _description_for(event: WebhookEvent) -> str:
+    data = event.data or {}
+
+    title = data.get("title")
+    artist_name = data.get("artist_name")
+    if title and artist_name:
+        return f"**{title}** by **{artist_name}**"
+    if title:
+        return f"**{title}**"
+
+    name = data.get("name")
+    if name:
+        return f"**{name}**"
+
+    message = data.get("message")
+    if message:
+        return str(message)
+
+    # Generic fallback -- always return something non-empty rather than
+    # an empty embed description, which Discord renders as a blank gap.
+    return _TITLES.get(event.event_type, event.event_type.value)
+
+
+def format_discord_embed(event: WebhookEvent) -> dict:
+    """Build a Discord-shaped embed payload for a webhook event."""
+    return {
+        "embeds": [
+            {
+                "title": _TITLES.get(event.event_type, event.event_type.value),
+                "description": _description_for(event),
+                "color": _color_for(event.event_type),
+                "timestamp": event.timestamp.isoformat(),
+            }
+        ]
+    }

--- a/src/services/discord_notification_formatter.py
+++ b/src/services/discord_notification_formatter.py
@@ -11,7 +11,7 @@ No thumbnail/poster art: self-hosted MVidarr instances often have no
 publicly reachable URL for Discord's servers to fetch an image from.
 """
 
-from src.services.webhook_service import WebhookEvent, WebhookEventType
+from src.services.webhook_models import WebhookEvent, WebhookEventType
 
 # Discord embed colors (decimal, as Discord's API expects) by outcome.
 _COLOR_GREEN = 0x2ECC71  # success: added/downloaded/completed

--- a/src/services/webhook_models.py
+++ b/src/services/webhook_models.py
@@ -1,0 +1,60 @@
+"""
+Shared webhook event data structures (#315).
+
+Split out of webhook_service.py so that provider-specific formatters
+(discord_notification_formatter.py, apprise_notification_service.py) can
+depend on WebhookEvent/WebhookEventType without creating a circular
+import with webhook_service.py, which in turn imports those formatters
+to use at delivery time. This module has no dependencies on any other
+mvidarr webhook module, so it's safe for all of them to import from.
+
+webhook_service.py re-exports WebhookEvent/WebhookEventType from here so
+existing `from src.services.webhook_service import WebhookEvent,
+WebhookEventType` call sites keep working unchanged.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict
+
+
+class WebhookEventType(Enum):
+    """Webhook event types"""
+
+    ARTIST_ADDED = "artist.added"
+    ARTIST_UPDATED = "artist.updated"
+    ARTIST_DELETED = "artist.deleted"
+    VIDEO_ADDED = "video.added"
+    VIDEO_UPDATED = "video.updated"
+    VIDEO_DELETED = "video.deleted"
+    VIDEO_DOWNLOADED = "video.downloaded"
+    VIDEO_DOWNLOAD_FAILED = "video.download_failed"
+    DOWNLOAD_STARTED = "download.started"
+    DOWNLOAD_COMPLETED = "download.completed"
+    DOWNLOAD_FAILED = "download.failed"
+    PLAYLIST_SYNC_STARTED = "playlist.sync_started"
+    PLAYLIST_SYNC_COMPLETED = "playlist.sync_completed"
+    EXTERNAL_IMPORT_STARTED = "external.import_started"
+    EXTERNAL_IMPORT_COMPLETED = "external.import_completed"
+    SYSTEM_HEALTH_CHANGED = "system.health_changed"
+    SYSTEM_ERROR = "system.error"
+
+
+@dataclass
+class WebhookEvent:
+    """Webhook event data structure"""
+
+    event_type: WebhookEventType
+    timestamp: datetime
+    data: Dict[str, Any]
+    metadata: Dict[str, Any] = None
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary for JSON serialization"""
+        return {
+            "event_type": self.event_type.value,
+            "timestamp": self.timestamp.isoformat(),
+            "data": self.data,
+            "metadata": self.metadata or {},
+        }

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import requests
 
 from src.services.apprise_notification_service import (
-    _redact_apprise_url,
+    redact_apprise_url,
     send_apprise_notification,
 )
 from src.services.discord_notification_formatter import format_discord_embed
@@ -56,6 +56,23 @@ class WebhookEndpoint:
             self.events = []
         if self.headers is None:
             self.headers = {}
+
+
+def _log_safe_url(url: str) -> str:
+    """Redact a URL for logging if it's credential-bearing.
+
+    Apprise URLs embed their credential directly in the URL string itself
+    (tgram://<bot_token>/<chat_id>, discord://<id>/<token>,
+    mailto://user:password@host, ...) -- any URL that isn't a plain
+    http(s) endpoint is, by construction, an Apprise URL and therefore a
+    live credential. Checking the scheme directly (rather than requiring
+    a WebhookEndpoint's tracked provider_type) means this stays correct
+    even in call sites like remove_endpoint() that only ever receive a
+    bare URL string.
+    """
+    if url.startswith(("http://", "https://")):
+        return url
+    return redact_apprise_url(url)
 
 
 class WebhookService:
@@ -141,7 +158,7 @@ class WebhookService:
 
             self.endpoints.append(endpoint)
             self.save_endpoints()
-            logger.info(f"Added webhook endpoint: {endpoint.url}")
+            logger.info(f"Added webhook endpoint: {_log_safe_url(endpoint.url)}")
             return True
 
         except Exception as e:
@@ -153,7 +170,7 @@ class WebhookService:
         try:
             self.endpoints = [ep for ep in self.endpoints if ep.url != url]
             self.save_endpoints()
-            logger.info(f"Removed webhook endpoint: {url}")
+            logger.info(f"Removed webhook endpoint: {_log_safe_url(url)}")
             return True
 
         except Exception as e:
@@ -184,7 +201,7 @@ class WebhookService:
                         endpoint.provider_type = updates["provider_type"]
 
                     self.save_endpoints()
-                    logger.info(f"Updated webhook endpoint: {url}")
+                    logger.info(f"Updated webhook endpoint: {_log_safe_url(url)}")
                     return True
 
             raise ValueError("Endpoint not found")
@@ -197,7 +214,11 @@ class WebhookService:
         """Get all webhook endpoints"""
         return [
             {
-                "url": ep.url,
+                "url": (
+                    redact_apprise_url(ep.url)
+                    if ep.provider_type == "apprise"
+                    else ep.url
+                ),
                 "secret": "***" if ep.secret else None,
                 "events": [event.value for event in ep.events],
                 "enabled": ep.enabled,
@@ -253,7 +274,7 @@ class WebhookService:
             # under this same retry loop so a transient failure still
             # gets MVidarr-level retries.
             if endpoint.provider_type == "apprise":
-                redacted_url = _redact_apprise_url(endpoint.url)
+                redacted_url = redact_apprise_url(endpoint.url)
                 for attempt in range(endpoint.max_retries + 1):
                     if send_apprise_notification(endpoint.url, event):
                         logger.info(
@@ -369,7 +390,13 @@ class WebhookService:
             # -- it isn't one.
             if provider_type == "apprise":
                 success = send_apprise_notification(url, test_event)
-                return {"success": success}
+                return {
+                    "success": success,
+                    "status_code": None,
+                    "response_time": None,
+                    "response_text": "Apprise notification sent" if success else None,
+                    "error": None if success else "Apprise delivery failed",
+                }
 
             if provider_type == "discord":
                 payload = format_discord_embed(test_event)

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -180,6 +180,8 @@ class WebhookService:
                         endpoint.timeout = updates["timeout"]
                     if "headers" in updates:
                         endpoint.headers = updates["headers"]
+                    if "provider_type" in updates:
+                        endpoint.provider_type = updates["provider_type"]
 
                     self.save_endpoints()
                     logger.info(f"Updated webhook endpoint: {url}")

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -10,57 +10,25 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import requests
 
+from src.services.apprise_notification_service import send_apprise_notification
+from src.services.discord_notification_formatter import format_discord_embed
 from src.services.settings_service import SettingsService
+
+# WebhookEvent/WebhookEventType live in webhook_models.py, not here, and are
+# re-exported below. apprise_notification_service.py and
+# discord_notification_formatter.py (imported above) also depend on those
+# two types -- keeping them in this module would make the imports above a
+# circular import that breaks `import webhook_service` entirely. See
+# webhook_models.py's docstring for the full explanation.
+from src.services.webhook_models import WebhookEvent, WebhookEventType
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.webhook")
-
-
-class WebhookEventType(Enum):
-    """Webhook event types"""
-
-    ARTIST_ADDED = "artist.added"
-    ARTIST_UPDATED = "artist.updated"
-    ARTIST_DELETED = "artist.deleted"
-    VIDEO_ADDED = "video.added"
-    VIDEO_UPDATED = "video.updated"
-    VIDEO_DELETED = "video.deleted"
-    VIDEO_DOWNLOADED = "video.downloaded"
-    VIDEO_DOWNLOAD_FAILED = "video.download_failed"
-    DOWNLOAD_STARTED = "download.started"
-    DOWNLOAD_COMPLETED = "download.completed"
-    DOWNLOAD_FAILED = "download.failed"
-    PLAYLIST_SYNC_STARTED = "playlist.sync_started"
-    PLAYLIST_SYNC_COMPLETED = "playlist.sync_completed"
-    EXTERNAL_IMPORT_STARTED = "external.import_started"
-    EXTERNAL_IMPORT_COMPLETED = "external.import_completed"
-    SYSTEM_HEALTH_CHANGED = "system.health_changed"
-    SYSTEM_ERROR = "system.error"
-
-
-@dataclass
-class WebhookEvent:
-    """Webhook event data structure"""
-
-    event_type: WebhookEventType
-    timestamp: datetime
-    data: Dict[str, Any]
-    metadata: Dict[str, Any] = None
-
-    def to_dict(self) -> Dict:
-        """Convert to dictionary for JSON serialization"""
-        return {
-            "event_type": self.event_type.value,
-            "timestamp": self.timestamp.isoformat(),
-            "data": self.data,
-            "metadata": self.metadata or {},
-        }
 
 
 @dataclass
@@ -274,7 +242,33 @@ class WebhookService:
         """Deliver webhook to endpoint with retry logic"""
 
         def delivery_task():
-            payload = event.to_dict()
+            # Apprise owns its own delivery mechanics entirely (it isn't
+            # an HTTP POST of a JSON body at all) -- handle it separately
+            # from the HTTP-based generic/discord path below, but still
+            # under this same retry loop so a transient failure still
+            # gets MVidarr-level retries.
+            if endpoint.provider_type == "apprise":
+                for attempt in range(endpoint.max_retries + 1):
+                    if send_apprise_notification(endpoint.url, event):
+                        logger.info(
+                            f"Apprise notification delivered to {endpoint.url} (attempt {attempt + 1})"
+                        )
+                        return
+                    logger.warning(
+                        f"Apprise notification failed to {endpoint.url} (attempt {attempt + 1})"
+                    )
+                    if attempt < endpoint.max_retries:
+                        time.sleep((2**attempt) * 1)
+                logger.error(
+                    f"Apprise notification failed permanently to {endpoint.url} after {endpoint.max_retries + 1} attempts"
+                )
+                return
+
+            if endpoint.provider_type == "discord":
+                payload = format_discord_embed(event)
+            else:
+                payload = event.to_dict()
+
             headers = {
                 "Content-Type": "application/json",
                 "User-Agent": "MVidarr-Enhanced-Webhook/1.0",
@@ -285,7 +279,10 @@ class WebhookService:
             # Add custom headers
             headers.update(endpoint.headers)
 
-            # Add signature if secret is configured
+            # Add signature if secret is configured (Discord webhooks
+            # don't use HMAC signatures -- the UI never collects a secret
+            # for provider_type == "discord", so endpoint.secret is None
+            # there and this block is a no-op for that case)
             if endpoint.secret:
                 signature = self._generate_signature(
                     endpoint.secret, json.dumps(payload)
@@ -343,7 +340,9 @@ class WebhookService:
         ).hexdigest()
         return f"sha256={signature}"
 
-    def test_endpoint(self, url: str, secret: Optional[str] = None) -> Dict:
+    def test_endpoint(
+        self, url: str, secret: Optional[str] = None, provider_type: str = "generic"
+    ) -> Dict:
         """Test webhook endpoint with a test event"""
         try:
             test_event = WebhookEvent(
@@ -360,7 +359,17 @@ class WebhookService:
                 },
             )
 
-            payload = test_event.to_dict()
+            # Apprise test delivery bypasses the HTTP-POST path entirely
+            # -- it isn't one.
+            if provider_type == "apprise":
+                success = send_apprise_notification(url, test_event)
+                return {"success": success}
+
+            if provider_type == "discord":
+                payload = format_discord_embed(test_event)
+            else:
+                payload = test_event.to_dict()
+
             headers = {
                 "Content-Type": "application/json",
                 "User-Agent": "MVidarr-Enhanced-Webhook/1.0",

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -15,7 +15,10 @@ from urllib.parse import urlparse
 
 import requests
 
-from src.services.apprise_notification_service import send_apprise_notification
+from src.services.apprise_notification_service import (
+    _redact_apprise_url,
+    send_apprise_notification,
+)
 from src.services.discord_notification_formatter import format_discord_embed
 from src.services.settings_service import SettingsService
 
@@ -248,19 +251,20 @@ class WebhookService:
             # under this same retry loop so a transient failure still
             # gets MVidarr-level retries.
             if endpoint.provider_type == "apprise":
+                redacted_url = _redact_apprise_url(endpoint.url)
                 for attempt in range(endpoint.max_retries + 1):
                     if send_apprise_notification(endpoint.url, event):
                         logger.info(
-                            f"Apprise notification delivered to {endpoint.url} (attempt {attempt + 1})"
+                            f"Apprise notification delivered to {redacted_url} (attempt {attempt + 1})"
                         )
                         return
                     logger.warning(
-                        f"Apprise notification failed to {endpoint.url} (attempt {attempt + 1})"
+                        f"Apprise notification failed to {redacted_url} (attempt {attempt + 1})"
                     )
                     if attempt < endpoint.max_retries:
                         time.sleep((2**attempt) * 1)
                 logger.error(
-                    f"Apprise notification failed permanently to {endpoint.url} after {endpoint.max_retries + 1} attempts"
+                    f"Apprise notification failed permanently to {redacted_url} after {endpoint.max_retries + 1} attempts"
                 )
                 return
 

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -74,6 +74,11 @@ class WebhookEndpoint:
     max_retries: int = 3
     timeout: int = 30
     headers: Dict[str, str] = None
+    # "generic" (today's raw MVidarr envelope), "discord" (embed-formatted),
+    # or "apprise" (delivered via the apprise library). Defaults to
+    # "generic" so every endpoint saved before this field existed keeps
+    # behaving exactly as it does today -- no migration needed.
+    provider_type: str = "generic"
 
     def __post_init__(self):
         if self.events is None:
@@ -115,6 +120,7 @@ class WebhookService:
                     max_retries=endpoint_config.get("max_retries", 3),
                     timeout=endpoint_config.get("timeout", 30),
                     headers=endpoint_config.get("headers", {}),
+                    provider_type=endpoint_config.get("provider_type", "generic"),
                 )
                 self.endpoints.append(endpoint)
 
@@ -137,6 +143,7 @@ class WebhookService:
                     "max_retries": endpoint.max_retries,
                     "timeout": endpoint.timeout,
                     "headers": endpoint.headers,
+                    "provider_type": endpoint.provider_type,
                 }
                 endpoints_data.append(endpoint_data)
 
@@ -224,6 +231,7 @@ class WebhookService:
                 "max_retries": ep.max_retries,
                 "timeout": ep.timeout,
                 "headers": ep.headers,
+                "provider_type": ep.provider_type,
             }
             for ep in self.endpoints
         ]

--- a/tests/unit/test_apprise_notification_service.py
+++ b/tests/unit/test_apprise_notification_service.py
@@ -1,0 +1,77 @@
+"""Unit tests for src/services/apprise_notification_service.py (#315).
+
+Mocks the apprise.Apprise object -- no real network calls, no real
+Apprise-supported service needed to test this.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from src.services.apprise_notification_service import send_apprise_notification
+from src.services.webhook_service import WebhookEvent, WebhookEventType
+
+FIXED_TIME = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _event(event_type=WebhookEventType.VIDEO_DOWNLOADED, data=None):
+    return WebhookEvent(
+        event_type=event_type, timestamp=FIXED_TIME, data=data or {}, metadata={}
+    )
+
+
+class TestSendAppriseNotification:
+    def test_adds_the_url_and_calls_notify(self):
+        mock_apprise_instance = MagicMock()
+        mock_apprise_instance.notify.return_value = True
+
+        with patch(
+            "src.services.apprise_notification_service.apprise.Apprise",
+            return_value=mock_apprise_instance,
+        ):
+            result = send_apprise_notification("tgram://bottoken/ChatID", _event())
+
+        mock_apprise_instance.add.assert_called_once_with("tgram://bottoken/ChatID")
+        mock_apprise_instance.notify.assert_called_once()
+        assert result is True
+
+    def test_notify_receives_a_title_and_body(self):
+        mock_apprise_instance = MagicMock()
+        mock_apprise_instance.notify.return_value = True
+
+        with patch(
+            "src.services.apprise_notification_service.apprise.Apprise",
+            return_value=mock_apprise_instance,
+        ):
+            send_apprise_notification(
+                "tgram://bottoken/ChatID",
+                _event(data={"title": "Example Song", "artist_name": "Example Artist"}),
+            )
+
+        _, kwargs = mock_apprise_instance.notify.call_args
+        assert kwargs["title"] == "Video Downloaded"
+        assert "Example Song" in kwargs["body"]
+        assert "Example Artist" in kwargs["body"]
+
+    def test_returns_false_when_notify_returns_false(self):
+        mock_apprise_instance = MagicMock()
+        mock_apprise_instance.notify.return_value = False
+
+        with patch(
+            "src.services.apprise_notification_service.apprise.Apprise",
+            return_value=mock_apprise_instance,
+        ):
+            result = send_apprise_notification("tgram://bottoken/ChatID", _event())
+
+        assert result is False
+
+    def test_returns_false_instead_of_raising_on_exception(self):
+        mock_apprise_instance = MagicMock()
+        mock_apprise_instance.notify.side_effect = RuntimeError("boom")
+
+        with patch(
+            "src.services.apprise_notification_service.apprise.Apprise",
+            return_value=mock_apprise_instance,
+        ):
+            result = send_apprise_notification("tgram://bottoken/ChatID", _event())
+
+        assert result is False

--- a/tests/unit/test_apprise_notification_service.py
+++ b/tests/unit/test_apprise_notification_service.py
@@ -24,8 +24,14 @@ class TestSendAppriseNotification:
         mock_apprise_instance = MagicMock()
         mock_apprise_instance.notify.return_value = True
 
+        # apprise_notification_service.py imports `apprise` locally inside
+        # send_apprise_notification() (#315 Finding 7 -- so a missing
+        # apprise install is a per-delivery failure, not a boot-time
+        # ImportError for the whole app), so there's no module-level
+        # `apprise` attribute on apprise_notification_service to patch
+        # through -- patch the real `apprise` package directly instead.
         with patch(
-            "src.services.apprise_notification_service.apprise.Apprise",
+            "apprise.Apprise",
             return_value=mock_apprise_instance,
         ):
             result = send_apprise_notification("tgram://bottoken/ChatID", _event())
@@ -38,8 +44,14 @@ class TestSendAppriseNotification:
         mock_apprise_instance = MagicMock()
         mock_apprise_instance.notify.return_value = True
 
+        # apprise_notification_service.py imports `apprise` locally inside
+        # send_apprise_notification() (#315 Finding 7 -- so a missing
+        # apprise install is a per-delivery failure, not a boot-time
+        # ImportError for the whole app), so there's no module-level
+        # `apprise` attribute on apprise_notification_service to patch
+        # through -- patch the real `apprise` package directly instead.
         with patch(
-            "src.services.apprise_notification_service.apprise.Apprise",
+            "apprise.Apprise",
             return_value=mock_apprise_instance,
         ):
             send_apprise_notification(
@@ -56,8 +68,14 @@ class TestSendAppriseNotification:
         mock_apprise_instance = MagicMock()
         mock_apprise_instance.notify.return_value = False
 
+        # apprise_notification_service.py imports `apprise` locally inside
+        # send_apprise_notification() (#315 Finding 7 -- so a missing
+        # apprise install is a per-delivery failure, not a boot-time
+        # ImportError for the whole app), so there's no module-level
+        # `apprise` attribute on apprise_notification_service to patch
+        # through -- patch the real `apprise` package directly instead.
         with patch(
-            "src.services.apprise_notification_service.apprise.Apprise",
+            "apprise.Apprise",
             return_value=mock_apprise_instance,
         ):
             result = send_apprise_notification("tgram://bottoken/ChatID", _event())
@@ -68,8 +86,14 @@ class TestSendAppriseNotification:
         mock_apprise_instance = MagicMock()
         mock_apprise_instance.notify.side_effect = RuntimeError("boom")
 
+        # apprise_notification_service.py imports `apprise` locally inside
+        # send_apprise_notification() (#315 Finding 7 -- so a missing
+        # apprise install is a per-delivery failure, not a boot-time
+        # ImportError for the whole app), so there's no module-level
+        # `apprise` attribute on apprise_notification_service to patch
+        # through -- patch the real `apprise` package directly instead.
         with patch(
-            "src.services.apprise_notification_service.apprise.Apprise",
+            "apprise.Apprise",
             return_value=mock_apprise_instance,
         ):
             result = send_apprise_notification("tgram://bottoken/ChatID", _event())

--- a/tests/unit/test_apprise_url_redaction.py
+++ b/tests/unit/test_apprise_url_redaction.py
@@ -1,0 +1,58 @@
+"""Security regression test: Apprise URLs embed their credential directly
+in the URL string by design (tgram://<bot_token>/<chat_id>,
+discord://<id>/<token>, mailto://user:password@host). Log lines must never
+contain the raw URL -- only the scheme -- so a delivery failure doesn't
+write a live, usable credential into observability output.
+"""
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from src.services.apprise_notification_service import (
+    _redact_apprise_url,
+    send_apprise_notification,
+)
+from src.services.webhook_models import WebhookEvent, WebhookEventType
+
+
+class TestRedactAppriseUrl:
+    def test_keeps_only_the_scheme(self):
+        assert (
+            _redact_apprise_url("tgram://123456789:AABBccddEE/-1001234567890")
+            == "tgram://***"
+        )
+        assert (
+            _redact_apprise_url("discord://webhook_id/webhook_token") == "discord://***"
+        )
+        assert (
+            _redact_apprise_url("mailto://user:hunter2@smtp.example.com")
+            == "mailto://***"
+        )
+
+    def test_handles_a_url_with_no_scheme_separator_without_raising(self):
+        assert _redact_apprise_url("not-a-real-url") == "unknown://***"
+
+
+class TestAppriseServiceNeverLogsTheRawUrl:
+    def test_exception_log_does_not_contain_the_credential(self, caplog):
+        mock_apprise_instance = MagicMock()
+        mock_apprise_instance.notify.side_effect = RuntimeError("boom")
+
+        secret_url = "tgram://123456789:AABBccddEE/-1001234567890"
+        event = WebhookEvent(
+            event_type=WebhookEventType.VIDEO_DOWNLOADED,
+            timestamp=datetime(2026, 8, 13, tzinfo=timezone.utc),
+            data={},
+            metadata={},
+        )
+
+        with caplog.at_level(logging.WARNING), patch(
+            "src.services.apprise_notification_service.apprise.Apprise",
+            return_value=mock_apprise_instance,
+        ):
+            send_apprise_notification(secret_url, event)
+
+        assert "AABBccddEE" not in caplog.text
+        assert "-1001234567890" not in caplog.text
+        assert "tgram://***" in caplog.text

--- a/tests/unit/test_apprise_url_redaction.py
+++ b/tests/unit/test_apprise_url_redaction.py
@@ -10,28 +10,41 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from src.services.apprise_notification_service import (
-    _redact_apprise_url,
+    redact_apprise_url,
     send_apprise_notification,
 )
 from src.services.webhook_models import WebhookEvent, WebhookEventType
+from src.services.webhook_service import WebhookEndpoint, WebhookService
+
+
+def _make_service_with_no_saved_endpoints(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.webhook_service.SettingsService.get_json",
+        lambda key, default: {"endpoints": []},
+    )
+    monkeypatch.setattr(
+        "src.services.webhook_service.SettingsService.set_json",
+        lambda key, value: None,
+    )
+    return WebhookService()
 
 
 class TestRedactAppriseUrl:
     def test_keeps_only_the_scheme(self):
         assert (
-            _redact_apprise_url("tgram://123456789:AABBccddEE/-1001234567890")
+            redact_apprise_url("tgram://123456789:AABBccddEE/-1001234567890")
             == "tgram://***"
         )
         assert (
-            _redact_apprise_url("discord://webhook_id/webhook_token") == "discord://***"
+            redact_apprise_url("discord://webhook_id/webhook_token") == "discord://***"
         )
         assert (
-            _redact_apprise_url("mailto://user:hunter2@smtp.example.com")
+            redact_apprise_url("mailto://user:hunter2@smtp.example.com")
             == "mailto://***"
         )
 
     def test_handles_a_url_with_no_scheme_separator_without_raising(self):
-        assert _redact_apprise_url("not-a-real-url") == "unknown://***"
+        assert redact_apprise_url("not-a-real-url") == "unknown://***"
 
 
 class TestAppriseServiceNeverLogsTheRawUrl:
@@ -47,12 +60,103 @@ class TestAppriseServiceNeverLogsTheRawUrl:
             metadata={},
         )
 
+        # apprise_notification_service.py imports `apprise` locally inside
+        # send_apprise_notification() (#315 Finding 7 -- so a missing
+        # apprise install is a per-delivery failure, not a boot-time
+        # ImportError for the whole app), so there's no module-level
+        # `apprise` attribute on apprise_notification_service to patch
+        # through -- patch the real `apprise` package directly instead.
         with caplog.at_level(logging.WARNING), patch(
-            "src.services.apprise_notification_service.apprise.Apprise",
+            "apprise.Apprise",
             return_value=mock_apprise_instance,
         ):
             send_apprise_notification(secret_url, event)
 
         assert "AABBccddEE" not in caplog.text
         assert "-1001234567890" not in caplog.text
+        assert "tgram://***" in caplog.text
+
+
+class TestGetEndpointsRedactsAppriseUrls:
+    """Final-review Finding 5: get_endpoints() masked `secret` as "***"
+    but returned `url` in full -- for an Apprise endpoint the URL *is*
+    the credential, so GET /api/webhooks/ handed it back to the browser
+    unmasked, which webhooks.html then printed as-is."""
+
+    def test_apprise_endpoint_url_is_redacted(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        service.add_endpoint(
+            WebhookEndpoint(
+                url="tgram://123456789:AABBccddEE/-1001234567890",
+                provider_type="apprise",
+            )
+        )
+
+        endpoints = service.get_endpoints()
+
+        assert endpoints[0]["url"] == "tgram://***"
+
+    def test_generic_endpoint_url_is_returned_in_full(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        service.add_endpoint(
+            WebhookEndpoint(
+                url="https://example.com/hook",
+                provider_type="generic",
+            )
+        )
+
+        endpoints = service.get_endpoints()
+
+        assert endpoints[0]["url"] == "https://example.com/hook"
+
+
+class TestCrudLogLinesRedactAppriseUrls:
+    """Final-review Finding 5: add_endpoint()/remove_endpoint()/
+    update_endpoint() each logged the raw URL directly, leaking the
+    credential embedded in an Apprise URL into application logs."""
+
+    def test_add_endpoint_does_not_log_the_raw_apprise_url(self, monkeypatch, caplog):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+
+        with caplog.at_level(logging.INFO):
+            service.add_endpoint(
+                WebhookEndpoint(
+                    url="tgram://123456789:AABBccddEE/-1001234567890",
+                    provider_type="apprise",
+                )
+            )
+
+        assert "AABBccddEE" not in caplog.text
+        assert "tgram://***" in caplog.text
+
+    def test_update_endpoint_does_not_log_the_raw_apprise_url(
+        self, monkeypatch, caplog
+    ):
+        secret_url = "tgram://123456789:AABBccddEE/-1001234567890"
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        service.add_endpoint(WebhookEndpoint(url=secret_url, provider_type="apprise"))
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO):
+            service.update_endpoint(secret_url, {"enabled": False})
+
+        assert "AABBccddEE" not in caplog.text
+        assert "tgram://***" in caplog.text
+
+    def test_remove_endpoint_does_not_log_the_raw_apprise_url(
+        self, monkeypatch, caplog
+    ):
+        # remove_endpoint() only ever receives a bare URL string, not a
+        # WebhookEndpoint with a tracked provider_type -- the redaction
+        # here keys off the URL's own scheme (non-http(s) == credential
+        # bearing) rather than a lookup against the stored endpoint.
+        secret_url = "tgram://123456789:AABBccddEE/-1001234567890"
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        service.add_endpoint(WebhookEndpoint(url=secret_url, provider_type="apprise"))
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO):
+            service.remove_endpoint(secret_url)
+
+        assert "AABBccddEE" not in caplog.text
         assert "tgram://***" in caplog.text

--- a/tests/unit/test_discord_notification_formatter.py
+++ b/tests/unit/test_discord_notification_formatter.py
@@ -1,0 +1,88 @@
+"""Unit tests for src/services/discord_notification_formatter.py (#315).
+
+Pure function, no I/O -- given a WebhookEvent, returns a Discord-shaped
+embed payload. No thumbnail/image art (self-hosted instances often have
+no publicly reachable URL for Discord to fetch an image from -- design
+doc's explicit non-goal).
+"""
+
+from datetime import datetime, timezone
+
+from src.services.discord_notification_formatter import format_discord_embed
+from src.services.webhook_service import WebhookEvent, WebhookEventType
+
+FIXED_TIME = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _event(event_type, data=None):
+    return WebhookEvent(
+        event_type=event_type, timestamp=FIXED_TIME, data=data or {}, metadata={}
+    )
+
+
+class TestFormatDiscordEmbed:
+    def test_returns_a_single_embed_in_the_embeds_list(self):
+        payload = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOADED))
+        assert "embeds" in payload
+        assert len(payload["embeds"]) == 1
+
+    def test_embed_has_no_image_or_thumbnail_keys(self):
+        embed = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOADED))[
+            "embeds"
+        ][0]
+        assert "image" not in embed
+        assert "thumbnail" not in embed
+
+    def test_embed_includes_iso_timestamp(self):
+        embed = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOADED))[
+            "embeds"
+        ][0]
+        assert embed["timestamp"] == FIXED_TIME.isoformat()
+
+    def test_downloaded_event_is_green(self):
+        embed = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOADED))[
+            "embeds"
+        ][0]
+        assert embed["color"] == 0x2ECC71  # green
+
+    def test_download_failed_event_is_red(self):
+        embed = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOAD_FAILED))[
+            "embeds"
+        ][0]
+        assert embed["color"] == 0xE74C3C  # red
+
+    def test_system_error_event_is_red(self):
+        embed = format_discord_embed(_event(WebhookEventType.SYSTEM_ERROR))["embeds"][
+            0
+        ]
+        assert embed["color"] == 0xE74C3C
+
+    def test_started_event_is_blue(self):
+        embed = format_discord_embed(_event(WebhookEventType.DOWNLOAD_STARTED))[
+            "embeds"
+        ][0]
+        assert embed["color"] == 0x3498DB  # blue
+
+    def test_title_is_human_readable_not_the_raw_enum_value(self):
+        embed = format_discord_embed(_event(WebhookEventType.VIDEO_DOWNLOADED))[
+            "embeds"
+        ][0]
+        assert embed["title"] == "Video Downloaded"
+        assert "video.downloaded" not in embed["title"]
+
+    def test_description_incorporates_event_data(self):
+        embed = format_discord_embed(
+            _event(
+                WebhookEventType.VIDEO_DOWNLOADED,
+                data={"title": "Example Song", "artist_name": "Example Artist"},
+            )
+        )["embeds"][0]
+        assert "Example Song" in embed["description"]
+        assert "Example Artist" in embed["description"]
+
+    def test_description_falls_back_gracefully_with_no_data(self):
+        embed = format_discord_embed(_event(WebhookEventType.SYSTEM_HEALTH_CHANGED))[
+            "embeds"
+        ][0]
+        assert isinstance(embed["description"], str)
+        assert len(embed["description"]) > 0

--- a/tests/unit/test_settings_links_to_webhooks.py
+++ b/tests/unit/test_settings_links_to_webhooks.py
@@ -1,0 +1,24 @@
+"""Regression/feature test for #315: Settings page must link to the
+webhooks/notifications page -- before this, nothing anywhere linked to
+it (confirmed by grep across frontend/templates/*.html), so it was
+undiscoverable even after Task 6 made it technically reachable by URL.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestSettingsLinksToWebhooks:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_settings_page_links_to_the_webhooks_page(self):
+        assert "/webhooks" in self.html
+
+    def test_the_link_is_a_sidebar_nav_button_styled_like_its_siblings(self):
+        start = self.html.index('class="sidebar-nav">')
+        end = self.html.index("</ul>", start)
+        nav_html = self.html[start:end]
+        assert "/webhooks" in nav_html
+        assert "settings-tab-btn" in nav_html

--- a/tests/unit/test_webhook_delivery_provider_type.py
+++ b/tests/unit/test_webhook_delivery_provider_type.py
@@ -1,0 +1,131 @@
+"""Regression/feature test for #315: _deliver_webhook() and
+test_endpoint() must format the payload per endpoint.provider_type
+instead of always sending the generic MVidarr envelope, which a real
+Discord webhook rejects and which isn't how Apprise delivery works at
+all.
+"""
+
+import time
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from src.services.webhook_service import (
+    WebhookEndpoint,
+    WebhookEvent,
+    WebhookEventType,
+    WebhookService,
+)
+
+
+def _make_service_with_no_saved_endpoints(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.webhook_service.SettingsService.get_json",
+        lambda key, default: {"endpoints": []},
+    )
+    return WebhookService()
+
+
+class TestDeliverWebhookProviderTypeBranching:
+    def test_discord_endpoint_posts_the_embed_shaped_payload(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        endpoint = WebhookEndpoint(
+            url="https://discord.com/api/webhooks/123/abc",
+            provider_type="discord",
+            max_retries=0,
+        )
+        event = WebhookEvent(
+            event_type=WebhookEventType.VIDEO_DOWNLOADED,
+            timestamp=datetime.now(),
+            data={},
+            metadata={},
+        )
+
+        with patch("src.services.webhook_service.requests.post") as mock_post, patch(
+            "src.utils.url_validator.validate_url_or_raise"
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            service._deliver_webhook(endpoint, event)
+            time.sleep(0.2)  # delivery runs in a background thread
+
+        _, kwargs = mock_post.call_args
+        assert "embeds" in kwargs["json"]
+
+    def test_apprise_endpoint_calls_send_apprise_notification_not_requests_post(
+        self, monkeypatch
+    ):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        endpoint = WebhookEndpoint(
+            url="tgram://bottoken/ChatID", provider_type="apprise", max_retries=0
+        )
+        event = WebhookEvent(
+            event_type=WebhookEventType.VIDEO_DOWNLOADED,
+            timestamp=datetime.now(),
+            data={},
+            metadata={},
+        )
+
+        with patch(
+            "src.services.webhook_service.send_apprise_notification"
+        ) as mock_send, patch(
+            "src.services.webhook_service.requests.post"
+        ) as mock_post:
+            mock_send.return_value = True
+            service._deliver_webhook(endpoint, event)
+            time.sleep(0.2)
+
+        mock_send.assert_called_once_with("tgram://bottoken/ChatID", event)
+        mock_post.assert_not_called()
+
+    def test_generic_endpoint_still_posts_the_raw_envelope(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        endpoint = WebhookEndpoint(
+            url="https://example.com/hook", provider_type="generic", max_retries=0
+        )
+        event = WebhookEvent(
+            event_type=WebhookEventType.VIDEO_DOWNLOADED,
+            timestamp=datetime.now(),
+            data={"title": "Example"},
+            metadata={},
+        )
+
+        with patch("src.services.webhook_service.requests.post") as mock_post, patch(
+            "src.utils.url_validator.validate_url_or_raise"
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            service._deliver_webhook(endpoint, event)
+            time.sleep(0.2)
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == event.to_dict()
+
+
+class TestTestEndpointProviderTypeBranching:
+    def test_discord_test_sends_an_embed_shaped_payload(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+
+        with patch("src.services.webhook_service.requests.post") as mock_post, patch(
+            "src.utils.url_validator.validate_url_or_raise"
+        ):
+            mock_post.return_value = MagicMock(
+                status_code=204, elapsed=MagicMock(total_seconds=lambda: 0.1), text=""
+            )
+            service.test_endpoint(
+                "https://discord.com/api/webhooks/123/abc", provider_type="discord"
+            )
+
+        _, kwargs = mock_post.call_args
+        assert "embeds" in kwargs["json"]
+
+    def test_apprise_test_calls_send_apprise_notification(self, monkeypatch):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+
+        with patch(
+            "src.services.webhook_service.send_apprise_notification"
+        ) as mock_send:
+            mock_send.return_value = True
+            result = service.test_endpoint(
+                "tgram://bottoken/ChatID", provider_type="apprise"
+            )
+
+        mock_send.assert_called_once()
+        assert result["success"] is True

--- a/tests/unit/test_webhook_endpoint_provider_type.py
+++ b/tests/unit/test_webhook_endpoint_provider_type.py
@@ -1,0 +1,78 @@
+"""Regression/feature test for #315: WebhookEndpoint gains a
+provider_type field ("generic" | "discord" | "apprise") so
+_deliver_webhook() can format payloads correctly per destination
+instead of always sending the same generic MVidarr envelope (which a
+real Discord webhook would reject -- it validates against its own
+{content, embeds: [...]} schema).
+
+Defaults to "generic" so every endpoint saved before this field
+existed loads and behaves exactly as it does today -- no migration.
+"""
+
+from src.services.webhook_service import WebhookEndpoint, WebhookService
+
+
+class TestWebhookEndpointProviderType:
+    def test_defaults_to_generic(self):
+        endpoint = WebhookEndpoint(url="https://example.com/hook")
+        assert endpoint.provider_type == "generic"
+
+    def test_accepts_discord_and_apprise(self):
+        discord_ep = WebhookEndpoint(
+            url="https://discord.com/api/webhooks/123/abc",
+            provider_type="discord",
+        )
+        assert discord_ep.provider_type == "discord"
+
+        apprise_ep = WebhookEndpoint(
+            url="tgram://bottoken/ChatID", provider_type="apprise"
+        )
+        assert apprise_ep.provider_type == "apprise"
+
+
+class TestLoadEndpointsDefaultsProviderType:
+    def test_pre_existing_saved_endpoint_with_no_provider_type_loads_as_generic(
+        self, monkeypatch
+    ):
+        """Simulates real pre-existing data: a webhooks_config JSON blob
+        saved before this field existed, with no provider_type key at
+        all. Must load as "generic", not crash or default to None."""
+        saved_config = {
+            "endpoints": [
+                {
+                    "url": "https://example.com/hook",
+                    "secret": None,
+                    "events": [],
+                    "enabled": True,
+                    "max_retries": 3,
+                    "timeout": 30,
+                    "headers": {},
+                    # deliberately no "provider_type" key
+                }
+            ]
+        }
+        monkeypatch.setattr(
+            "src.services.webhook_service.SettingsService.get_json",
+            lambda key, default: saved_config,
+        )
+
+        service = WebhookService()
+
+        assert len(service.endpoints) == 1
+        assert service.endpoints[0].provider_type == "generic"
+
+
+class TestGetEndpointsIncludesProviderType:
+    def test_get_endpoints_reports_provider_type(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.webhook_service.SettingsService.get_json",
+            lambda key, default: {"endpoints": []},
+        )
+        service = WebhookService()
+        service.endpoints = [
+            WebhookEndpoint(url="https://example.com/hook", provider_type="discord")
+        ]
+
+        result = service.get_endpoints()
+
+        assert result[0]["provider_type"] == "discord"

--- a/tests/unit/test_webhooks_api_provider_type.py
+++ b/tests/unit/test_webhooks_api_provider_type.py
@@ -9,7 +9,7 @@ for every endpoint before this change.
 import pytest
 from pydantic import ValidationError
 
-from src.api.fastapi.webhooks import WebhookEndpointRequest
+from src.api.fastapi.webhooks import WebhookEndpointRequest, WebhookTestRequest
 
 
 class TestWebhookEndpointRequestProviderType:
@@ -43,4 +43,53 @@ class TestWebhookEndpointRequestProviderType:
 
     def test_rejects_invalid_provider_type(self):
         with pytest.raises(ValidationError):
-            WebhookEndpointRequest(url="https://example.com/hook", provider_type="carrier_pigeon")
+            WebhookEndpointRequest(
+                url="https://example.com/hook", provider_type="carrier_pigeon"
+            )
+
+    def test_rejects_url_with_injection_characters_for_generic(self):
+        # Final-review Finding 1 (Critical, stored XSS): url is a plain
+        # str (not HttpUrl) so it no longer gets percent-encoded, and
+        # webhooks.html interpolates it raw into innerHTML. A URL
+        # containing HTML/attribute-breakout characters must never pass
+        # validation for generic/discord endpoints.
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(
+                url='https://example.com/x"><img src=x onerror=alert(1)>',
+                provider_type="generic",
+            )
+
+    def test_rejects_url_with_single_quote_for_discord(self):
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(
+                url="https://example.com/x'onmouseover='alert(1)",
+                provider_type="discord",
+            )
+
+    def test_apprise_url_is_not_checked_for_injection_characters(self):
+        # Apprise URLs skip the http(s)-shape check entirely (they're not
+        # HTTP URLs), so this documents that the injection-character
+        # check only applies within the non-apprise branch, same as the
+        # scheme/netloc check it sits next to.
+        req = WebhookEndpointRequest(
+            url="tgram://bottoken/ChatID?title=<b>", provider_type="apprise"
+        )
+        assert req.url == "tgram://bottoken/ChatID?title=<b>"
+
+
+class TestWebhookTestRequestInjectionCharacters:
+    # WebhookTestRequest.validate_url is the identical validator to
+    # WebhookEndpointRequest's -- the Test Webhook panel posts straight
+    # to this model, so it needs the same Finding 1 hardening.
+    def test_rejects_url_with_injection_characters_for_generic(self):
+        with pytest.raises(ValidationError):
+            WebhookTestRequest(
+                url='https://example.com/x"><img src=x onerror=alert(1)>',
+                provider_type="generic",
+            )
+
+    def test_accepts_a_clean_url(self):
+        req = WebhookTestRequest(
+            url="https://example.com/hook", provider_type="generic"
+        )
+        assert req.url == "https://example.com/hook"

--- a/tests/unit/test_webhooks_api_provider_type.py
+++ b/tests/unit/test_webhooks_api_provider_type.py
@@ -1,0 +1,46 @@
+"""Regression/feature test for #315: the webhooks API must accept
+provider_type, and must accept a plain (non-HTTP) URL string for Apprise
+endpoints -- Apprise URLs like "tgram://bottoken/ChatID" or
+"discord://webhook_id/token" are not standard HTTP(S) URLs and would be
+rejected by Pydantic's HttpUrl validator, which the request model used
+for every endpoint before this change.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.fastapi.webhooks import WebhookEndpointRequest
+
+
+class TestWebhookEndpointRequestProviderType:
+    def test_defaults_to_generic(self):
+        req = WebhookEndpointRequest(url="https://example.com/hook")
+        assert req.provider_type == "generic"
+
+    def test_accepts_discord_with_a_real_https_url(self):
+        req = WebhookEndpointRequest(
+            url="https://discord.com/api/webhooks/123/abc", provider_type="discord"
+        )
+        assert req.provider_type == "discord"
+
+    def test_accepts_an_apprise_style_non_http_url(self):
+        req = WebhookEndpointRequest(
+            url="tgram://bottoken/ChatID", provider_type="apprise"
+        )
+        assert req.url == "tgram://bottoken/ChatID"
+
+    def test_rejects_garbage_url_for_generic(self):
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(url="not a url at all", provider_type="generic")
+
+    def test_rejects_garbage_url_for_discord(self):
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(url="not a url at all", provider_type="discord")
+
+    def test_rejects_empty_url_for_apprise(self):
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(url="", provider_type="apprise")
+
+    def test_rejects_invalid_provider_type(self):
+        with pytest.raises(ValidationError):
+            WebhookEndpointRequest(url="https://example.com/hook", provider_type="carrier_pigeon")

--- a/tests/unit/test_webhooks_page_route.py
+++ b/tests/unit/test_webhooks_page_route.py
@@ -1,0 +1,47 @@
+"""Regression/feature test for #315: the webhooks management page
+(frontend/templates/webhooks.html) exists and its API router
+(src/api/fastapi/webhooks.py) is mounted, but no page route has ever
+pointed at it -- confirmed via grep, zero hits for "webhooks" in
+frontend_router.py before this change. GET /webhooks 404s today.
+
+Matches the exact pattern every other authenticated page route already
+uses (e.g. lastfm_manager/lidarr_manager in frontend_router.py):
+@frontend_router.get(...) -> template_routes.<method>(request) in a
+try/except that logs and raises HTTPException(500) on failure.
+"""
+
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "api" / "fastapi"
+
+
+class TestWebhooksPageRoute:
+    def setup_method(self):
+        self.frontend_router_source = (SRC_DIR / "frontend_router.py").read_text()
+        self.template_system_source = (SRC_DIR / "template_system.py").read_text()
+
+    def test_frontend_router_registers_a_webhooks_route(self):
+        assert '@frontend_router.get("/webhooks"' in self.frontend_router_source
+
+    def test_webhooks_route_requires_authentication(self):
+        start = self.frontend_router_source.index('@frontend_router.get("/webhooks"')
+        end = self.frontend_router_source.index("\n\n", start)
+        route_block = self.frontend_router_source[start:end]
+        assert "Depends(require_authentication)" in route_block
+
+    def test_webhooks_route_calls_template_routes_webhooks(self):
+        start = self.frontend_router_source.index('@frontend_router.get("/webhooks"')
+        end = self.frontend_router_source.index("\n\n", start)
+        route_block = self.frontend_router_source[start:end]
+        assert "template_routes.webhooks(request)" in route_block
+
+    def test_template_system_has_a_webhooks_method(self):
+        assert "async def webhooks(self, request: Request)" in self.template_system_source
+
+    def test_webhooks_method_renders_webhooks_html(self):
+        start = self.template_system_source.index(
+            "async def webhooks(self, request: Request)"
+        )
+        end = self.template_system_source.index("\n\n", start)
+        method_block = self.template_system_source[start:end]
+        assert '"webhooks.html"' in method_block

--- a/tests/unit/test_webhooks_provider_type_ui.py
+++ b/tests/unit/test_webhooks_provider_type_ui.py
@@ -1,0 +1,41 @@
+"""Regression/feature test for #315: the Add Webhook form gains a Type
+selector (Generic / Discord / Apprise). Selecting a type shows/hides
+the relevant fields (Discord/Apprise don't use a secret or custom
+headers -- Discord webhooks don't do HMAC, and Apprise's URL string is
+the entire config). getFormData() includes provider_type in the
+payload sent to POST /api/webhooks/.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestWebhooksProviderTypeUI:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "webhooks.html").read_text()
+
+    def test_type_selector_exists_with_all_three_options(self):
+        assert 'id="webhookProviderType"' in self.html
+        start = self.html.index('id="webhookProviderType"')
+        end = self.html.index("</select>", start)
+        select_html = self.html[start:end]
+        assert 'value="generic"' in select_html
+        assert 'value="discord"' in select_html
+        assert 'value="apprise"' in select_html
+
+    def test_type_selector_has_a_change_handler(self):
+        start = self.html.index('id="webhookProviderType"')
+        end = self.html.index(">", start)
+        tag = self.html[start:end]
+        assert "onchange=" in tag
+
+    def test_a_handler_function_exists_to_toggle_fields_by_type(self):
+        assert "function updateWebhookFormForProviderType" in self.html
+
+    def test_get_form_data_includes_provider_type(self):
+        start = self.html.index("function getFormData()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "provider_type" in body
+        assert "webhookProviderType" in body

--- a/tests/unit/test_webhooks_provider_type_ui.py
+++ b/tests/unit/test_webhooks_provider_type_ui.py
@@ -39,3 +39,23 @@ class TestWebhooksProviderTypeUI:
         body = self.html[start:end]
         assert "provider_type" in body
         assert "webhookProviderType" in body
+
+    def test_hide_webhook_form_resyncs_provider_type_toggle_state(self):
+        # hideWebhookForm() calls webhookConfigForm.reset(), which resets the
+        # <select> back to "generic" but does NOT undo the field
+        # show/hide/relabel side effects applied by
+        # updateWebhookFormForProviderType(). Without an explicit resync
+        # call, reopening the form after a reset leaves the URL
+        # field/label/hint and Secret/Custom-Headers groups stuck in
+        # whatever provider mode was last selected, desynced from the
+        # (reset) dropdown value.
+        start = self.html.index("function hideWebhookForm()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "updateWebhookFormForProviderType()" in body
+
+    def test_show_add_webhook_form_syncs_provider_type_toggle_state(self):
+        start = self.html.index("function showAddWebhookForm()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "updateWebhookFormForProviderType()" in body

--- a/tests/unit/test_webhooks_provider_type_ui.py
+++ b/tests/unit/test_webhooks_provider_type_ui.py
@@ -59,3 +59,68 @@ class TestWebhooksProviderTypeUI:
         end = self.html.index("\n}", start)
         body = self.html[start:end]
         assert "updateWebhookFormForProviderType()" in body
+
+    def test_test_webhook_panel_has_a_provider_type_selector(self):
+        # Final-review Finding 2: the standalone Test Webhook panel only
+        # ever posted {url, secret} -- no provider_type -- so Apprise
+        # URLs got rejected by the generic-only validator and Discord
+        # URLs got tested with the wrong payload shape.
+        assert 'id="testWebhookProviderType"' in self.html
+        start = self.html.index('id="testWebhookProviderType"')
+        end = self.html.index("</select>", start)
+        select_html = self.html[start:end]
+        assert 'value="generic"' in select_html
+        assert 'value="discord"' in select_html
+        assert 'value="apprise"' in select_html
+
+    def test_test_webhook_sends_provider_type_in_the_request_body(self):
+        start = self.html.index("function testWebhook()")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "provider_type" in body
+        assert "testWebhookProviderType" in body
+
+
+class TestWebhooksHtmlEscaping:
+    """Final-review Finding 1 (Critical): webhook.url is a plain str
+    that is no longer percent-encoded by pydantic's HttpUrl (see
+    WebhookEndpointRequest.url in src/api/fastapi/webhooks.py), and
+    displayWebhooks() previously interpolated it raw into innerHTML --
+    both in the visible content and inside
+    onclick="editWebhook('${webhook.url}')", making it a stored-XSS
+    vector.
+    """
+
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "webhooks.html").read_text()
+
+    def test_an_escape_html_helper_exists(self):
+        assert "function escapeHtml(" in self.html
+
+    def test_display_webhooks_escapes_url_in_visible_content(self):
+        start = self.html.index("function displayWebhooks(")
+        end = self.html.index("\nfunction ", start + 1)
+        body = self.html[start:end]
+        assert "escapeHtml(webhook.url)" in body
+        # The raw, unescaped interpolation must be gone.
+        assert "${webhook.url}" not in body
+
+    def test_display_webhooks_escapes_url_inside_onclick_attributes(self):
+        start = self.html.index("function displayWebhooks(")
+        end = self.html.index("\nfunction ", start + 1)
+        body = self.html[start:end]
+        assert "editWebhook('${escapeHtmlAttr(webhook.url)}')" in body
+        assert "deleteWebhook('${escapeHtmlAttr(webhook.url)}')" in body
+
+    def test_escape_html_attr_also_escapes_single_quotes(self):
+        # The onclick="fn('...')" case nests a single-quoted JS string
+        # literal inside a double-quoted HTML attribute -- escapeHtml
+        # alone (which only handles &, <, >, ", by delegating to
+        # textContent/innerHTML) leaves a bare `'` free to break out of
+        # that JS string literal, so the onclick-specific helper must
+        # additionally escape `'`.
+        assert "function escapeHtmlAttr(" in self.html
+        start = self.html.index("function escapeHtmlAttr(")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "&#39;" in body


### PR DESCRIPTION
## Summary

Adds first-class Discord and Apprise notification providers to MVidarr's existing webhook system (`webhook_service.py`), per #315. Previously, every webhook endpoint got an identical generic JSON envelope — a real Discord webhook would reject that payload outright, since Discord validates against its own `{content, embeds: [...]}` schema. There was no way to get a usable Discord notification out of MVidarr without hand-building a translation layer.

- **`provider_type`** field (`generic`|`discord`|`apprise`, default `generic`) on `WebhookEndpoint` — fully backward compatible, every endpoint saved before this field existed loads and behaves exactly as it did before.
- **Discord**: text-only embeds (title, description, color-coded by outcome) via a new pure-function formatter. No thumbnail art — self-hosted instances often have no publicly reachable image URL for Discord to fetch.
- **Apprise**: delivers to whatever ~100 services an Apprise URL string targets (Slack, Telegram, ntfy, email, etc.), via the new `apprise==1.12.0` dependency.
- The `/webhooks` management page — which existed as fully orphaned code before this branch (template + API router both worked, but literally nothing routed to it or linked to it anywhere in the app) — is now wired up and linked from Settings, with a Type selector on the add-webhook form.

## Process

Built via `superpowers:subagent-driven-development` — 8 plan tasks, each with fresh implementer + task-scoped review (6 clean on first pass, 2 needed one fix round each — both real, well-diagnosed bugs, both re-reviewed clean):

- **Circular import**, caught and fixed during Task 4: the plan's literal import instructions created a genuine bidirectional cycle between `webhook_service.py` and the two new formatter modules. Fixed by extracting `WebhookEvent`/`WebhookEventType` into a new zero-dependency `webhook_models.py`, with `webhook_service.py` re-exporting both names so every existing call site keeps working unchanged. Independently reproduced and verified by the task reviewer.
- **Mid-plan security finding**: a background review flagged that Apprise URLs embed credentials directly in the URL string by design (e.g. `tgram://<bot_token>/<chat_id>`). Fixed with a redaction helper; the actual delivery call was independently verified to still receive the real, unredacted URL.
- **Stale UI toggle state**: canceling/submitting the add-webhook form didn't resync the Discord/Apprise field-visibility toggle with the reset dropdown, leaving the form stuck in the wrong mode on reopen. Fixed and re-verified.

The final whole-branch review (Opus) found and this branch now fixes: a **stored XSS regression** (the `url` field's Pydantic type changed from `HttpUrl` to `str` to support Apprise's non-HTTP URL schemes, which dropped `HttpUrl`'s automatic character-escaping — `webhooks.html` interpolated `webhook.url` raw into `innerHTML` and an `onclick` attribute; fixed with HTML-escaping helpers + server-side injection-character rejection), plus gaps in the Test Webhook panel, the `/validate` endpoint, and the Apprise test-result shape that only surfaced once the whole feature was exercised end-to-end. All re-reviewed clean.

Filed two follow-ups discovered along the way, deliberately kept out of this branch's scope: #369 (pre-existing generic/Discord URL logging, same risk class as the Apprise fix but predates this branch) and #370 (nothing in the app actually *emits* webhook events yet — `trigger_*` functions have zero call sites outside `webhook_service.py`, a pre-existing gap affecting the generic provider too, not something #315 introduced).

## Testing

248 tests passing (4 pre-existing, unrelated files excluded — missing `yt-dlp` binary in the test venv). Live-verified in the `mvidarr-dev` container: `/webhooks` and `/settings` route correctly, the Discord formatter and Apprise redaction run correctly against real imports, and the escaping helpers are deployed and match the reviewed diff exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)