### PR TITLE
fix(downloads): duplicate concurrent download dispatch race condition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ curl -X POST http://localhost:5001/api/videos/123/extract-ffmpeg-metadata
   - ✅ Native Discord and Apprise notification providers, wired to real download/artist activity (not just a manual test endpoint)
   - ✅ "Recently Found" videos view, live artist thumbnail sourcing (Spotify/Last.fm before Wikipedia)
   - ✅ Numerous live-testing bug fixes: 2FA audit logging, OAuth callback error handling, Videos-page pagination dropping active filters, webhook URL credential logging, header username display, Edit Webhook modal scroll
+  - ✅ Fix (#329): closed a duplicate-concurrent-download-dispatch race — `bulk_download_wanted_videos()` (FastAPI) and `download_all_wanted_videos_internal()` (Celery) could both dispatch the same WANTED video, with the loser silently overwriting the winner's result (including a real successful download getting overwritten back to FAILED) and firing a false download-failed webhook. Fixed via a new atomic `claim_video_for_download()` helper (row-locked `UPDATE ... WHERE status='WANTED'`) plus a defensive already-DOWNLOADED guard (which had shipped as dead code due to an enum-vs-string `.value` comparison bug, caught and fixed in final review) that also suppresses the false webhook
   - See GitHub milestone "v1.0.0" for the complete issue list
 - **v0.12.19** (2026-08-13): Recently Found Videos View
   - ✅ Feature: "Recently Found" one-click view on Videos page (#316) — shows all videos sorted by date_added desc, regardless of status, via a new button + shareable deep-link URL (`?sort_by=date_added&sort_order=desc&status=`)

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -646,12 +646,16 @@ async def bulk_download_wanted_videos(
                 session.add(download)
                 session.flush()  # Ensure download.id is available
 
-                # video.status is already DOWNLOADING -- claim_video_for_download()
-                # set and committed it above. Refresh the in-memory object so
-                # later code in this loop iteration (and the final bulk
-                # session.commit()) sees the current value rather than a
-                # stale pre-claim copy.
-                session.refresh(video)
+                # video.status is already DOWNLOADING, committed by
+                # claim_video_for_download() above. We never reassign
+                # video.status anywhere in this loop after the claim, so
+                # SQLAlchemy's dirty-tracking emits no UPDATE for it at
+                # this function's final session.commit() -- the claim
+                # can't be stomped. (A session.refresh() here would not
+                # even see the post-claim value under MariaDB's default
+                # REPEATABLE READ isolation, since this outer session's
+                # snapshot predates the claim -- confirmed during final
+                # review, not worth the round-trip either way.)
 
                 # Create background job for download processing via ytdlp_service
                 try:

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -25,6 +25,7 @@ from src.api.fastapi.auth_dependencies import get_current_user
 from src.api.fastapi.videos_models import BulkDownloadRequest
 from src.database.connection import get_db_session
 from src.database.models import Artist, Download, Video, VideoStatus
+from src.services.video_batch_service import claim_video_for_download
 from src.utils.logger import get_logger
 
 router = APIRouter()
@@ -614,6 +615,16 @@ async def bulk_download_wanted_videos(
                     skipped_count += 1
                     continue
 
+                # Atomically claim this video before dispatching (#329) --
+                # download_all_wanted_videos_internal() (the Celery-side
+                # equivalent of this function) can run concurrently and
+                # select the same WANTED video; only one of them may win.
+                # A failed claim means another process already has it --
+                # a normal, healthy skip, not an error.
+                if not claim_video_for_download(video.id):
+                    skipped_count += 1
+                    continue
+
                 # Create download entry
                 download = Download(
                     artist_id=video.artist_id,
@@ -635,9 +646,12 @@ async def bulk_download_wanted_videos(
                 session.add(download)
                 session.flush()  # Ensure download.id is available
 
-                # Update video status to downloading/queued
-                video.status = VideoStatus.DOWNLOADING
-                video.updated_at = datetime.utcnow()
+                # video.status is already DOWNLOADING -- claim_video_for_download()
+                # set and committed it above. Refresh the in-memory object so
+                # later code in this loop iteration (and the final bulk
+                # session.commit()) sees the current value rather than a
+                # stale pre-claim copy.
+                session.refresh(video)
 
                 # Create background job for download processing via ytdlp_service
                 try:

--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -644,16 +644,24 @@ class UnifiedDownloadService:
                     }
                 )
             else:
-                self._update_database_failure(context.video_id, result.error_message)
-                logger.error(f"Download {download_id} failed: {result.error_message}")
-                trigger_video_download_failed(
-                    {
-                        "id": context.video_id,
-                        "title": context.title,
-                        "artist_name": context.artist,
-                    },
-                    result.error_message,
+                wrote_failure = self._update_database_failure(
+                    context.video_id, result.error_message
                 )
+                logger.error(f"Download {download_id} failed: {result.error_message}")
+                # #329: only notify subscribers if the failure was actually
+                # written -- the already-DOWNLOADED guard in
+                # _update_database_failure() suppresses stale duplicate-
+                # dispatch failures, and firing this webhook anyway would
+                # falsely report a DOWNLOADED video as failed.
+                if wrote_failure:
+                    trigger_video_download_failed(
+                        {
+                            "id": context.video_id,
+                            "title": context.title,
+                            "artist_name": context.artist,
+                        },
+                        result.error_message,
+                    )
 
             # Execute callbacks
             for callback in self.download_callbacks.get(download_id, []):
@@ -664,15 +672,18 @@ class UnifiedDownloadService:
 
         except Exception as e:
             logger.error(f"Download {download_id} exception: {e}")
-            self._update_database_failure(context.video_id, str(e))
-            trigger_video_download_failed(
-                {
-                    "id": context.video_id,
-                    "title": context.title,
-                    "artist_name": context.artist,
-                },
-                str(e),
-            )
+            wrote_failure = self._update_database_failure(context.video_id, str(e))
+            # #329: same gating as the normal-failure path above -- don't
+            # notify subscribers for a no-op failure write.
+            if wrote_failure:
+                trigger_video_download_failed(
+                    {
+                        "id": context.video_id,
+                        "title": context.title,
+                        "artist_name": context.artist,
+                    },
+                    str(e),
+                )
 
         finally:
             # Cleanup
@@ -940,8 +951,17 @@ class UnifiedDownloadService:
         except Exception as e:
             logger.error(f"Database success update failed: {e}", exc_info=True)
 
-    def _update_database_failure(self, video_id: int, error_message: str):
-        """Update database on failed download"""
+    def _update_database_failure(self, video_id: int, error_message: str) -> bool:
+        """Update database on failed download.
+
+        Returns True if a failure was actually written (video status
+        flipped to FAILED / Download row recorded), False if this call
+        was a no-op -- either the video wasn't found, or the #329
+        already-DOWNLOADED guard below suppressed it. Callers (see
+        _execute_download()) must gate trigger_video_download_failed()
+        on this return value: firing that webhook for a no-op write
+        would falsely notify that a DOWNLOADED video failed.
+        """
         try:
             from src.database.connection import get_db
             from src.database.models import Download, Video, VideoStatus
@@ -958,12 +978,12 @@ class UnifiedDownloadService:
                     # if some other, not-yet-identified path ever manages
                     # to dispatch a duplicate download for an
                     # already-succeeded video.
-                    if video.status == VideoStatus.DOWNLOADED.value:
+                    if video.status == VideoStatus.DOWNLOADED:
                         logger.warning(
                             f"Ignoring stale failure for video {video_id} "
                             f"(already DOWNLOADED): {error_message}"
                         )
-                        return
+                        return False
 
                     video.status = VideoStatus.FAILED.value
 
@@ -1004,8 +1024,11 @@ class UnifiedDownloadService:
                         )
 
                     session.commit()
+                    return True
+                return False
         except Exception as e:
             logger.error(f"Database failure update failed: {e}", exc_info=True)
+            return False
 
     def get_active_downloads(self) -> Dict[int, str]:
         """Get currently active downloads"""

--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -950,6 +950,21 @@ class UnifiedDownloadService:
                 # Update video status
                 video = session.query(Video).filter(Video.id == video_id).first()
                 if video:
+                    # #329: a video already confirmed DOWNLOADED must never
+                    # be downgraded by a failure -- this is exactly the
+                    # scenario claim_video_for_download() (video_batch_service.py)
+                    # closes the *source* of, but this check is an
+                    # independent safety net: it protects correctness even
+                    # if some other, not-yet-identified path ever manages
+                    # to dispatch a duplicate download for an
+                    # already-succeeded video.
+                    if video.status == VideoStatus.DOWNLOADED.value:
+                        logger.warning(
+                            f"Ignoring stale failure for video {video_id} "
+                            f"(already DOWNLOADED): {error_message}"
+                        )
+                        return
+
                     video.status = VideoStatus.FAILED.value
 
                     # Create or update Download record with error message

--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import subprocess
+from datetime import datetime
 from typing import Dict, List, Optional
 
 from src.database.connection import get_db
@@ -16,6 +17,46 @@ from src.database.models import Artist, Video, VideoStatus
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.services.video_batch")
+
+
+def claim_video_for_download(video_id: int) -> bool:
+    """Atomically claim a WANTED video for download by flipping its
+    status to DOWNLOADING, but only if it is still WANTED (#329).
+
+    Two independently-implemented "download all wanted videos" functions
+    exist in this codebase (this module's download_all_wanted_videos_internal
+    and videos_downloads.py's bulk_download_wanted_videos), reachable
+    concurrently from a Celery worker and a FastAPI background thread --
+    separate OS processes with no shared memory. Without an atomic claim,
+    both can select and dispatch the same video, and whichever process's
+    result writes last silently wins, regardless of which one was
+    actually correct.
+
+    Returns True if this caller won the claim (the video was WANTED and
+    is now DOWNLOADING), False if it wasn't WANTED to begin with, doesn't
+    exist, or a concurrent caller already claimed it. MariaDB/MySQL's
+    row-level locking makes this correct under concurrency: two callers
+    racing on the same row serialize at the database level, and the
+    loser's WHERE clause re-evaluates against the now-committed
+    DOWNLOADING value, matching zero rows.
+
+    Must be called -- and its result checked -- before dispatching a
+    download, never after.
+    """
+    from sqlalchemy import update
+
+    try:
+        with get_db() as session:
+            result = session.execute(
+                update(Video)
+                .where(Video.id == video_id, Video.status == VideoStatus.WANTED)
+                .values(status=VideoStatus.DOWNLOADING, updated_at=datetime.utcnow())
+            )
+            session.commit()
+            return result.rowcount == 1
+    except Exception as e:
+        logger.error(f"Failed to claim video {video_id} for download: {e}")
+        return False
 
 
 def get_ytdlp_path() -> str:

--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -250,10 +250,30 @@ def download_all_wanted_videos_internal(
                         failed_count += 1
                         continue
 
+                    # Atomically claim this video before dispatching (#329)
+                    # -- bulk_download_wanted_videos() (the manual-trigger
+                    # equivalent of this function) can run concurrently and
+                    # select the same WANTED video; only one of them may
+                    # win. A failed claim means another process already has
+                    # it -- report as skipped, not failed, and move on.
+                    if not claim_video_for_download(video_id):
+                        results.append(
+                            {
+                                "video_id": video_id,
+                                "title": video_title,
+                                "artist": artist_name,
+                                "success": False,
+                                "skipped": True,
+                                "error": "Already claimed by another download process",
+                            }
+                        )
+                        continue
+
                     # Import yt-dlp service
                     from src.services.download_service_adapter import ytdlp_service
 
-                    # Queue download
+                    # Queue download -- video.status is already DOWNLOADING,
+                    # set and committed by claim_video_for_download() above.
                     result = ytdlp_service.add_music_video_download(
                         artist=artist_name,
                         title=video_title,
@@ -265,10 +285,6 @@ def download_all_wanted_videos_internal(
                     )
 
                     if result and result.get("success"):
-                        # Update the video status in a separate transaction
-                        video.status = VideoStatus.DOWNLOADING
-                        session.commit()
-
                         results.append(
                             {
                                 "video_id": video_id,

--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -42,17 +42,33 @@ def claim_video_for_download(video_id: int) -> bool:
 
     Must be called -- and its result checked -- before dispatching a
     download, never after.
+
+    Deliberately does NOT use get_db() here: get_db() wraps a
+    thread-local scoped_session, and both current callers
+    (bulk_download_wanted_videos() and
+    download_all_wanted_videos_internal()) already hold their own
+    get_db() session open on the same thread when they call this. A
+    nested get_db() call can silently resolve to that *same* underlying
+    Session object, and this function's own commit()/close() would then
+    tear down the caller's session mid-iteration. Using a dedicated
+    engine connection/transaction instead makes this function immune to
+    whatever session state its caller happens to hold (#329 final
+    review).
     """
     from sqlalchemy import update
 
+    import src.database.connection as db_connection
+
     try:
-        with get_db() as session:
-            result = session.execute(
+        if db_connection.db_manager is None:
+            db_connection.init_db_standalone()
+        engine = db_connection.db_manager.create_engine()
+        with engine.begin() as conn:
+            result = conn.execute(
                 update(Video)
                 .where(Video.id == video_id, Video.status == VideoStatus.WANTED)
                 .values(status=VideoStatus.DOWNLOADING, updated_at=datetime.utcnow())
             )
-            session.commit()
             return result.rowcount == 1
     except Exception as e:
         logger.error(f"Failed to claim video {video_id} for download: {e}")
@@ -165,6 +181,7 @@ def download_all_wanted_videos_internal(
         results = []
         success_count = 0
         failed_count = 0
+        skipped_count = 0
         wanted_video_ids = []
 
         # Import settings service for subtitle configuration
@@ -209,6 +226,7 @@ def download_all_wanted_videos_internal(
                     "message": "No wanted videos found",
                     "success_count": 0,
                     "failed_count": 0,
+                    "skipped_count": 0,
                     "results": [],
                 }
 
@@ -216,6 +234,7 @@ def download_all_wanted_videos_internal(
 
         # Process each video individually to avoid session issues
         for video_id, video_title, artist_name in wanted_video_ids:
+            claimed = False
             try:
                 with get_db() as session:
                     # Get fresh video object for each download
@@ -267,7 +286,9 @@ def download_all_wanted_videos_internal(
                                 "error": "Already claimed by another download process",
                             }
                         )
+                        skipped_count += 1
                         continue
+                    claimed = True
 
                     # Import yt-dlp service
                     from src.services.download_service_adapter import ytdlp_service
@@ -297,6 +318,16 @@ def download_all_wanted_videos_internal(
                         )
                         success_count += 1
                     else:
+                        # #329: the claim above already committed
+                        # DOWNLOADING -- dispatch then failed (falsy
+                        # result), so revert to WANTED here or this video
+                        # is stuck at DOWNLOADING forever: invisible to
+                        # every status == WANTED query, never retried by
+                        # the next scheduled run. Matches the
+                        # revert-on-dispatch-failure precedent in
+                        # videos_downloads.py.
+                        video.status = VideoStatus.WANTED
+                        session.commit()
                         results.append(
                             {
                                 "video_id": video_id,
@@ -310,6 +341,29 @@ def download_all_wanted_videos_internal(
 
             except Exception as e:
                 logger.error(f"Failed to process video {video_id} ({video_title}): {e}")
+                if claimed:
+                    # #329: the claim committed DOWNLOADING before this
+                    # exception was raised -- the `with get_db() as
+                    # session` block above has already rolled back and
+                    # closed on the way out, so revert with a fresh
+                    # session rather than reusing it. Same
+                    # stuck-forever concern as the dispatch-failure
+                    # branch above.
+                    try:
+                        with get_db() as revert_session:
+                            revert_video = (
+                                revert_session.query(Video)
+                                .filter(Video.id == video_id)
+                                .first()
+                            )
+                            if revert_video:
+                                revert_video.status = VideoStatus.WANTED
+                                revert_session.commit()
+                    except Exception as revert_error:
+                        logger.error(
+                            f"Failed to revert video {video_id} to WANTED "
+                            f"after dispatch exception: {revert_error}"
+                        )
                 results.append(
                     {
                         "video_id": video_id,
@@ -323,9 +377,10 @@ def download_all_wanted_videos_internal(
 
         return {
             "success": True,
-            "message": f"Processed {len(wanted_video_ids)} videos: {success_count} succeeded, {failed_count} failed",
+            "message": f"Processed {len(wanted_video_ids)} videos: {success_count} succeeded, {failed_count} failed, {skipped_count} skipped",
             "success_count": success_count,
             "failed_count": failed_count,
+            "skipped_count": skipped_count,
             "results": results,
         }
 
@@ -336,6 +391,7 @@ def download_all_wanted_videos_internal(
             "error": str(e),
             "success_count": 0,
             "failed_count": 0,
+            "skipped_count": 0,
             "results": [],
         }
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for tests/unit/.
+
+Currently provides one thing: a real, temp-file SQLite database wired
+transparently behind `src.database.connection.get_db()` for
+`test_claim_video_for_download.py` (#329). That test module intentionally
+calls the *real*, unpatched `get_db()` (see its docstring — it wants a
+real database, not mocks), but this repo's `Config`/`DatabaseManager`
+only ever build a `mysql+pymysql://` URL, and no MySQL/MariaDB server is
+reachable from this sandboxed test environment (the dev stack's mariadb
+container publishes no host port). Rather than have that test module
+silently require infrastructure that isn't there, this fixture swaps the
+module-level `db_manager` singleton in `src.database.connection` for one
+backed by a throwaway SQLite file for the duration of that module only,
+then restores it. Every other test module is unaffected -- most already
+patch `get_db`/`get_db_session` themselves and none rely on this file.
+"""
+
+import os
+import tempfile
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import src.database.connection as connection
+from src.database.models import Artist, Video
+
+# Test modules that want a real (unpatched) get_db() backed by a real DB.
+_REAL_DB_MODULES = {"test_claim_video_for_download.py"}
+
+
+@pytest.fixture(autouse=True)
+def _wire_real_sqlite_db(request, monkeypatch):
+    if request.node.fspath.basename not in _REAL_DB_MODULES:
+        yield
+        return
+
+    db_fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(db_fd)
+    engine = create_engine(f"sqlite:///{db_path}")
+    connection.Base.metadata.create_all(
+        engine, tables=[Artist.__table__, Video.__table__]
+    )
+    # expire_on_commit=False: the wanted_video fixture in
+    # test_claim_video_for_download.py reads `artist.id` in its teardown
+    # block, after the setup `with get_db()` session (where `artist` was
+    # created) has already committed and closed. With the default
+    # expire_on_commit=True -- which this codebase's real
+    # DatabaseManager.create_session_factory() also uses, unchanged here
+    # -- that attribute access raises DetachedInstanceError because the
+    # object's attributes are expired on commit and there's no session
+    # left to reload them from. Disabling it only in this test shim keeps
+    # already-loaded attribute values cached on the Python object across
+    # the session boundary, which is what the fixture assumes.
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _fake_get_session():
+        session = session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    class _FakeDbManager:
+        def get_session(self):
+            return _fake_get_session()
+
+    monkeypatch.setattr(connection, "db_manager", _FakeDbManager())
+
+    yield
+
+    engine.dispose()
+    os.remove(db_path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,10 @@ import src.database.connection as connection
 from src.database.models import Artist, Video
 
 # Test modules that want a real (unpatched) get_db() backed by a real DB.
-_REAL_DB_MODULES = {"test_claim_video_for_download.py"}
+_REAL_DB_MODULES = {
+    "test_claim_video_for_download.py",
+    "test_failure_write_protects_downloaded_status.py",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +73,14 @@ def _wire_real_sqlite_db(request, monkeypatch):
     class _FakeDbManager:
         def get_session(self):
             return _fake_get_session()
+
+        def create_engine(self):
+            # claim_video_for_download() (#329) deliberately uses its own
+            # engine connection/transaction instead of get_db()'s scoped
+            # session -- see that function's docstring. Return the same
+            # engine backing get_session() above so both routes see the
+            # same SQLite-backed data.
+            return engine
 
     monkeypatch.setattr(connection, "db_manager", _FakeDbManager())
 

--- a/tests/unit/test_bulk_download_claims_before_dispatch.py
+++ b/tests/unit/test_bulk_download_claims_before_dispatch.py
@@ -1,0 +1,45 @@
+"""Regression/feature test for #329: bulk_download_wanted_videos() must
+atomically claim each video (claim_video_for_download()) before
+dispatching it, and must skip (not error) a video whose claim fails --
+matching download_all_wanted_videos_internal()'s equivalent fix in the
+same plan.
+"""
+
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "api" / "fastapi"
+
+
+class TestBulkDownloadClaimsBeforeDispatch:
+    def setup_method(self):
+        self.source = (SRC_DIR / "videos_downloads.py").read_text()
+
+    def _function_body(self, name):
+        start = self.source.index(f"async def {name}(")
+        # Next top-level "async def " or "def " after this one marks the end.
+        # Falls back to end-of-file when this is the last function defined
+        # (as bulk_download_wanted_videos currently is in this module).
+        try:
+            next_def = self.source.index("\nasync def ", start + 10)
+        except ValueError:
+            next_def = len(self.source)
+        return self.source[start:next_def]
+
+    def test_calls_claim_video_for_download(self):
+        body = self._function_body("bulk_download_wanted_videos")
+        assert "claim_video_for_download(" in body
+
+    def test_claim_happens_before_the_dispatch_call(self):
+        body = self._function_body("bulk_download_wanted_videos")
+        claim_index = body.index("claim_video_for_download(")
+        dispatch_index = body.index("ytdlp_service.add_music_video_download(")
+        assert claim_index < dispatch_index
+
+    def test_a_failed_claim_increments_skipped_not_errors(self):
+        body = self._function_body("bulk_download_wanted_videos")
+        claim_index = body.index("claim_video_for_download(")
+        # The nearest "if not <claim result>:" branch after the claim call
+        # should touch skipped_count, not errors.append, within a small
+        # window (the immediate handling of a failed claim).
+        window = body[claim_index : claim_index + 400]
+        assert "skipped_count" in window

--- a/tests/unit/test_claim_video_for_download.py
+++ b/tests/unit/test_claim_video_for_download.py
@@ -1,0 +1,79 @@
+"""Regression/feature test for #329: two independently-implemented
+"download all wanted videos" functions (bulk_download_wanted_videos() in
+videos_downloads.py, download_all_wanted_videos_internal() in this same
+module) could both select and dispatch the same WANTED video
+concurrently -- one via a FastAPI background thread, one via a Celery
+worker (a separate OS process) -- with no coordination. Whichever
+finished writing last won, so a genuine success could be silently
+overwritten by a stale duplicate-dispatch failure.
+
+claim_video_for_download() closes the race: a single atomic
+UPDATE ... WHERE status = 'WANTED' that only one concurrent caller can
+ever win. Real behavioral tests against a real (SQLite-backed) DB, not
+mocks -- video_batch_service.py imports cleanly in this test venv
+(unlike unified_download_service.py, which has a module-level
+yt-dlp-dependent singleton).
+"""
+
+import pytest
+
+from src.database.connection import get_db
+from src.database.models import Artist, Video, VideoStatus
+from src.services.video_batch_service import claim_video_for_download
+
+
+@pytest.fixture
+def wanted_video():
+    """Creates a real WANTED video row, yields its id, cleans up after."""
+    with get_db() as session:
+        artist = Artist(name="Test Artist For Claim")
+        session.add(artist)
+        session.flush()
+        video = Video(
+            artist_id=artist.id,
+            title="Test Video For Claim",
+            status=VideoStatus.WANTED,
+        )
+        session.add(video)
+        session.commit()
+        video_id = video.id
+    yield video_id
+    with get_db() as session:
+        session.query(Video).filter(Video.id == video_id).delete()
+        session.query(Artist).filter(Artist.id == artist.id).delete()
+        session.commit()
+
+
+class TestClaimVideoForDownload:
+    def test_claims_a_wanted_video(self, wanted_video):
+        result = claim_video_for_download(wanted_video)
+        assert result is True
+
+        with get_db() as session:
+            video = session.query(Video).filter(Video.id == wanted_video).first()
+            assert video.status == VideoStatus.DOWNLOADING
+
+    def test_second_claim_on_the_same_video_fails(self, wanted_video):
+        first = claim_video_for_download(wanted_video)
+        second = claim_video_for_download(wanted_video)
+
+        assert first is True
+        assert second is False
+
+    def test_returns_false_for_a_video_that_is_not_wanted(self, wanted_video):
+        with get_db() as session:
+            video = session.query(Video).filter(Video.id == wanted_video).first()
+            video.status = VideoStatus.DOWNLOADED
+            session.commit()
+
+        result = claim_video_for_download(wanted_video)
+
+        assert result is False
+        with get_db() as session:
+            video = session.query(Video).filter(Video.id == wanted_video).first()
+            # Must not have been touched -- still DOWNLOADED, not DOWNLOADING.
+            assert video.status == VideoStatus.DOWNLOADED
+
+    def test_returns_false_for_a_nonexistent_video(self):
+        result = claim_video_for_download(999999999)
+        assert result is False

--- a/tests/unit/test_failure_write_protects_downloaded_status.py
+++ b/tests/unit/test_failure_write_protects_downloaded_status.py
@@ -6,12 +6,33 @@ dispatch (see claim_video_for_download() and its two call sites, added
 earlier in this same plan) could silently erase a real, already-persisted
 success.
 
-Static source-assertion test -- unified_download_service.py cannot be
-imported in this test venv (module-level yt-dlp-dependent singleton,
-same constraint as #370's tests for this file).
+The static source-assertion tests below cannot catch every bug in this
+guard -- notably they passed against a version of the guard that compared
+`video.status == VideoStatus.DOWNLOADED.value`, which is *always False*:
+`Video.status` is `Column(SQLEnum(VideoStatus))` and `VideoStatus` is a
+plain `Enum` (not a `str` mixin), so SQLAlchemy hydrates the attribute as
+a `VideoStatus` *member*, never a string. That made the entire guard dead
+code -- it could never fire. `TestDownloadedStatusComparisonBugClass`
+below is a real, DB-backed behavioral test added specifically to catch
+that class of bug: it evaluates the actual guard expression currently
+present in the source file against a genuinely ORM-hydrated `Video` row
+(status set via a committed session, exactly the way
+_update_database_failure()'s own query would load it -- not a raw string
+assignment).
+
+unified_download_service.py itself still cannot be imported in this test
+venv (module-level yt-dlp-dependent singleton, same constraint as #370's
+tests for this file), which is why the guard expression is evaluated out
+of the source text rather than by calling the real function directly.
 """
 
+import re
 from pathlib import Path
+
+import pytest
+
+from src.database.connection import get_db
+from src.database.models import Artist, Video, VideoStatus
 
 SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "services"
 
@@ -27,10 +48,89 @@ class TestFailureWriteProtectsDownloadedStatus:
 
     def test_checks_current_status_before_writing(self):
         body = self._function_body("_update_database_failure")
-        assert "VideoStatus.DOWNLOADED.value" in body
+        assert "if video.status == VideoStatus.DOWNLOADED:" in body
 
     def test_the_downloaded_check_happens_before_any_status_or_download_row_write(self):
         body = self._function_body("_update_database_failure")
-        check_index = body.index("VideoStatus.DOWNLOADED.value")
+        check_index = body.index("if video.status == VideoStatus.DOWNLOADED:")
         status_write_index = body.index("video.status = VideoStatus.FAILED.value")
         assert check_index < status_write_index
+
+
+@pytest.fixture
+def downloaded_video():
+    """A real, committed DOWNLOADED video row -- hydrated by the ORM the
+    same way _update_database_failure()'s own query would load it, not a
+    raw string assignment.
+    """
+    with get_db() as session:
+        artist = Artist(name="Test Artist For Failure Guard")
+        session.add(artist)
+        session.flush()
+        video = Video(
+            artist_id=artist.id,
+            title="Test Video For Failure Guard",
+            status=VideoStatus.DOWNLOADED,
+        )
+        session.add(video)
+        session.commit()
+        video_id = video.id
+        artist_id = artist.id
+    yield video_id
+    with get_db() as session:
+        session.query(Video).filter(Video.id == video_id).delete()
+        session.query(Artist).filter(Artist.id == artist_id).delete()
+        session.commit()
+
+
+class TestDownloadedStatusComparisonBugClass:
+    """Directly proves the comparison bug class Finding 1 describes,
+    against a real SQLite-backed, ORM-hydrated Video row.
+    """
+
+    def _guard_expression(self):
+        source = (SRC_DIR / "unified_download_service.py").read_text()
+        start = source.index("def _update_database_failure(")
+        body = source[start : source.index("\n    def ", start + 10)]
+        match = re.search(
+            r"if (video\.status == VideoStatus\.DOWNLOADED(?:\.value)?):", body
+        )
+        assert (
+            match
+        ), "Could not locate the DOWNLOADED guard in _update_database_failure()"
+        return match.group(1)
+
+    def test_real_hydrated_downloaded_video_satisfies_the_actual_source_guard(
+        self, downloaded_video
+    ):
+        """Evaluates the *actual guard expression currently in the source
+        file* against a real, ORM-hydrated DOWNLOADED video. Fails
+        against the buggy `.value`-suffixed comparison (which is always
+        False), passes once Finding 1's fix drops the `.value` suffix.
+        """
+        with get_db() as session:
+            video = session.query(Video).filter(Video.id == downloaded_video).first()
+            assert video.status is VideoStatus.DOWNLOADED  # sanity: real ORM hydration
+
+            expr = self._guard_expression()
+            # eval() is safe here: `expr` is not external/untrusted input --
+            # it's a substring matched by a fixed regex out of this repo's
+            # own source file, deliberately re-evaluated (rather than
+            # reimplemented) so this test tracks the guard's real text.
+            result = eval(expr, {"video": video, "VideoStatus": VideoStatus})
+
+            assert result is True, (
+                f"_update_database_failure()'s guard expression `{expr}` "
+                "evaluated False against a real DOWNLOADED video -- the "
+                "safety net cannot fire (Finding 1)."
+            )
+
+    def test_the_value_suffixed_comparison_is_always_false(self, downloaded_video):
+        """Directly demonstrates the bug class: comparing the hydrated
+        enum member against VideoStatus.DOWNLOADED.value's plain string
+        is never True, no matter the row's actual status -- while the
+        bare-member comparison correctly reflects it."""
+        with get_db() as session:
+            video = session.query(Video).filter(Video.id == downloaded_video).first()
+            assert (video.status == VideoStatus.DOWNLOADED) is True
+            assert (video.status == VideoStatus.DOWNLOADED.value) is False

--- a/tests/unit/test_failure_write_protects_downloaded_status.py
+++ b/tests/unit/test_failure_write_protects_downloaded_status.py
@@ -1,0 +1,36 @@
+"""Regression/feature test for #329: _update_database_failure() set
+video.status = FAILED and overwrote the most recent Download row
+unconditionally, with no check for whether the video already reached a
+terminal DOWNLOADED state. A late-arriving failure from a duplicate
+dispatch (see claim_video_for_download() and its two call sites, added
+earlier in this same plan) could silently erase a real, already-persisted
+success.
+
+Static source-assertion test -- unified_download_service.py cannot be
+imported in this test venv (module-level yt-dlp-dependent singleton,
+same constraint as #370's tests for this file).
+"""
+
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "services"
+
+
+class TestFailureWriteProtectsDownloadedStatus:
+    def setup_method(self):
+        self.source = (SRC_DIR / "unified_download_service.py").read_text()
+
+    def _function_body(self, name):
+        start = self.source.index(f"def {name}(")
+        next_def = self.source.index("\n    def ", start + 10)
+        return self.source[start:next_def]
+
+    def test_checks_current_status_before_writing(self):
+        body = self._function_body("_update_database_failure")
+        assert "VideoStatus.DOWNLOADED.value" in body
+
+    def test_the_downloaded_check_happens_before_any_status_or_download_row_write(self):
+        body = self._function_body("_update_database_failure")
+        check_index = body.index("VideoStatus.DOWNLOADED.value")
+        status_write_index = body.index("video.status = VideoStatus.FAILED.value")
+        assert check_index < status_write_index

--- a/tests/unit/test_internal_download_claims_before_dispatch.py
+++ b/tests/unit/test_internal_download_claims_before_dispatch.py
@@ -1,0 +1,41 @@
+"""Regression/feature test for #329: download_all_wanted_videos_internal()
+must atomically claim each video (claim_video_for_download()) before
+dispatching it -- today it dispatches first and only updates status
+afterward, conditionally on success, meaning there is no claim attempt
+at all before the download is fired off. A failed claim must skip that
+video (not dispatch, not count as failed) and move to the next one.
+"""
+
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "services"
+
+
+class TestInternalDownloadClaimsBeforeDispatch:
+    def setup_method(self):
+        self.source = (SRC_DIR / "video_batch_service.py").read_text()
+
+    def _function_body(self, name):
+        start = self.source.index(f"def {name}(")
+        next_def = self.source.index("\ndef ", start + 10)
+        return self.source[start:next_def]
+
+    def test_calls_claim_video_for_download(self):
+        body = self._function_body("download_all_wanted_videos_internal")
+        assert "claim_video_for_download(" in body
+
+    def test_claim_happens_before_the_dispatch_call(self):
+        body = self._function_body("download_all_wanted_videos_internal")
+        claim_index = body.index("claim_video_for_download(")
+        dispatch_index = body.index("ytdlp_service.add_music_video_download(")
+        assert claim_index < dispatch_index
+
+    def test_a_failed_claim_does_not_dispatch(self):
+        body = self._function_body("download_all_wanted_videos_internal")
+        claim_index = body.index("claim_video_for_download(")
+        dispatch_index = body.index("ytdlp_service.add_music_video_download(")
+        # Between the claim and the dispatch call, there must be a
+        # "continue" (or equivalent skip) reachable when the claim fails --
+        # confirmed by requiring a "continue" to appear in that window.
+        window = body[claim_index:dispatch_index]
+        assert "continue" in window

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "build_date": "2026-08-17T15:27:53.318527",
-  "git_commit": "565b33dd",
+  "build_date": "2026-08-17T19:11:16.655781",
+  "git_commit": "1b14354a",
   "git_branch": "dev",
   "release_name": "v1.0.0 - First Production-Ready Release",
   "features": [


### PR DESCRIPTION
## Summary

Fixes the real root cause behind #329 (video 69 \"Dead Pioneers - PO\$T AMERICAN\" reported \"failed all 3 attempts\"). The original issue title (\"requested format is not available\") was misleading — live investigation via `fastapi_error.log`/`celery-worker_error.log` for that exact video found a genuine data-integrity race: the same video could be dispatched for download twice concurrently by two independent, uncoordinated code paths (a FastAPI background thread and a separate Celery worker process). Whichever finished last silently overwrote the other's result — including overwriting a real, successful 44.6MB download back to `FAILED`, and firing a false `video.download_failed` webhook.

## Two-layer fix (per approved design)

1. **Root cause**: a new `claim_video_for_download()` helper does an atomic `UPDATE ... WHERE status = 'WANTED'` + `rowcount` check, relying on MariaDB/InnoDB row locking to serialize concurrent claimants. Wired into both known dispatch paths (`bulk_download_wanted_videos()`, `download_all_wanted_videos_internal()`) so only one process can ever win the race.
2. **Defensive backstop**: `_update_database_failure()` now refuses to downgrade a video that's already `DOWNLOADED` back to `FAILED`, and suppresses the false webhook notification when it does.

## Process

Built via subagent-driven-development: 4 implementation tasks (each with its own task-scoped review), a final whole-branch review on Opus that caught a Critical dead-code bug (an enum-vs-string `.value` comparison mistake made the defensive layer inert) plus a real regression the fix itself introduced (dispatch failures after a successful claim could leave a video stuck at `DOWNLOADING` forever, with no automatic recovery), and a fix wave + scoped re-review that confirmed all 7 findings resolved with no new defects.

**Not in scope** (filed as a follow-up issue): several other download-dispatch call sites elsewhere in the codebase (`videos_downloads.py` bulk-by-IDs and single-video endpoints, `metube.py`, `videos_import.py`, `video_quality_service.py`, `workers/video_download_worker.py`) remain unprotected by this claim mechanism. The reviewer explicitly recommended not blocking this merge on it.

## Testing

- 274/274 unit tests pass, including new real (SQLite-backed) behavioral tests for the atomic claim and the enum-comparison bug class
- `black --check` / `isort --check-only` clean
- Live-verified against the `mvidarr-dev` container: fastapi + celery-worker both load the edited modules cleanly, `/health` returns 200

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)