### PR TITLE
Close #379 and #380: residual dispatch/discovery/migration gaps from #377

### DIFF
--- a/migrations/024_add_youtube_id_unique_constraint.py
+++ b/migrations/024_add_youtube_id_unique_constraint.py
@@ -77,9 +77,29 @@ def upgrade(connection):
 
 
 def downgrade(connection):
-    """Remove the unique index"""
-    connection.execute(text("""
-        ALTER TABLE videos
-        DROP INDEX ux_videos_youtube_id
+    """Remove the unique index on videos.youtube_id, whatever it's
+    actually named. #379.5: this used to hardcode DROP INDEX
+    ux_videos_youtube_id, which fails on a fresh install where
+    create_all() auto-created the unique index under a different,
+    SQLAlchemy-generated name (upgrade() was already fixed to handle
+    this asymmetry -- #377 Finding 6 -- but downgrade() was not).
+    """
+    result = connection.execute(text("""
+        SELECT index_name FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+        AND table_name = 'videos'
+        AND column_name = 'youtube_id'
+        AND non_unique = 0
+        LIMIT 1
     """))
-    print("✅ Removed unique index ux_videos_youtube_id from videos.youtube_id")
+    row = result.fetchone()
+    if not row:
+        print("✅ No unique index on videos.youtube_id to remove (skipped)")
+        return
+
+    index_name = row[0]
+    connection.execute(text(f"""
+        ALTER TABLE videos
+        DROP INDEX {index_name}
+    """))
+    print(f"✅ Removed unique index {index_name} from videos.youtube_id")

--- a/migrations/025_drop_redundant_youtube_id_index.py
+++ b/migrations/025_drop_redundant_youtube_id_index.py
@@ -1,0 +1,44 @@
+"""
+Migration 025: Drop redundant idx_video_youtube_id index
+
+#377 added a unique index (ux_videos_youtube_id) on videos.youtube_id
+and removed the old non-unique Index("idx_video_youtube_id", ...)
+declaration from the SQLAlchemy model -- but never dropped the
+physical index itself from databases that already had it (i.e.
+existing/production databases; fresh installs never had the old index
+in the first place, since create_all() only ever reflects the current
+model). Harmless (MariaDB permits duplicate indexes on the same
+column) but wasteful (#379.4).
+
+Date: 2026-08-18
+"""
+
+from sqlalchemy import text
+
+
+def upgrade(connection):
+    """Drop the old non-unique idx_video_youtube_id index if present"""
+    result = connection.execute(text("""
+        SELECT COUNT(*) FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+        AND table_name = 'videos'
+        AND index_name = 'idx_video_youtube_id'
+    """))
+    if result.scalar() == 0:
+        print("✅ idx_video_youtube_id already absent (skipped)")
+        return
+
+    connection.execute(text("""
+        ALTER TABLE videos
+        DROP INDEX idx_video_youtube_id
+    """))
+    print("✅ Dropped redundant idx_video_youtube_id index from videos.youtube_id")
+
+
+def downgrade(connection):
+    """Recreate the old non-unique index"""
+    connection.execute(text("""
+        ALTER TABLE videos
+        ADD INDEX idx_video_youtube_id (youtube_id)
+    """))
+    print("✅ Recreated idx_video_youtube_id index on videos.youtube_id")

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -32,24 +32,40 @@ router = APIRouter()
 logger = get_logger("mvidarr.api.fastapi.videos_downloads")
 
 
-async def resolve_video_url(video: Video, session: Session) -> Optional[str]:
+async def resolve_video_url(
+    video: Video, session: Session, timeout: int = 30
+) -> Optional[str]:
     """
-    Helper function to resolve video URL using yt-dlp search
+    Resolve a video's download URL via yt-dlp search, off the event loop.
 
-    This is a placeholder - the actual implementation should be imported
-    from the main videos module or moved to a shared utilities module.
+    #380.1: this used to import a same-named function from
+    src.api.fastapi.videos, which does not define one -- every call
+    raised ImportError. The real, working implementation lives in
+    video_batch_service.resolve_video_url() (checks video.url, falls
+    back to video.youtube_url, then does a live yt-dlp search as a
+    last resort, persisting the result on success). It is synchronous
+    (a blocking subprocess.run call), so it's run via asyncio.to_thread
+    here rather than awaited directly -- awaiting a non-coroutine would
+    raise a TypeError, and calling it bare would block this async
+    handler's event loop for up to `timeout` seconds.
 
     Args:
         video: Video object
         session: Database session
+        timeout: Max seconds to wait for the yt-dlp search subprocess,
+            default 30. Callers resolving many videos in a loop (e.g.
+            bulk_download_videos()) should pass a shorter value.
 
     Returns:
         str: Resolved URL or None
     """
-    # Import from parent module to avoid duplication
-    from src.api.fastapi.videos import resolve_video_url as _resolve_video_url
+    import asyncio
 
-    return await _resolve_video_url(video, session)
+    from src.services.video_batch_service import (
+        resolve_video_url as _resolve_video_url_sync,
+    )
+
+    return await asyncio.to_thread(_resolve_video_url_sync, video, session, timeout)
 
 
 # ========================================================================================

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -14,6 +14,7 @@ Uses shared utility functions (resolve_video_url) from the parent module.
 Authentication: All endpoints require session-based authentication via get_current_user dependency.
 """
 
+import time
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -72,6 +73,14 @@ async def resolve_video_url(
 # DOWNLOAD OPERATIONS
 # ========================================================================================
 
+# bulk_download_videos() resolves URLs for potentially many videos in a
+# single request, each via a live yt-dlp search subprocess (#379.3). A
+# per-video timeout shorter than resolve_video_url()'s 30s default, plus
+# an overall wall-clock budget for the whole batch, keeps one slow/stuck
+# request from ballooning into a many-minutes-long request.
+BULK_URL_RESOLUTION_TIMEOUT_SECONDS = 10
+BULK_URL_RESOLUTION_BUDGET_SECONDS = 60
+
 
 @router.post("/bulk/download")
 async def bulk_download_videos(
@@ -90,7 +99,9 @@ async def bulk_download_videos(
 
         queued_count = 0
         skipped_count = 0
+        failed_count = 0
         errors = []
+        url_resolution_time_used = 0.0
 
         for video in videos:
             claimed = False
@@ -126,8 +137,18 @@ async def bulk_download_videos(
                 )
 
                 if not video_url:
-                    # Try to resolve URL
-                    resolved_url = await resolve_video_url(video, session)
+                    if url_resolution_time_used >= BULK_URL_RESOLUTION_BUDGET_SECONDS:
+                        errors.append(
+                            f"Video {video_id}: Skipped URL resolution "
+                            f"(bulk request's {BULK_URL_RESOLUTION_BUDGET_SECONDS}s "
+                            f"resolution time budget exhausted)"
+                        )
+                        continue
+                    resolution_start = time.monotonic()
+                    resolved_url = await resolve_video_url(
+                        video, session, timeout=BULK_URL_RESOLUTION_TIMEOUT_SECONDS
+                    )
+                    url_resolution_time_used += time.monotonic() - resolution_start
                     if not resolved_url:
                         errors.append(f"Video {video_id}: No valid URL found")
                         continue
@@ -137,6 +158,17 @@ async def bulk_download_videos(
                     claim_video_for_redownload,
                 )
 
+                # Refresh before capturing: for every video after the
+                # first in this batch, the prior video's per-video
+                # commit (#377) expires this session's objects, so this
+                # read is already fresh -- but the FIRST video has no
+                # such prior commit, and the await resolve_video_url()
+                # call above can take real wall-clock time, during
+                # which a concurrent process could change this video's
+                # status. Refreshing explicitly (instead of relying on
+                # that incidental expire-on-commit side effect) makes
+                # this correct uniformly, not just for videos 2+ (#379).
+                session.refresh(video, attribute_names=["status"])
                 # Capture the real pre-claim status so a revert (below)
                 # restores it exactly, rather than assuming WANTED -- the
                 # claim below can succeed from FAILED, MONITORED, or
@@ -180,11 +212,23 @@ async def bulk_download_videos(
                 #      connections from other requests (deadlock risk).
                 session.commit()
 
-                # Submit job to ytdlp_service
+                # Submit job to ytdlp_service. #379.6: revert on ANY
+                # dispatch failure now -- both a raised exception and a
+                # falsy/{"success": False} result -- not just leave the
+                # video at DOWNLOADING and the Download row at "queued"
+                # forever either way. #377 deliberately left this
+                # unhandled, reasoning the Download row was enough of a
+                # paper trail; on reflection a permanently-stuck
+                # DOWNLOADING/"queued" pair with no explanation is the
+                # same "stuck forever" problem #329 and #377 both exist
+                # to close. Mirrors download_all_wanted_videos_internal()
+                # (video_batch_service.py, #329) as closely as this
+                # function's shape allows.
+                dispatch_error_message = None
+                result = None
                 try:
                     from src.services.download_service_adapter import ytdlp_service
 
-                    # Submit to ytdlp_service with download options
                     result = ytdlp_service.add_music_video_download(
                         artist=video.artist.name if video.artist else "Unknown Artist",
                         title=video.title,
@@ -194,22 +238,34 @@ async def bulk_download_videos(
                         video_id=video_id,
                         download_id=download.id,
                     )
-
-                    logger.info(
-                        f"✅ Submitted bulk download job {result.get('download_id')} for video {video_id}"
-                    )
-
                 except Exception as download_error:
+                    dispatch_error_message = str(download_error)
                     logger.error(
                         f"Failed to submit download task for video {video_id}: {download_error}"
                     )
-                    # Still count as queued since it's in the database.
-                    # Deliberately no revert here (#377): the Download row
-                    # above is already committed, so this video isn't
-                    # stranded with no record at all -- pre-existing
-                    # behavior, out of scope for this finding.
 
-                queued_count += 1
+                if result and result.get("success"):
+                    logger.info(
+                        f"✅ Submitted bulk download job {result.get('download_id')} for video {video_id}"
+                    )
+                    queued_count += 1
+                else:
+                    if dispatch_error_message is None:
+                        dispatch_error_message = (
+                            result.get("error", "Unknown dispatch error")
+                            if result
+                            else "Unknown dispatch error"
+                        )
+                    video.status = original_status
+                    download.status = "failed"
+                    download.error_message = dispatch_error_message
+                    session.commit()
+                    errors.append(f"Video {video_id}: {dispatch_error_message}")
+                    failed_count += 1
+                    logger.error(
+                        f"Dispatch failed for video {video_id}, reverted to "
+                        f"{original_status}: {dispatch_error_message}"
+                    )
 
             except Exception as e:
                 video_id = getattr(video, "id", "unknown")  # Safe ID retrieval
@@ -262,12 +318,16 @@ async def bulk_download_videos(
                             f"exception: {revert_error}"
                         )
 
-        logger.info(f"Bulk queued {queued_count} downloads, skipped {skipped_count}")
+        logger.info(
+            f"Bulk queued {queued_count} downloads, skipped {skipped_count}, "
+            f"failed {failed_count}"
+        )
 
         result = {
             "message": "Bulk download completed",
             "queued_count": queued_count,
             "skipped_count": skipped_count,
+            "failed_count": failed_count,
             "total_requested": len(request.video_ids),
         }
 
@@ -386,6 +446,7 @@ async def queue_video_download(
             return {
                 "message": "Video is currently downloading",
                 "video_id": video_id,
+                "download_id": None,
             }
 
         # Submit download to unified service via ytdlp_service adapter

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -9,11 +9,15 @@ These endpoints handle video download management:
 - Debug download endpoints
 
 Extracted from videos.py as part of the API modularization effort.
-Uses shared utility functions (resolve_video_url) from the parent module.
+The resolve_video_url() helper below wraps
+src.services.video_batch_service.resolve_video_url() (the real,
+working implementation) rather than defining its own resolution
+logic or importing from the parent module.
 
 Authentication: All endpoints require session-based authentication via get_current_user dependency.
 """
 
+import asyncio
 import time
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -26,7 +30,12 @@ from src.api.fastapi.auth_dependencies import get_current_user
 from src.api.fastapi.videos_models import BulkDownloadRequest
 from src.database.connection import get_db_session
 from src.database.models import Artist, Download, Video, VideoStatus
-from src.services.video_batch_service import claim_video_for_download
+from src.services.video_batch_service import (
+    claim_video_for_download,
+)
+from src.services.video_batch_service import (
+    resolve_video_url as _resolve_video_url_sync,
+)
 from src.utils.logger import get_logger
 
 router = APIRouter()
@@ -60,12 +69,6 @@ async def resolve_video_url(
     Returns:
         str: Resolved URL or None
     """
-    import asyncio
-
-    from src.services.video_batch_service import (
-        resolve_video_url as _resolve_video_url_sync,
-    )
-
     return await asyncio.to_thread(_resolve_video_url_sync, video, session, timeout)
 
 
@@ -158,16 +161,16 @@ async def bulk_download_videos(
                     claim_video_for_redownload,
                 )
 
-                # Refresh before capturing: for every video after the
-                # first in this batch, the prior video's per-video
-                # commit (#377) expires this session's objects, so this
-                # read is already fresh -- but the FIRST video has no
-                # such prior commit, and the await resolve_video_url()
-                # call above can take real wall-clock time, during
-                # which a concurrent process could change this video's
-                # status. Refreshing explicitly (instead of relying on
-                # that incidental expire-on-commit side effect) makes
-                # this correct uniformly, not just for videos 2+ (#379).
+                # Refresh before capturing. This does NOT by itself
+                # guarantee a fresh read: with no isolation_level set,
+                # MariaDB/InnoDB defaults to REPEATABLE READ, so a plain
+                # SELECT inside an already-open transaction (true for the
+                # FIRST video here) still returns that transaction's
+                # original snapshot. For videos 2+, it's the PRIOR video's
+                # commit (#377) that actually makes the read fresh. Real
+                # correctness against a concurrent status change comes
+                # from the atomic row-locked UPDATE inside the claim call
+                # below, not from this refresh (#379).
                 session.refresh(video, attribute_names=["status"])
                 # Capture the real pre-claim status so a revert (below)
                 # restores it exactly, rather than assuming WANTED -- the
@@ -246,7 +249,7 @@ async def bulk_download_videos(
 
                 if result and result.get("success"):
                     logger.info(
-                        f"✅ Submitted bulk download job {result.get('download_id')} for video {video_id}"
+                        f"✅ Submitted bulk download job {result.get('id')} for video {video_id}"
                     )
                     queued_count += 1
                 else:
@@ -256,6 +259,13 @@ async def bulk_download_videos(
                             if result
                             else "Unknown dispatch error"
                         )
+                    # This assignment only emits an UPDATE because the
+                    # earlier session.commit() above expired `video`
+                    # (expire_on_commit=True, the sessionmaker default in
+                    # src/database/connection.py) -- it re-sets a value
+                    # the attribute would otherwise already hold. If that
+                    # default ever changes, this write silently no-ops,
+                    # stranding the video at DOWNLOADING.
                     video.status = original_status
                     download.status = "failed"
                     download.error_message = dispatch_error_message

--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -140,13 +140,15 @@ def get_ytdlp_path() -> str:
     return "/usr/local/bin/yt-dlp"
 
 
-def resolve_video_url(video, session) -> Optional[str]:
+def resolve_video_url(video, session, timeout: int = 30) -> Optional[str]:
     """
     Helper function to resolve video URL using yt-dlp search
 
     Args:
         video: Video object from database
         session: Database session
+        timeout: Max seconds to wait for the yt-dlp search subprocess,
+            default 30
 
     Returns:
         str: Resolved URL or None
@@ -179,7 +181,7 @@ def resolve_video_url(video, session) -> Optional[str]:
             f"ytsearch1:{search_query}",
         ]
 
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
         if result.returncode == 0 and result.stdout:
             video_info = json.loads(result.stdout.strip())

--- a/src/services/video_discovery_service.py
+++ b/src/services/video_discovery_service.py
@@ -798,21 +798,24 @@ class VideoDiscoveryService:
             )
 
             try:
-                session.add(video)
-                session.flush()  # Ensure video ID is available
+                with session.begin_nested():
+                    session.add(video)
+                    session.flush()  # Ensure video ID is available
             except IntegrityError:
                 # Defensive backstop (#377) for the TOCTOU race the
                 # check-first dedup above can't fully close: a
                 # concurrent insert (another discovery run, an import,
                 # etc.) may have committed a video with this youtube_id
                 # between the `existing` query above and this flush.
-                # Critical: roll back here so this session isn't left in
-                # a pending-rollback state -- without this, every
-                # subsequent session.add()/query() in the caller's loop
-                # (discover_videos_for_artist's `for video_data in
-                # unified_videos:` loop) would raise PendingRollbackError,
-                # discarding the rest of that artist's discovery batch.
-                session.rollback()
+                # session.begin_nested() (a SQL SAVEPOINT) scopes the
+                # rollback to just this failed insert -- the context
+                # manager already rolled back to the savepoint by the
+                # time this except block runs. #379: a plain
+                # session.rollback() here (the #377 original fix) rolled
+                # back the WHOLE session, discarding every video flushed
+                # earlier in this same discover_videos_for_artist() call
+                # (which only commits once, after its whole loop) even
+                # though only this one insert actually failed.
                 logger.info(
                     f"Concurrent insert already stored a video with "
                     f"youtube_id={youtube_id!r} (or a matching URL) -- "

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,6 +33,7 @@ _REAL_DB_MODULES = {
     "test_failure_write_protects_downloaded_status.py",
     "test_import_duplicate_video_race.py",
     "test_discovery_dedup_global_youtube_id.py",
+    "test_discovery_savepoint_preserves_earlier_inserts.py",
 }
 
 

--- a/tests/unit/test_bulk_download_full_revert_and_url_budget.py
+++ b/tests/unit/test_bulk_download_full_revert_and_url_budget.py
@@ -1,0 +1,76 @@
+"""Static source-assertion tests for bulk_download_videos()'s (#379.6,
+#379.3, #380.1) fixes: full revert on ANY dispatch failure (not just
+raised exceptions), a fresh original_status read for every video (not
+just relying on expire-on-commit for videos after the first), and a
+bulk-specific URL-resolution time budget.
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_downloads.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestBulkDownloadFullRevertOnDispatchFailure:
+    def test_checks_result_success_key_not_just_exceptions(self):
+        source = _function_source("bulk_download_videos")
+        assert 'result.get("success")' in source or "result and result.get" in source
+
+    def test_reverts_video_status_on_falsy_result(self):
+        source = _function_source("bulk_download_videos")
+        assert "video.status = original_status" in source
+
+    def test_marks_download_row_failed_on_dispatch_failure(self):
+        source = _function_source("bulk_download_videos")
+        assert 'download.status = "failed"' in source
+        assert "download.error_message" in source
+
+    def test_tracks_a_separate_failed_count(self):
+        source = _function_source("bulk_download_videos")
+        assert "failed_count" in source
+
+
+class TestBulkDownloadOriginalStatusFreshness:
+    def test_refreshes_status_before_capturing_original_status(self):
+        source = _function_source("bulk_download_videos")
+        refresh_pos = source.index('session.refresh(video, attribute_names=["status"])')
+        original_status_pos = source.index("original_status = video.status")
+        assert refresh_pos < original_status_pos
+
+
+class TestBulkDownloadUrlResolutionBudget:
+    def test_defines_a_bulk_specific_timeout_and_budget(self):
+        source = _function_source("bulk_download_videos")
+        assert "BULK_URL_RESOLUTION_TIMEOUT_SECONDS" in source
+        assert "BULK_URL_RESOLUTION_BUDGET_SECONDS" in source
+
+    def test_passes_the_bulk_timeout_to_resolve_video_url(self):
+        source = _function_source("bulk_download_videos")
+        assert "timeout=BULK_URL_RESOLUTION_TIMEOUT_SECONDS" in source
+
+    def test_stops_resolving_once_the_budget_is_exhausted(self):
+        source = _function_source("bulk_download_videos")
+        assert "BULK_URL_RESOLUTION_BUDGET_SECONDS" in source
+        # the budget check must guard the resolve_video_url call, not
+        # just be declared and unused
+        budget_check_pos = source.index("url_resolution_time_used")
+        resolve_call_pos = source.index("await resolve_video_url(")
+        assert budget_check_pos < resolve_call_pos

--- a/tests/unit/test_bulk_download_full_revert_and_url_budget.py
+++ b/tests/unit/test_bulk_download_full_revert_and_url_budget.py
@@ -6,6 +6,7 @@ bulk-specific URL-resolution time budget.
 """
 
 import ast
+import re
 from pathlib import Path
 
 SOURCE_PATH = (
@@ -36,7 +37,24 @@ class TestBulkDownloadFullRevertOnDispatchFailure:
 
     def test_reverts_video_status_on_falsy_result(self):
         source = _function_source("bulk_download_videos")
-        assert "video.status = original_status" in source
+        # Word-boundary match on `video.status = original_status` isn't
+        # enough by itself: this same function also contains an older,
+        # unrelated revert inside its outer exception handler --
+        # `revert_video.status = original_status` -- and a bare substring
+        # check on "video.status = original_status" matches inside that
+        # longer identifier too, so it would pass even without this
+        # task's new dispatch-failure revert block. Anchor on the
+        # specific new block instead: the plain (non-"revert_") `video`
+        # assignment sitting right next to `download.status = "failed"`.
+        match = re.search(
+            r'\bvideo\.status = original_status\s*\n\s*download\.status = "failed"',
+            source,
+        )
+        assert match is not None, (
+            "expected the dispatch-failure revert block "
+            "(`video.status = original_status` immediately followed by "
+            '`download.status = "failed"`) in bulk_download_videos()'
+        )
 
     def test_marks_download_row_failed_on_dispatch_failure(self):
         source = _function_source("bulk_download_videos")

--- a/tests/unit/test_discovery_savepoint_preserves_earlier_inserts.py
+++ b/tests/unit/test_discovery_savepoint_preserves_earlier_inserts.py
@@ -1,0 +1,126 @@
+"""Real (SQLite-backed) test proving the savepoint fix for #379.1:
+video_discovery_service.py's IntegrityError backstop (#377) must only
+discard the ONE failed insert, not every video flushed earlier in the
+same discovery batch.
+
+Forcing a genuine IntegrityError via a pre-committed colliding row
+doesn't reliably trigger the dedup-miss-then-flush-collision path in
+SQLite the way it does in MariaDB, so -- mirroring the proven pattern in
+test_discovery_dedup_global_youtube_id.py's
+test_integrity_error_on_flush_is_caught_and_session_recovers -- the
+dedup query's `existing` result is monkeypatched to `None` for the
+colliding call only, forcing _store_discovered_video() to reach
+session.add()/flush() against an already-colliding youtube_id.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from src.database.connection import get_db
+from src.database.models import Artist, Video, VideoStatus
+from src.services.video_discovery_service import VideoDiscoveryService
+
+
+@pytest.fixture
+def artist():
+    with get_db() as session:
+        a = Artist(name="Test Artist")
+        session.add(a)
+        session.flush()
+        return a.id
+
+
+class TestDiscoverySavepointPreservesEarlierInserts:
+    def test_a_collision_only_discards_the_colliding_insert(self, artist):
+        service = VideoDiscoveryService()
+
+        with get_db() as session:
+            # Simulate the caller's loop: one video stores successfully
+            # (flushed, not yet committed -- discover_videos_for_artist()
+            # only commits once, after its whole loop).
+            service._store_discovered_video(
+                session,
+                artist,
+                {
+                    "title": "First Video",
+                    "youtube_id": "first123",
+                    "url": "https://youtube.com/watch?v=first123",
+                },
+            )
+
+            # A second video collides (simulating a concurrent insert
+            # that already landed this youtube_id -- forced directly in
+            # this same session/transaction for a deterministic test.
+            # Note: a genuinely separate, still-open session can't be
+            # used here -- SQLite's file-level write lock means a
+            # second session trying to insert while this session still
+            # holds an uncommitted write (the "First Video" flush above)
+            # would just block/raise "database is locked" rather than
+            # cleanly simulating a concurrent commit. The unique
+            # constraint on youtube_id is enforced at flush time
+            # regardless of whether the colliding row is committed, so
+            # inserting it directly here reproduces the same collision
+            # the flush below needs to hit.)
+            session.add(
+                Video(
+                    artist_id=artist,
+                    title="Concurrent Insert",
+                    youtube_id="dup456",
+                    url="https://youtube.com/watch?v=dup456",
+                    status=VideoStatus.MONITORED,
+                    discovered_date=datetime.utcnow(),
+                )
+            )
+            session.flush()
+
+            # Bypass the dedup check (Video model only) so the colliding
+            # call falls through to session.add()/flush() and actually
+            # hits the IntegrityError backstop, mirroring the TOCTOU
+            # race the check-first dedup can't fully close.
+            real_query = session.query
+
+            class _NoMatchQuery:
+                def filter(self, *args, **kwargs):
+                    return self
+
+                def first(self):
+                    return None
+
+            def _query_stub(model, *args, **kwargs):
+                if model is Video:
+                    return _NoMatchQuery()
+                return real_query(model, *args, **kwargs)
+
+            session.query = _query_stub
+            try:
+                service._store_discovered_video(
+                    session,
+                    artist,
+                    {
+                        "title": "Colliding Video",
+                        "youtube_id": "dup456",
+                        "url": "https://youtube.com/watch?v=dup456-different-path",
+                    },
+                )
+            finally:
+                session.query = real_query
+
+            # The first video must still be present in this session
+            # after the collision -- proving the savepoint rolled back
+            # only the failed insert, not the whole session.
+            first = session.query(Video).filter(Video.youtube_id == "first123").first()
+            assert first is not None
+            assert first.title == "First Video"
+
+            # The caller's eventual commit must succeed and actually
+            # persist the first video.
+            session.commit()
+
+        with get_db() as verify_session:
+            persisted = (
+                verify_session.query(Video)
+                .filter(Video.youtube_id == "first123")
+                .first()
+            )
+            assert persisted is not None

--- a/tests/unit/test_migration_024_downgrade_is_name_agnostic.py
+++ b/tests/unit/test_migration_024_downgrade_is_name_agnostic.py
@@ -1,0 +1,22 @@
+"""Test for migration 024's downgrade() fix (#379.5): must look up the
+actual unique index name on videos.youtube_id rather than assuming a
+hardcoded name, mirroring upgrade()'s existing column-based approach.
+"""
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "migrations"
+    / "024_add_youtube_id_unique_constraint.py"
+)
+
+
+class TestMigration024DowngradeIsNameAgnostic:
+    def test_downgrade_no_longer_hardcodes_the_index_name_in_a_bare_drop(self):
+        source = MIGRATION_PATH.read_text()
+        downgrade_source = source[source.index("def downgrade(connection):") :]
+        # The old bug: an unconditional DROP INDEX ux_videos_youtube_id
+        # with no lookup first. The fix must look up the actual index
+        # name via information_schema before dropping.
+        assert "information_schema.statistics" in downgrade_source

--- a/tests/unit/test_migration_025_drop_redundant_index.py
+++ b/tests/unit/test_migration_025_drop_redundant_index.py
@@ -1,0 +1,31 @@
+"""Tests for migrations/025_drop_redundant_youtube_id_index.py (#379.4)."""
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "migrations"
+    / "025_drop_redundant_youtube_id_index.py"
+)
+
+
+class TestMigration025Structure:
+    def test_migration_file_exists(self):
+        assert MIGRATION_PATH.exists()
+
+    def test_has_upgrade_and_downgrade_functions(self):
+        source = MIGRATION_PATH.read_text()
+        assert "def upgrade(connection):" in source
+        assert "def downgrade(connection):" in source
+
+    def test_upgrade_checks_for_existence_before_dropping(self):
+        source = MIGRATION_PATH.read_text()
+        assert "information_schema.statistics" in source
+        assert "idx_video_youtube_id" in source
+
+    def test_upgrade_is_idempotent_guarded(self):
+        source = MIGRATION_PATH.read_text()
+        # Must not unconditionally DROP INDEX without a preceding check
+        drop_pos = source.index("DROP INDEX idx_video_youtube_id")
+        check_pos = source.index("information_schema.statistics")
+        assert check_pos < drop_pos

--- a/tests/unit/test_resolve_video_url_timeout.py
+++ b/tests/unit/test_resolve_video_url_timeout.py
@@ -1,0 +1,35 @@
+"""Tests for resolve_video_url()'s timeout parameter (#380.1)."""
+
+from unittest.mock import MagicMock, patch
+
+from src.services.video_batch_service import resolve_video_url
+
+
+class TestResolveVideoUrlTimeout:
+    def test_default_timeout_is_30_seconds(self):
+        video = MagicMock(url=None, youtube_url=None)
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="not found"
+            )
+            resolve_video_url(video, session)
+            assert mock_run.call_args.kwargs["timeout"] == 30
+
+    def test_custom_timeout_is_passed_through(self):
+        video = MagicMock(url=None, youtube_url=None)
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="not found"
+            )
+            resolve_video_url(video, session, timeout=10)
+            assert mock_run.call_args.kwargs["timeout"] == 10
+
+    def test_existing_url_short_circuits_without_calling_subprocess(self):
+        video = MagicMock(url="https://youtube.com/watch?v=abc123")
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            result = resolve_video_url(video, session, timeout=5)
+            assert result == "https://youtube.com/watch?v=abc123"
+            mock_run.assert_not_called()

--- a/tests/unit/test_single_video_download_claims_before_dispatch.py
+++ b/tests/unit/test_single_video_download_claims_before_dispatch.py
@@ -96,8 +96,19 @@ class TestQueueVideoDownloadClaimsBeforeDispatch:
         except_to_end = source[except_pos:]
         assert "video.status = original_status" in except_to_end
 
+    def test_claim_refused_response_includes_download_id(self):
+        source = _function_source(self.FUNCTION_NAME)
+        assert '"download_id": None' in source
+
 
 class TestQueueDownloadVideoClaimsBeforeDispatch(
     TestQueueVideoDownloadClaimsBeforeDispatch
 ):
     FUNCTION_NAME = "queue_download_video"
+
+    def test_claim_refused_response_includes_download_id(self):
+        # queue_download_video()'s claim-refused response does not
+        # include a download_id key today, and this fix is scoped to
+        # queue_video_download() alone per #380.2 -- don't force this
+        # assertion onto a function whose response shape doesn't match.
+        pass

--- a/tests/unit/test_videos_downloads_resolve_url_wrapper.py
+++ b/tests/unit/test_videos_downloads_resolve_url_wrapper.py
@@ -5,6 +5,12 @@ resolve_video_url), so every call raised ImportError. This test proves
 the fix: import the real, working implementation from
 video_batch_service, and run it off the event loop since it's a
 blocking subprocess call.
+
+The video_batch_service import was originally function-local; a later
+fix wave hoisted it to module level for consistency with this same
+file's other module-level imports (claim_video_for_download), so the
+module-level-import tests below check the whole file's source rather
+than just the function's.
 """
 
 import ast
@@ -17,6 +23,10 @@ SOURCE_PATH = (
     / "fastapi"
     / "videos_downloads.py"
 )
+
+
+def _module_source() -> str:
+    return SOURCE_PATH.read_text()
 
 
 def _function_source(function_name: str) -> str:
@@ -33,13 +43,16 @@ def _function_source(function_name: str) -> str:
 
 class TestResolveVideoUrlWrapperFix:
     def test_no_longer_imports_from_nonexistent_videos_module(self):
-        source = _function_source("resolve_video_url")
+        source = _module_source()
         assert "from src.api.fastapi.videos import" not in source
 
     def test_imports_the_real_implementation_from_video_batch_service(self):
-        source = _function_source("resolve_video_url")
+        source = _module_source()
         assert "from src.services.video_batch_service import" in source
-        assert "resolve_video_url" in source
+        assert "resolve_video_url as _resolve_video_url_sync" in source
+        # ...and the wrapper function actually calls the hoisted import.
+        function_source = _function_source("resolve_video_url")
+        assert "_resolve_video_url_sync" in function_source
 
     def test_runs_the_blocking_call_off_the_event_loop(self):
         source = _function_source("resolve_video_url")

--- a/tests/unit/test_videos_downloads_resolve_url_wrapper.py
+++ b/tests/unit/test_videos_downloads_resolve_url_wrapper.py
@@ -1,0 +1,51 @@
+"""Static source-assertion tests for videos_downloads.py's
+resolve_video_url() wrapper fix (#380.1). The wrapper previously
+imported a function that doesn't exist (src.api.fastapi.videos has no
+resolve_video_url), so every call raised ImportError. This test proves
+the fix: import the real, working implementation from
+video_batch_service, and run it off the event loop since it's a
+blocking subprocess call.
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_downloads.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestResolveVideoUrlWrapperFix:
+    def test_no_longer_imports_from_nonexistent_videos_module(self):
+        source = _function_source("resolve_video_url")
+        assert "from src.api.fastapi.videos import" not in source
+
+    def test_imports_the_real_implementation_from_video_batch_service(self):
+        source = _function_source("resolve_video_url")
+        assert "from src.services.video_batch_service import" in source
+        assert "resolve_video_url" in source
+
+    def test_runs_the_blocking_call_off_the_event_loop(self):
+        source = _function_source("resolve_video_url")
+        assert "asyncio.to_thread(" in source
+
+    def test_accepts_and_forwards_a_timeout_parameter(self):
+        source = _function_source("resolve_video_url")
+        assert "timeout: int = 30" in source
+        assert "timeout" in source.split("asyncio.to_thread(")[1][:200]


### PR DESCRIPTION
## Summary

Closes the fixable items from #379 and #380 (residual gaps found while fixing #377's duplicate-concurrent-download-dispatch race). Four independent-ish fixes, each task-reviewed individually, plus a final whole-branch review and fix wave.

1. **`resolve_video_url()` wiring (#380.1)** — the async wrapper in `videos_downloads.py` imported a function from a module that never defined it (`src.api.fastapi.videos`), so every call raised `ImportError`. Fixed to correctly wrap the real implementation in `video_batch_service.py`, run off the event loop via `asyncio.to_thread(...)`, with a new `timeout` parameter.

2. **`bulk_download_videos()` fixes (#379.6, #379.3, #380.2)**:
   - `queue_video_download()`'s claim-refused response was missing a `download_id` key.
   - `original_status` is now captured after an explicit `session.refresh()`.
   - Full revert on ANY dispatch failure (not just raised exceptions) — reverts video status, marks the Download row `"failed"` with an error message, tracks a new `failed_count`.
   - Bulk-specific URL-resolution timeout (10s) + overall budget (60s), so one slow/unresolvable video can't block the rest of a bulk request.

3. **Discovery's `IntegrityError` savepoint fix (#379.1)** — `_store_discovered_video()`'s duplicate-insert backstop used to do a plain `session.rollback()`, discarding the *entire* session's pending work (every video flushed earlier in the same discovery batch), not just the one collision. Now scoped via `session.begin_nested()` (a SQL SAVEPOINT) to just the failed insert.

4. **Migration fixes (#379.4, #379.5)** — new `migrations/025_drop_redundant_youtube_id_index.py` drops the old non-unique index made redundant by #377's unique index; `migrations/024`'s `downgrade()` no longer hardcodes an index name that doesn't exist on fresh installs (now looks it up via `information_schema.statistics`, matching its own `upgrade()`'s established pattern).

## Process

Built via subagent-driven development: brainstorm → design → plan → 4 task dispatches (each with its own task-scoped review) → final whole-branch review (opus) → one fix wave addressing all 6 of its findings → one scoped re-review confirming all addressed, no new breakage.

## Follow-up issues filed from the final review

Findings judged real but out of this branch's scope:
- #383 — `queue_video_download()`/`queue_download_video()` still don't revert on `{"success": False}` dispatch results (same bug class as #379.6, just not yet applied to the two single-video paths)
- #384 — `bulk_download_videos()`'s tests rely on source-assertion greps rather than real behavior, due to a stale premise (the module actually imports fine in-venv with a small shim)
- #385 — migration 025's `downgrade()` lacks an idempotency guard; migration 024's index lookup lacks `ORDER BY`/`seq_in_index` safety
- #386 — **security**: `videos_downloads.py` imports but never calls `get_current_user` — its endpoints (including bulk download dispatch) are effectively unauthenticated, contradicting CLAUDE.md's stated auth policy
- #387 — pre-existing operator-precedence bug in the URL-resolution call condition (harmless today, just wasteful)

## Testing

353 tests passing (348 baseline + 5 new from migration tests; earlier tasks added their own new tests on top of a starting baseline of 330). `black --check` / `isort --check-only` clean on `src/`.

## Live verification still needed post-merge

Per the plan: `docker cp` migrations 024/025 into `mvidarr-dev` (migrations/ isn't bind-mounted), restart, confirm `SHOW INDEX FROM videos WHERE Key_name LIKE '%youtube%'` leaves only `ux_videos_youtube_id`, and `/api/health` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)