### PR TITLE
feat(webhooks): wire real download/artist activity to webhook events (#370)

### DIFF
--- a/src/api/fastapi/artists_crud.py
+++ b/src/api/fastapi/artists_crud.py
@@ -40,6 +40,7 @@ from src.api.fastapi.auth_dependencies import (
 )
 from src.database.connection import get_db_session
 from src.database.models import Artist, Video
+from src.services.webhook_service import trigger_artist_added
 from src.utils.logger import get_logger
 
 
@@ -533,6 +534,11 @@ async def create_artist(
         session.refresh(artist)
 
         logger.info(f"Created new artist: {artist.name} (ID: {artist.id})")
+        # #370: notify webhook subscribers (Discord/Apprise/generic) now
+        # that the artist is committed -- never fire before commit(), or a
+        # notification could arrive for an artist a concurrent failure
+        # still rolled back.
+        trigger_artist_added({"id": artist.id, "name": artist.name})
 
         return ArtistResponse(
             id=artist.id,

--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -15,6 +15,10 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Callable, Dict, List, Optional
 
+from src.services.webhook_service import (
+    trigger_video_download_failed,
+    trigger_video_downloaded,
+)
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.unified_download")
@@ -628,9 +632,28 @@ class UnifiedDownloadService:
                 logger.info(
                     f"Download {download_id} completed successfully: {result.file_path}"
                 )
+                # #370: notify webhook subscribers (Discord/Apprise/generic)
+                # now that the DB reflects the video as downloaded -- never
+                # fire before the DB update, or a notification could arrive
+                # for a video the DB doesn't yet show as downloaded.
+                trigger_video_downloaded(
+                    {
+                        "id": context.video_id,
+                        "title": context.title,
+                        "artist_name": context.artist,
+                    }
+                )
             else:
                 self._update_database_failure(context.video_id, result.error_message)
                 logger.error(f"Download {download_id} failed: {result.error_message}")
+                trigger_video_download_failed(
+                    {
+                        "id": context.video_id,
+                        "title": context.title,
+                        "artist_name": context.artist,
+                    },
+                    result.error_message,
+                )
 
             # Execute callbacks
             for callback in self.download_callbacks.get(download_id, []):
@@ -642,6 +665,14 @@ class UnifiedDownloadService:
         except Exception as e:
             logger.error(f"Download {download_id} exception: {e}")
             self._update_database_failure(context.video_id, str(e))
+            trigger_video_download_failed(
+                {
+                    "id": context.video_id,
+                    "title": context.title,
+                    "artist_name": context.artist,
+                },
+                str(e),
+            )
 
         finally:
             # Cleanup

--- a/tests/unit/test_webhook_events_wired.py
+++ b/tests/unit/test_webhook_events_wired.py
@@ -1,0 +1,97 @@
+"""Regression/feature test for #370: webhook events were never actually
+triggered by real application activity -- webhook_service.py defines 17
+trigger_* convenience functions with zero call sites anywhere else in
+src/. This wires the three highest-value, unambiguous ones (per the
+brainstorming conversation): video.downloaded, video.download_failed
+(both in UnifiedDownloadService._execute_download(), the one real
+download orchestration point), and artist.added (in create_artist()).
+download.started/completed/failed and the remaining 12 event types are
+deliberately deferred -- see the issue for the full scope discussion.
+
+Static source-text assertions rather than real function calls, for two
+different environmental reasons per file:
+
+- unified_download_service.py cannot be imported at all in this test
+  venv: it instantiates a module-level UnifiedDownloadService() singleton
+  that requires a real yt-dlp binary (RuntimeError: yt-dlp executable
+  not found) -- the same root cause as the 4 pre-existing environmentally
+  broken test files this session's test runs already exclude.
+- create_artist() has heavy SQLAlchemy session / auto-processing-service
+  dependencies with no existing mocking precedent in this test suite to
+  build a real behavioral test against without substantial new
+  infrastructure disproportionate to a one-line trigger call.
+"""
+
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+
+
+class TestVideoDownloadEventsWired:
+    def setup_method(self):
+        self.source = (SRC_DIR / "services" / "unified_download_service.py").read_text()
+
+    def test_imports_the_trigger_functions(self):
+        assert "trigger_video_downloaded" in self.source
+        assert "trigger_video_download_failed" in self.source
+
+    def test_success_path_triggers_video_downloaded_after_db_update(self):
+        # _update_database_success() marks the video DOWNLOADED in the DB;
+        # the trigger call must come after that, not before, so a
+        # notification never fires for a video the DB doesn't yet show
+        # as downloaded.
+        marker = "self._update_database_success(context.video_id, result)"
+        start = self.source.index(marker)
+        # Look at the ~15 lines following the DB update for the trigger call.
+        window = self.source[start : start + 600]
+        assert "trigger_video_downloaded(" in window
+
+    def test_failure_path_triggers_video_download_failed(self):
+        # Both failure call sites in _execute_download(): the normal
+        # (result.success is False) path and the caught-exception path.
+        failure_markers = [
+            m for m in self.source.split("_update_database_failure(")[1:]
+        ]
+        assert len(failure_markers) >= 2, (
+            "expected both the normal-failure and exception-path calls "
+            "to _update_database_failure() to be present"
+        )
+        # trigger_video_download_failed must appear at least twice --
+        # once following each _update_database_failure() call site.
+        assert self.source.count("trigger_video_download_failed(") >= 2
+
+    def test_triggered_video_data_includes_title_and_artist_name(self):
+        # Discord/Apprise's description-building both read data["title"]
+        # and data["artist_name"] specifically (not e.g. "artist") --
+        # confirmed against discord_notification_formatter.py's
+        # _description_for().
+        start = self.source.index("trigger_video_downloaded(")
+        end = self.source.index(")", start)
+        call_site = self.source[start : end + 1]
+        assert '"title"' in call_site
+        assert '"artist_name"' in call_site
+
+
+class TestArtistAddedEventWired:
+    def setup_method(self):
+        self.source = (SRC_DIR / "api" / "fastapi" / "artists_crud.py").read_text()
+
+    def test_imports_the_trigger_function(self):
+        assert "trigger_artist_added" in self.source
+
+    def test_fires_after_commit_not_before(self):
+        # Firing before session.commit() would notify about an artist
+        # that a concurrent failure could still roll back.
+        commit_index = self.source.index(
+            "session.commit()", self.source.index("def create_artist")
+        )
+        trigger_index = self.source.index(
+            "trigger_artist_added(", self.source.index("def create_artist")
+        )
+        assert trigger_index > commit_index
+
+    def test_triggered_artist_data_includes_name(self):
+        start = self.source.index("trigger_artist_added(")
+        end = self.source.index(")", start)
+        call_site = self.source[start : end + 1]
+        assert '"name"' in call_site


### PR DESCRIPTION
## Summary

`webhook_service.py` defines 17 `trigger_*` convenience functions with zero call sites anywhere else in `src/` — the only way `trigger_event()` ever fired was the manual `POST /api/webhooks/trigger` test endpoint. A user who configured a Discord/Apprise/generic endpoint and subscribed to `video.downloaded` would never actually receive a notification, no matter how many real downloads completed.

Wires the three highest-value, unambiguous events:

- **`video.downloaded` / `video.download_failed`** — both in `UnifiedDownloadService._execute_download()`, the one real download orchestration point (success, normal-failure, and exception-failure paths), fired only *after* the DB update so a notification can't arrive for a video the DB doesn't yet reflect as downloaded.
- **`artist.added`** — in `create_artist()`, fired only after `session.commit()` so a notification can't arrive for an artist a concurrent failure still rolled back.

## Scope decisions (from brainstorming, not assumed)

- `download.started/completed/failed` deliberately **not** wired — tracing the actual code found only one real orchestration point per download, not the "grab vs import" split those event types seem to have been designed around. Rather than guess an interpretation, only the `video.*` events (the ones people actually asked for in #315) are wired for now.
- `system.error` deliberately deferred — no natural single call site exists (no global exception handler in the app today), and "a system error" could mean many different things. Left for a follow-up once there's a concrete definition.
- The remaining 12 event types (artist/video updated/deleted, playlist sync, external import, system health) are out of scope for this pass — curated subset first, per explicit decision.

Closes #370.

## Testing

New `tests/unit/test_webhook_events_wired.py` (7 tests). Static source-assertion style rather than executing the real functions, for two environment-specific reasons: `unified_download_service.py` can't be imported at all in the test venv (module-level singleton requires a real `yt-dlp` binary — same root cause as this session's other pre-existing excluded test files), and `create_artist()` has heavy DB/service dependencies with no existing mocking precedent to build against cheaply.

Full suite: 255 passed. Live-verified: both modules import cleanly against the real `mvidarr-dev` container (which has a working `yt-dlp`, unlike the local test venv), and the full app restarts healthy with these changes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)