### PR TITLE
fix(artist-page): Download Selected / Delete Selected did nothing

### DIFF
--- a/frontend/templates/artist_detail.html
+++ b/frontend/templates/artist_detail.html
@@ -10920,31 +10920,13 @@ async function addVideosToPlaylist() {
     }
 }
 
-function bulkDownloadSelected() {
-    if (selectedVideos.size === 0) {
-        showError('Please select videos to download');
-        return;
-    }
-    
-    const videoIds = Array.from(selectedVideos);
-    // Implement bulk download logic here
-    showInfo(`Starting download for ${videoIds.length} selected videos...`);
-}
-
-
-
-function bulkDeleteSelected() {
-    if (selectedVideos.size === 0) {
-        showError('Please select videos to delete');
-        return;
-    }
-    
-    if (confirm(`Are you sure you want to delete ${selectedVideos.size} selected videos?`)) {
-        const videoIds = Array.from(selectedVideos);
-        // Implement bulk delete logic here
-        showInfo(`Deleting ${videoIds.length} selected videos...`);
-    }
-}
+// bulkDownloadSelected() and bulkDeleteSelected() are defined earlier
+// in this file (they actually call the /api/videos/bulk/download and
+// /api/videos/bulk/delete endpoints). Dead-stub duplicates of both
+// used to live here, silently shadowing the real implementations
+// (JS function declarations with the same name in the same scope: the
+// LAST one defined wins) -- removed as the fix for the "Download
+// Selected does nothing" bug report.
 
 function updateSelectionUI() {
     const count = selectedVideos.size;

--- a/tests/unit/test_artist_detail_no_duplicate_bulk_functions.py
+++ b/tests/unit/test_artist_detail_no_duplicate_bulk_functions.py
@@ -1,0 +1,67 @@
+"""Regression test for a duplicate-function-definition bug in
+artist_detail.html: bulkDownloadSelected() and bulkDeleteSelected()
+were each defined twice in the same <script>. JavaScript function
+declarations with the same name in the same scope silently shadow one
+another -- whichever definition appears LAST in source order wins at
+runtime. The second (later) definitions of both functions here were
+dead stubs (explicit "// Implement bulk download logic here" /
+"// Implement bulk delete logic here" comments, no fetch() call at
+all), which silently shadowed the real, working implementations
+earlier in the file. The user-visible symptom: clicking "Download
+Selected" on the artist page's video tab showed an "info" toast
+("Starting download for N selected videos...") but never actually
+sent anything to the backend.
+
+Root cause fix: the dead stub definitions were removed, leaving each
+function defined exactly once -- the real implementation that calls
+the actual API endpoint.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "frontend"
+    / "templates"
+    / "artist_detail.html"
+)
+
+
+def _count_function_definitions(source: str, function_name: str) -> int:
+    pattern = re.compile(rf"^function {re.escape(function_name)}\s*\(", re.MULTILINE)
+    return len(pattern.findall(source))
+
+
+class TestNoDuplicateBulkActionFunctions:
+    def test_bulk_download_selected_defined_exactly_once(self):
+        source = TEMPLATE_PATH.read_text()
+        assert _count_function_definitions(source, "bulkDownloadSelected") == 1
+
+    def test_bulk_delete_selected_defined_exactly_once(self):
+        source = TEMPLATE_PATH.read_text()
+        assert _count_function_definitions(source, "bulkDeleteSelected") == 1
+
+    def test_bulk_download_selected_actually_calls_the_api(self):
+        source = TEMPLATE_PATH.read_text()
+        match = re.search(
+            r"function bulkDownloadSelected\s*\([^)]*\)\s*\{(.*?)\n\}",
+            source,
+            re.DOTALL,
+        )
+        assert match, "bulkDownloadSelected() not found"
+        body = match.group(1)
+        assert "/api/videos/bulk/download" in body
+        assert "fetch(" in body
+
+    def test_bulk_delete_selected_actually_calls_the_api(self):
+        source = TEMPLATE_PATH.read_text()
+        match = re.search(
+            r"function bulkDeleteSelected\s*\([^)]*\)\s*\{(.*?)\n\}",
+            source,
+            re.DOTALL,
+        )
+        assert match, "bulkDeleteSelected() not found"
+        body = match.group(1)
+        assert "/api/videos/bulk/delete" in body
+        assert "fetch(" in body


### PR DESCRIPTION
## Summary

Live-reported bug: clicking "Download Selected" on the artist page's video tab showed an info toast ("Starting download for N selected videos...") but never actually sent anything to the backend.

## Root cause

`bulkDownloadSelected()` and `bulkDeleteSelected()` were each defined **twice** in `artist_detail.html`. JavaScript function declarations with the same name in the same scope silently shadow one another — whichever definition appears last in source order wins at runtime, no warning, no error. The later definitions of both were dead stubs (explicit `// Implement bulk download/delete logic here` comments, no `fetch()` call at all) that silently shadowed the real, working implementations earlier in the file, which actually call `/api/videos/bulk/download` and `/api/videos/bulk/delete`.

## Fix

Removed the two dead-stub duplicate definitions, leaving each function defined exactly once — the real implementation.

## Testing

- New regression test (`tests/unit/test_artist_detail_no_duplicate_bulk_functions.py`) proves both functions are defined exactly once and the surviving definition actually calls its API endpoint — written first, confirmed red against the pre-fix template, confirmed green after.
- 321/321 unit tests pass (317 baseline + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)