### PR TITLE
fix(downloads): 403 Forbidden never escalated anti-detection, yt-dlp self-update always silently failed

### DIFF
--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -118,29 +119,50 @@ class YtDlpManager:
         return datetime.now() - self.last_version_check > self.version_check_interval
 
     def update_if_needed(self) -> bool:
-        """Update yt-dlp if necessary"""
+        """Update yt-dlp if necessary.
+
+        The update mechanism must match how this specific executable
+        was actually installed:
+        - self.current_executable == the pipx-managed path -> pipx
+          upgrade (the previous guard here,
+          `"/root/.local/bin/yt-dlp" in self.executable_paths`, was a
+          bug: it tested whether a hardcoded string literal is in a
+          hardcoded list containing that same literal, which is always
+          True regardless of which executable _find_best_executable()
+          actually found).
+        - anything else (this deployment's actual case -- yt-dlp is
+          pip-installed per requirements.txt, never pipx) -> pip
+          install --upgrade, via `sys.executable -m pip` for
+          environment-correctness rather than assuming a bare `pip` is
+          on PATH.
+        Each branch is tried in isolation: if the tool for the wrong
+        installation method is missing (the original bug's trigger --
+        pipx was never installed here), that must not raise past this
+        function and abort the download attempt that called it.
+        """
         if not self.needs_update():
             return True
 
         try:
-            # Try to update via pipx first (preferred)
-            if "/root/.local/bin/yt-dlp" in self.executable_paths:
+            if self.current_executable == "/root/.local/bin/yt-dlp":
                 result = subprocess.run(
                     ["pipx", "upgrade", "yt-dlp"], capture_output=True, timeout=300
                 )
-                if result.returncode == 0:
+                success = result.returncode == 0
+                if success:
                     self.last_version_check = datetime.now()
                     logger.info("yt-dlp updated successfully via pipx")
-                    return True
+                return success
 
-            # Fallback to self-update
             result = subprocess.run(
-                [self.current_executable, "-U"], capture_output=True, timeout=300
+                [sys.executable, "-m", "pip", "install", "--upgrade", "yt-dlp"],
+                capture_output=True,
+                timeout=300,
             )
             success = result.returncode == 0
             if success:
                 self.last_version_check = datetime.now()
-                logger.info("yt-dlp updated successfully")
+                logger.info("yt-dlp updated successfully via pip")
 
             return success
 
@@ -238,8 +260,35 @@ class AntiDetectionManager:
         self.current_ua_index = (self.current_ua_index + 1) % len(self.USER_AGENTS)
         return ua
 
-    def handle_detection_error(self, error: str) -> AntiDetectionLevel:
-        """Determine escalated anti-detection level based on error"""
+    # Escalation ladder for the generic (unrecognized-error) path below.
+    _ESCALATION_ORDER = [
+        AntiDetectionLevel.MINIMAL,
+        AntiDetectionLevel.MODERATE,
+        AntiDetectionLevel.AGGRESSIVE,
+        AntiDetectionLevel.STEALTH,
+    ]
+
+    def handle_detection_error(
+        self,
+        error: str,
+        current_level: AntiDetectionLevel = AntiDetectionLevel.MODERATE,
+    ) -> AntiDetectionLevel:
+        """Determine escalated anti-detection level based on error and
+        the level the failed attempt actually used.
+
+        Specifically-diagnosed error signatures jump straight to the
+        countermeasure level known to address them. Anything else --
+        including "403: Forbidden", one of yt-dlp/YouTube's most common
+        failure signatures -- used to unconditionally return MODERATE
+        regardless of current_level, which meant a 403 at the retry
+        loop's starting level (MODERATE) never actually escalated on
+        any of its 3 attempts: three functionally-identical attempts
+        against a block MODERATE had already failed to avoid, since
+        AGGRESSIVE+ is what adds the explicit player_client=web,mweb,tv
+        fallback (see get_anti_detection_args() above). Progressively
+        stepping up the ladder instead means repeated failures keep
+        making forward progress.
+        """
         self.detection_count += 1
         self.last_detection = datetime.now()
 
@@ -250,7 +299,14 @@ class AntiDetectionManager:
         elif "429" in error or "rate" in error.lower():
             return AntiDetectionLevel.AGGRESSIVE
         else:
-            return AntiDetectionLevel.MODERATE
+            try:
+                current_index = self._ESCALATION_ORDER.index(current_level)
+            except ValueError:
+                current_index = self._ESCALATION_ORDER.index(
+                    AntiDetectionLevel.MODERATE
+                )
+            next_index = min(current_index + 1, len(self._ESCALATION_ORDER) - 1)
+            return self._ESCALATION_ORDER[next_index]
 
 
 class DownloadStrategy(ABC):
@@ -329,7 +385,7 @@ class YouTubeDownloadStrategy(DownloadStrategy):
                 # Escalate anti-detection on failure
                 if attempt < max_attempts - 1:
                     current_level = self.anti_detection.handle_detection_error(
-                        result.error_message
+                        result.error_message, current_level
                     )
                     logger.info(
                         f"Download attempt {attempt + 1} failed, escalating to {current_level}"

--- a/tests/unit/test_anti_detection_escalation.py
+++ b/tests/unit/test_anti_detection_escalation.py
@@ -1,0 +1,84 @@
+"""Tests for AntiDetectionManager.handle_detection_error()'s escalation
+logic. Live-reported bug: videos got "All 3 download attempts failed:
+unable to download video data: HTTP Error 403: Forbidden" -- tracing
+the logs showed all 3 attempts stayed at AntiDetectionLevel.MODERATE.
+handle_detection_error() only recognized "Signature extraction failed",
+"bot", and "429"/"rate" as escalation triggers; a 403 matched none of
+them and fell through to an `else` that unconditionally returned
+MODERATE regardless of the current level -- so three "escalating"
+retries were functionally identical attempts against the same block.
+"""
+
+from unittest.mock import patch
+
+# unified_download_service.py instantiates a module-level singleton
+# (UnifiedDownloadService() -> YtDlpManager()) that raises RuntimeError
+# if no yt-dlp executable is found on disk -- true in this test venv
+# (yt-dlp is only installed inside the mvidarr-dev Docker image, not
+# this sandbox). AntiDetectionManager/AntiDetectionLevel themselves
+# have no yt-dlp dependency, so patch os.path.exists just long enough
+# for the module-level singleton's executable lookup to succeed during
+# import, then let it go back to the real implementation for the rest
+# of the test run.
+with patch("os.path.exists", return_value=True):
+    from src.services.unified_download_service import (
+        AntiDetectionLevel,
+        AntiDetectionManager,
+    )
+
+
+class TestAntiDetectionEscalation:
+    def test_403_forbidden_escalates_past_moderate(self):
+        manager = AntiDetectionManager()
+        result = manager.handle_detection_error(
+            "unable to download video data: HTTP Error 403: Forbidden",
+            AntiDetectionLevel.MODERATE,
+        )
+        assert result != AntiDetectionLevel.MODERATE
+
+    def test_403_forbidden_progressively_escalates_on_repeat(self):
+        """A second consecutive 403 (now at AGGRESSIVE) must escalate
+        further, not return the same level again -- otherwise attempts
+        2 and 3 are identical to each other even after the first fix."""
+        manager = AntiDetectionManager()
+        first = manager.handle_detection_error(
+            "unable to download video data: HTTP Error 403: Forbidden",
+            AntiDetectionLevel.MODERATE,
+        )
+        second = manager.handle_detection_error(
+            "unable to download video data: HTTP Error 403: Forbidden",
+            first,
+        )
+        assert second != first
+
+    def test_escalation_caps_at_stealth(self):
+        manager = AntiDetectionManager()
+        result = manager.handle_detection_error(
+            "unable to download video data: HTTP Error 403: Forbidden",
+            AntiDetectionLevel.STEALTH,
+        )
+        assert result == AntiDetectionLevel.STEALTH
+
+    def test_signature_extraction_failure_still_jumps_to_aggressive(self):
+        """Pre-existing, specifically-diagnosed error signatures keep
+        their targeted response -- not swept into the generic
+        progressive-escalation path."""
+        manager = AntiDetectionManager()
+        result = manager.handle_detection_error(
+            "Signature extraction failed", AntiDetectionLevel.MODERATE
+        )
+        assert result == AntiDetectionLevel.AGGRESSIVE
+
+    def test_bot_detection_still_jumps_to_stealth(self):
+        manager = AntiDetectionManager()
+        result = manager.handle_detection_error(
+            "Confirm you're not a bot", AntiDetectionLevel.MODERATE
+        )
+        assert result == AntiDetectionLevel.STEALTH
+
+    def test_rate_limit_still_jumps_to_aggressive(self):
+        manager = AntiDetectionManager()
+        result = manager.handle_detection_error(
+            "HTTP Error 429: Too Many Requests", AntiDetectionLevel.MODERATE
+        )
+        assert result == AntiDetectionLevel.AGGRESSIVE

--- a/tests/unit/test_ytdlp_manager_update.py
+++ b/tests/unit/test_ytdlp_manager_update.py
@@ -1,0 +1,71 @@
+"""Tests for YtDlpManager.update_if_needed(). Live investigation found
+this always silently failed: "Failed to update yt-dlp: [Errno 2] No
+such file or directory: 'pipx'" on every single download, forever. Two
+bugs: (1) the guard `"/root/.local/bin/yt-dlp" in self.executable_paths`
+tests whether a hardcoded string literal is in a hardcoded list
+containing that same literal -- always True regardless of which
+executable was actually found -- so the pipx branch always ran even
+though this deployment installs yt-dlp via pip (requirements.txt:
+yt-dlp>=2024.12.0), never pipx; (2) since pipx isn't installed, that
+subprocess.run() call raised FileNotFoundError, which escaped to the
+outer except before ever reaching the intended fallback, so yt-dlp
+could never actually update at runtime.
+"""
+
+from unittest.mock import MagicMock, patch
+
+# See test_anti_detection_escalation.py's comment for why this import
+# guard is needed -- the module instantiates a yt-dlp-dependent
+# singleton at import time that this test venv can't satisfy.
+with patch("os.path.exists", return_value=True):
+    from src.services.unified_download_service import YtDlpManager
+
+
+class TestYtDlpManagerUpdate:
+    def _manager_with_forced_recheck(self, executable_path: str) -> YtDlpManager:
+        with patch("os.path.exists", return_value=True):
+            manager = YtDlpManager()
+        manager.current_executable = executable_path
+        manager.last_version_check = None  # force needs_update() True
+        return manager
+
+    def test_pip_installed_yt_dlp_updates_via_pip_not_pipx(self):
+        """The actual, common case in this deployment: yt-dlp found at
+        a pip-installed console-script path (e.g. /usr/local/bin/yt-dlp
+        or venv site-packages), not a pipx path."""
+        manager = self._manager_with_forced_recheck("/usr/local/bin/yt-dlp")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = manager.update_if_needed()
+
+        assert result is True
+        called_command = mock_run.call_args_list[0].args[0]
+        assert "pipx" not in called_command
+        assert "pip" in called_command or "-m" in called_command
+
+    def test_pipx_installed_yt_dlp_still_updates_via_pipx(self):
+        """When yt-dlp genuinely was found at the pipx-managed path,
+        pipx upgrade is still the right mechanism -- this case must
+        keep working, not just the pip case."""
+        manager = self._manager_with_forced_recheck("/root/.local/bin/yt-dlp")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = manager.update_if_needed()
+
+        assert result is True
+        called_command = mock_run.call_args_list[0].args[0]
+        assert "pipx" in called_command
+
+    def test_missing_update_tool_does_not_raise(self):
+        """If the update mechanism's own executable is missing (the
+        original bug's trigger), update_if_needed() must return False
+        gracefully -- never let the exception escape and crash the
+        download attempt that called it."""
+        manager = self._manager_with_forced_recheck("/usr/local/bin/yt-dlp")
+
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = manager.update_if_needed()
+
+        assert result is False


### PR DESCRIPTION
## Summary

Live-reported: "All 3 download attempts failed: unable to download video data: HTTP Error 403: Forbidden" on videos 149, 128, 122.

Traced the actual logs for all three failures in `mvidarr-dev`. Every one of the 3 retry attempts stayed at `AntiDetectionLevel.MODERATE` — functionally identical to each other, not actually escalating at all.

## Root cause 1: escalation never triggers for 403s

`AntiDetectionManager.handle_detection_error()` only recognized `"Signature extraction failed"`, `"bot"`, and `"429"`/`"rate"` as escalation triggers. A 403 — one of the most common yt-dlp/YouTube failure modes — matches none of them and fell through to an `else` that unconditionally returned `MODERATE` regardless of the current level. `AGGRESSIVE`+ is what adds the explicit `player_client=web,mweb,tv` fallback that's often what actually avoids this exact block, so all 3 attempts against a 403 were running the identical configuration 3 times.

**Fix**: `handle_detection_error()` now takes the current level and, for unrecognized errors (including 403), progressively steps up a `MINIMAL → MODERATE → AGGRESSIVE → STEALTH` ladder instead of returning a fixed value. Specifically-diagnosed error signatures keep their targeted jump (signature extraction → AGGRESSIVE, bot detection → STEALTH, rate limiting → AGGRESSIVE).

## Root cause 2: yt-dlp can never actually self-update

`YtDlpManager.update_if_needed()` always tried `pipx upgrade yt-dlp` first, guarded by `"/root/.local/bin/yt-dlp" in self.executable_paths` — a bug, since that tests whether a hardcoded string literal is a member of a hardcoded list containing that same literal, which is **always `True`** regardless of which executable was actually found. This deployment installs yt-dlp via pip (`requirements.txt: yt-dlp>=2024.12.0`), never pipx — confirmed via `pip show yt-dlp` and the console-script wrapper at `/usr/local/bin/yt-dlp`. Since pipx isn't installed, that `subprocess.run()` call raised `FileNotFoundError`, which escaped to the outer `except` before ever reaching the intended fallback. yt-dlp (2026.07.04 at time of investigation, ~6 weeks stale) could never actually update at runtime, silently, on every single download attempt, forever.

**Fix**: check `self.current_executable` (the actually-found path) instead of the always-true membership test, and use `sys.executable -m pip install --upgrade yt-dlp` for the non-pipx case — matching this deployment's real installation method. The pipx path is preserved for environments where it genuinely is pipx-installed.

## Testing

- 9 new tests (real behavioral tests, not source assertions — this logic's actual return *values* are what matter): escalation ladder progression, cap at STEALTH, all 3 pre-existing specific-signature jumps still work; pip-path update, pipx-path update, and graceful (non-raising) failure when the update tool itself is missing.
- 330/330 unit tests pass (321 baseline + 9 new)
- `black --check` / `isort --check-only` clean
- Live-verified against `mvidarr-dev`: restarted cleanly, no startup errors, `/api/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)