### PR TITLE
fix(webhooks): redact Discord webhook URLs in log output (#369)

### DIFF
--- a/src/api/fastapi/webhooks.py
+++ b/src/api/fastapi/webhooks.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm import Session
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
-from src.services.apprise_notification_service import redact_apprise_url
 from src.services.webhook_service import (
     WebhookEndpoint,
     WebhookEventType,
+    log_safe_url,
     webhook_service,
 )
 
@@ -240,13 +240,9 @@ async def create_webhook(
     try:
         user_id = current_user.get("user_id", 1)
 
-        log_url = (
-            redact_apprise_url(webhook_request.url)
-            if webhook_request.provider_type == "apprise"
-            else webhook_request.url
-        )
         logger.info(
-            f"Creating webhook endpoint for URL '{log_url}' by user {current_user.get('username')}"
+            f"Creating webhook endpoint for URL '{log_safe_url(webhook_request.url)}' "
+            f"by user {current_user.get('username')}"
         )
 
         # Convert event strings to enum values
@@ -361,13 +357,9 @@ async def test_webhook(
     try:
         user_id = current_user.get("user_id", 1)
 
-        log_url = (
-            redact_apprise_url(test_request.url)
-            if test_request.provider_type == "apprise"
-            else test_request.url
-        )
         logger.info(
-            f"Testing webhook endpoint '{log_url}' for user {current_user.get('username')}"
+            f"Testing webhook endpoint '{log_safe_url(test_request.url)}' "
+            f"for user {current_user.get('username')}"
         )
 
         result = webhook_service.test_endpoint(

--- a/src/services/webhook_service.py
+++ b/src/services/webhook_service.py
@@ -58,21 +58,42 @@ class WebhookEndpoint:
             self.headers = {}
 
 
-def _log_safe_url(url: str) -> str:
+_DISCORD_WEBHOOK_HOSTS = ("discord.com", "discordapp.com")
+
+
+def log_safe_url(url: str) -> str:
     """Redact a URL for logging if it's credential-bearing.
 
-    Apprise URLs embed their credential directly in the URL string itself
-    (tgram://<bot_token>/<chat_id>, discord://<id>/<token>,
-    mailto://user:password@host, ...) -- any URL that isn't a plain
-    http(s) endpoint is, by construction, an Apprise URL and therefore a
-    live credential. Checking the scheme directly (rather than requiring
-    a WebhookEndpoint's tracked provider_type) means this stays correct
+    Two cases (#369, following the same reasoning as #315's Apprise fix):
+
+    - Apprise URLs embed their credential directly in the URL string
+      itself (tgram://<bot_token>/<chat_id>, discord://<id>/<token>,
+      mailto://user:password@host, ...) -- any URL that isn't a plain
+      http(s) endpoint is, by construction, an Apprise URL and therefore
+      a live credential.
+    - Discord webhook URLs (https://discord.com/api/webhooks/{id}/{token})
+      always carry a credential too -- the token IS the URL path, not a
+      separate secret field.
+
+    A generic http(s) URL that is neither of the above is logged
+    unchanged: not every generic webhook URL is guaranteed to carry a
+    credential (unlike Apprise's and Discord's, which always do), so
+    blanket-redacting every http(s) URL would throw away genuinely
+    useful, non-sensitive debugging information.
+
+    Checking the URL string directly (rather than requiring a
+    WebhookEndpoint's tracked provider_type) means this stays correct
     even in call sites like remove_endpoint() that only ever receive a
     bare URL string.
     """
-    if url.startswith(("http://", "https://")):
-        return url
-    return redact_apprise_url(url)
+    if not url.startswith(("http://", "https://")):
+        return redact_apprise_url(url)
+
+    parsed = urlparse(url)
+    if parsed.hostname in _DISCORD_WEBHOOK_HOSTS:
+        return f"{parsed.scheme}://{parsed.hostname}/api/webhooks/***"
+
+    return url
 
 
 class WebhookService:
@@ -158,7 +179,7 @@ class WebhookService:
 
             self.endpoints.append(endpoint)
             self.save_endpoints()
-            logger.info(f"Added webhook endpoint: {_log_safe_url(endpoint.url)}")
+            logger.info(f"Added webhook endpoint: {log_safe_url(endpoint.url)}")
             return True
 
         except Exception as e:
@@ -170,7 +191,7 @@ class WebhookService:
         try:
             self.endpoints = [ep for ep in self.endpoints if ep.url != url]
             self.save_endpoints()
-            logger.info(f"Removed webhook endpoint: {_log_safe_url(url)}")
+            logger.info(f"Removed webhook endpoint: {log_safe_url(url)}")
             return True
 
         except Exception as e:
@@ -201,7 +222,7 @@ class WebhookService:
                         endpoint.provider_type = updates["provider_type"]
 
                     self.save_endpoints()
-                    logger.info(f"Updated webhook endpoint: {_log_safe_url(url)}")
+                    logger.info(f"Updated webhook endpoint: {log_safe_url(url)}")
                     return True
 
             raise ValueError("Endpoint not found")
@@ -321,6 +342,13 @@ class WebhookService:
 
             validate_url_or_raise(endpoint.url, allow_local_network=True)
 
+            # Discord webhook URLs carry their credential directly in the
+            # path (https://discord.com/api/webhooks/{id}/{token}), same
+            # risk class as Apprise's always-credential-bearing URLs
+            # (#369) -- log_safe_url() redacts both; a truly generic
+            # http(s) URL passes through unchanged.
+            safe_url = log_safe_url(endpoint.url)
+
             # Retry logic
             for attempt in range(endpoint.max_retries + 1):
                 try:
@@ -333,17 +361,17 @@ class WebhookService:
 
                     if response.status_code in [200, 201, 202, 204]:
                         logger.info(
-                            f"Webhook delivered successfully to {endpoint.url} (attempt {attempt + 1})"
+                            f"Webhook delivered successfully to {safe_url} (attempt {attempt + 1})"
                         )
                         return
                     else:
                         logger.warning(
-                            f"Webhook delivery failed to {endpoint.url}: HTTP {response.status_code}"
+                            f"Webhook delivery failed to {safe_url}: HTTP {response.status_code}"
                         )
 
                 except requests.exceptions.RequestException as e:
                     logger.warning(
-                        f"Webhook delivery failed to {endpoint.url} (attempt {attempt + 1}): {e}"
+                        f"Webhook delivery failed to {safe_url} (attempt {attempt + 1}): {e}"
                     )
 
                 # Wait before retry (exponential backoff)
@@ -352,7 +380,7 @@ class WebhookService:
                     time.sleep(wait_time)
 
             logger.error(
-                f"Webhook delivery failed permanently to {endpoint.url} after {endpoint.max_retries + 1} attempts"
+                f"Webhook delivery failed permanently to {safe_url} after {endpoint.max_retries + 1} attempts"
             )
 
         # Run delivery in separate thread

--- a/tests/unit/test_webhook_url_logging.py
+++ b/tests/unit/test_webhook_url_logging.py
@@ -1,0 +1,97 @@
+"""Regression test for #369: webhook_service.py logged raw endpoint
+URLs, which may embed credentials -- same risk class as #315's
+Apprise-specific redaction fix, but for the generic/Discord HTTP
+delivery path this time.
+
+Apprise URLs always carry a credential (tgram://<bot_token>/<chat_id>,
+etc. -- already redacted since #315). A Discord webhook URL
+(https://discord.com/api/webhooks/{id}/{token}) ALWAYS carries a
+credential too -- the token IS the path. A truly generic http(s)
+webhook URL might or might not, so this fix does not blanket-redact
+every http(s) URL -- only Apprise-shaped and Discord-shaped ones.
+
+`_log_safe_url()` (webhook_service.py) already existed from #315's fix
+wave and already handled the Apprise case; this extends it to also
+redact Discord, and wires the three remaining raw-`endpoint.url` log
+lines in `_deliver_webhook()`'s generic/discord HTTP path plus the two
+raw-URL log lines in webhooks.py's create_webhook()/test_webhook()
+(previously apprise-only) to use it.
+"""
+
+import logging
+import time
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.webhook_models import WebhookEvent, WebhookEventType
+from src.services.webhook_service import (
+    WebhookEndpoint,
+    WebhookService,
+    log_safe_url,
+)
+
+
+class TestLogSafeUrl:
+    def test_generic_http_url_is_returned_unchanged(self):
+        assert (
+            log_safe_url("https://example.com/my-webhook-endpoint")
+            == "https://example.com/my-webhook-endpoint"
+        )
+
+    def test_apprise_url_is_redacted_to_scheme_only(self):
+        assert (
+            log_safe_url("tgram://123456789:AABBccddEE/-1001234567890") == "tgram://***"
+        )
+
+    def test_discord_webhook_url_redacts_the_credential_bearing_path(self):
+        url = "https://discord.com/api/webhooks/123456789012345678/AbCdEfGhIjKlMnOpQrStUvWxYz"
+        redacted = log_safe_url(url)
+        assert "AbCdEfGhIjKlMnOpQrStUvWxYz" not in redacted
+        assert redacted.startswith("https://discord.com/api/webhooks/")
+
+    def test_discordapp_com_legacy_host_is_also_redacted(self):
+        url = "https://discordapp.com/api/webhooks/123456789012345678/secrettoken"
+        redacted = log_safe_url(url)
+        assert "secrettoken" not in redacted
+
+
+def _make_service_with_no_saved_endpoints(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.webhook_service.SettingsService.get_json",
+        lambda key, default: {"endpoints": []},
+    )
+    monkeypatch.setattr(
+        "src.services.webhook_service.SettingsService.set_json",
+        lambda key, value: None,
+    )
+    return WebhookService()
+
+
+class TestDeliverWebhookLogsDoNotContainTheRawDiscordToken:
+    def test_success_failure_and_permanent_failure_logs_redact_the_discord_token(
+        self, monkeypatch, caplog
+    ):
+        service = _make_service_with_no_saved_endpoints(monkeypatch)
+        secret_token = "AbCdEfGhIjKlMnOpQrStUvWxYzSecretToken"
+        endpoint = WebhookEndpoint(
+            url=f"https://discord.com/api/webhooks/123456789012345678/{secret_token}",
+            provider_type="discord",
+            max_retries=0,
+        )
+        event = WebhookEvent(
+            event_type=WebhookEventType.VIDEO_DOWNLOADED,
+            timestamp=datetime.now(),
+            data={},
+            metadata={},
+        )
+
+        with caplog.at_level(logging.WARNING), patch(
+            "src.services.webhook_service.requests.post"
+        ) as mock_post, patch("src.utils.url_validator.validate_url_or_raise"):
+            mock_post.return_value = MagicMock(status_code=400)
+            service._deliver_webhook(endpoint, event)
+            time.sleep(0.2)  # delivery runs in a background thread
+
+        assert secret_token not in caplog.text


### PR DESCRIPTION
## Summary

Discord webhook URLs (`https://discord.com/api/webhooks/{id}/{token}`) carry their credential directly in the path — same risk class #315's Apprise-specific redaction fix addressed, just for the generic/Discord HTTP delivery path this time.

- `_log_safe_url()` (added in #315's final review, previously Apprise-only) renamed to public `log_safe_url()` and extended to also redact Discord-hosted URLs to `https://discord.com/api/webhooks/***`.
- A genuinely generic http(s) URL is still logged **unchanged** — not every generic webhook URL is guaranteed to carry a credential the way Apprise's and Discord's always do, so this deliberately doesn't blanket-redact every http(s) URL (matching the issue's own scoping).
- Wires the three remaining raw-`endpoint.url` log lines in `_deliver_webhook()`'s HTTP delivery path.
- Replaces `webhooks.py`'s `create_webhook()`/`test_webhook()` apprise-only redaction ternary with the unified helper — they now also cover Discord, which they previously didn't.

Closes #369.

## Testing

New `tests/unit/test_webhook_url_logging.py` (5 tests, including a `caplog`-based check that a real Discord token never appears in log output through the full `_deliver_webhook()` path). Full suite: 253 passed (up from 248). Live-verified against the running dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)