### PR TITLE
Phase 1 route authentication sweep: close #386 + 7 more unauthenticated/fake-auth FastAPI modules

### DIFF
--- a/src/api/fastapi/api_gateway_management.py
+++ b/src/api/fastapi/api_gateway_management.py
@@ -6,9 +6,10 @@ RESTful API for managing API Gateway services, routes, and configurations
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin
 from src.services.api_gateway import (
     RouteRule,
     RoutingStrategy,
@@ -130,7 +131,10 @@ class VersionInfoResponse(BaseModel):
 
 # Service Management Endpoints
 @router.post("/services", response_model=Dict[str, Any])
-async def register_service(service_request: ServiceRegistrationRequest):
+async def register_service(
+    service_request: ServiceRegistrationRequest,
+    current_user: dict = Depends(require_admin),
+):
     """Register a new service with the gateway"""
     try:
         gateway = await get_api_gateway()
@@ -165,7 +169,7 @@ async def register_service(service_request: ServiceRegistrationRequest):
 
 
 @router.get("/services", response_model=Dict[str, Any])
-async def list_services():
+async def list_services(current_user: dict = Depends(require_admin)):
     """List all registered services"""
     try:
         gateway = await get_api_gateway()
@@ -214,7 +218,9 @@ async def list_services():
 
 
 @router.delete("/services/{service_id}")
-async def deregister_service(service_id: str):
+async def deregister_service(
+    service_id: str, current_user: dict = Depends(require_admin)
+):
     """Deregister a service from the gateway"""
     try:
         gateway = await get_api_gateway()
@@ -240,7 +246,9 @@ async def deregister_service(service_id: str):
 
 
 @router.get("/services/{service_id}/health")
-async def check_service_health(service_id: str):
+async def check_service_health(
+    service_id: str, current_user: dict = Depends(require_admin)
+):
     """Check health of a specific service"""
     try:
         gateway = await get_api_gateway()
@@ -272,7 +280,10 @@ async def check_service_health(service_id: str):
 
 # Route Management Endpoints
 @router.post("/routes", response_model=Dict[str, Any])
-async def create_route_rule(route_request: RouteRuleRequest):
+async def create_route_rule(
+    route_request: RouteRuleRequest,
+    current_user: dict = Depends(require_admin),
+):
     """Create a new routing rule"""
     try:
         gateway = await get_api_gateway()
@@ -320,7 +331,7 @@ async def create_route_rule(route_request: RouteRuleRequest):
 
 
 @router.get("/routes", response_model=Dict[str, Any])
-async def list_routes():
+async def list_routes(current_user: dict = Depends(require_admin)):
     """List all routing rules"""
     try:
         gateway = await get_api_gateway()
@@ -349,7 +360,7 @@ async def list_routes():
 
 
 @router.delete("/routes/{rule_id}")
-async def delete_route_rule(rule_id: str):
+async def delete_route_rule(rule_id: str, current_user: dict = Depends(require_admin)):
     """Delete a routing rule"""
     try:
         gateway = await get_api_gateway()
@@ -380,7 +391,7 @@ async def delete_route_rule(rule_id: str):
 
 # Gateway Statistics and Monitoring
 @router.get("/stats", response_model=GatewayStatsResponse)
-async def get_gateway_statistics():
+async def get_gateway_statistics(current_user: dict = Depends(require_admin)):
     """Get comprehensive gateway statistics"""
     try:
         gateway = await get_api_gateway()
@@ -416,7 +427,7 @@ async def get_gateway_statistics():
 
 
 @router.get("/health")
-async def gateway_health_check():
+async def gateway_health_check(current_user: dict = Depends(require_admin)):
     """Gateway health check endpoint"""
     try:
         gateway = await get_api_gateway()
@@ -458,7 +469,7 @@ async def gateway_health_check():
 
 # API Versioning Endpoints
 @router.get("/versions", response_model=Dict[str, Any])
-async def list_api_versions():
+async def list_api_versions(current_user: dict = Depends(require_admin)):
     """List all API versions"""
     try:
         versioning_service = await get_api_versioning_service()
@@ -481,7 +492,7 @@ async def list_api_versions():
 
 
 @router.get("/versions/{version}/info", response_model=VersionInfoResponse)
-async def get_version_info(version: str):
+async def get_version_info(version: str, current_user: dict = Depends(require_admin)):
     """Get detailed information about an API version"""
     try:
         versioning_service = await get_api_versioning_service()
@@ -502,7 +513,9 @@ async def get_version_info(version: str):
 
 
 @router.get("/versions/{version}/migration", response_model=Dict[str, Any])
-async def get_migration_recommendations(version: str):
+async def get_migration_recommendations(
+    version: str, current_user: dict = Depends(require_admin)
+):
     """Get migration recommendations for an API version"""
     try:
         versioning_service = await get_api_versioning_service()
@@ -527,6 +540,7 @@ async def get_migration_recommendations(version: str):
 async def test_route_matching(
     path: str = Query(description="Test path"),
     method: str = Query(default="GET", description="HTTP method"),
+    current_user: dict = Depends(require_admin),
 ):
     """Test route matching for a given path and method"""
     try:

--- a/src/api/fastapi/frontend_router.py
+++ b/src/api/fastapi/frontend_router.py
@@ -8,6 +8,9 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from src.api.fastapi.auth_dependencies import (
+    require_authentication as require_api_authentication,
+)
 from src.api.fastapi.template_system import (
     require_admin,
     require_authentication,
@@ -492,7 +495,11 @@ async def job_dashboard_modal_component(request: Request):
 
 
 @frontend_router.get("/api/search", name="frontend_search")
-async def frontend_search(request: Request, q: Optional[str] = Query(None)):
+async def frontend_search(
+    request: Request,
+    q: Optional[str] = Query(None),
+    current_user: dict = Depends(require_api_authentication),
+):
     """Frontend search endpoint for universal search"""
     try:
         if not q:
@@ -701,56 +708,6 @@ async def internal_server_error_handler(request: Request, exc):
             """,
             status_code=500,
         )
-
-
-# =====================================
-# Template Development Helpers
-# =====================================
-
-
-@frontend_router.get("/dev/template-info", name="dev_template_info")
-async def template_development_info(request: Request):
-    """Development endpoint for template information"""
-    try:
-        from src.api.fastapi.template_system import TemplateMigrationHelper
-
-        migration_report = TemplateMigrationHelper.generate_migration_report()
-
-        return {
-            "template_system": "FastAPI Jinja2 with async support",
-            "migration_report": migration_report,
-            "context_processors": len(template_system.context_processors),
-            "registered_filters": list(template_system.env.filters.keys()),
-            "registered_globals": list(template_system.env.globals.keys()),
-        }
-    except Exception as e:
-        logger.error(f"Template dev info error: {e}")
-        return {"error": str(e)}
-
-
-@frontend_router.get("/dev/context-preview", name="dev_context_preview")
-async def template_context_preview(request: Request):
-    """Development endpoint to preview template context"""
-    try:
-        context = await template_system.get_template_context(request)
-
-        # Remove complex objects for JSON serialization
-        preview_context = {}
-        for key, value in context.items():
-            try:
-                if isinstance(value, (str, int, float, bool, list, dict)):
-                    preview_context[key] = value
-                elif hasattr(value, "__dict__"):
-                    preview_context[key] = f"<{type(value).__name__} object>"
-                else:
-                    preview_context[key] = str(type(value))
-            except:
-                preview_context[key] = "<unable to serialize>"
-
-        return preview_context
-    except Exception as e:
-        logger.error(f"Context preview error: {e}")
-        return {"error": str(e)}
 
 
 # Function to get the router

--- a/src/api/fastapi/lastfm.py
+++ b/src/api/fastapi/lastfm.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.api.lastfm")
@@ -60,7 +60,7 @@ class SyncHistoryRequest(BaseModel):
 
 # Status and configuration endpoints
 @router.get("/status")
-async def get_lastfm_status():
+async def get_lastfm_status(current_user: dict = Depends(require_authentication)):
     """Get Last.fm service status - no authentication required"""
     try:
         if not lastfm_available:
@@ -107,7 +107,7 @@ async def get_lastfm_status():
 
 
 @router.post("/test")
-async def test_lastfm_connection():
+async def test_lastfm_connection(current_user: dict = Depends(require_admin)):
     """Test Last.fm API connection"""
     try:
         if not lastfm_available:
@@ -154,7 +154,7 @@ async def test_lastfm_connection():
 
 # Authentication endpoints
 @router.get("/auth/url")
-async def get_auth_url():
+async def get_auth_url(current_user: dict = Depends(require_admin)):
     """Get Last.fm authentication URL"""
     try:
         if not lastfm_available:
@@ -180,7 +180,9 @@ async def get_auth_url():
 
 
 @router.get("/callback")
-async def handle_callback(token: Optional[str] = Query(None)):
+async def handle_callback(
+    token: Optional[str] = Query(None), current_user: dict = Depends(require_admin)
+):
     """Handle Last.fm authentication callback"""
     try:
         if not lastfm_available:
@@ -218,7 +220,10 @@ async def handle_callback(token: Optional[str] = Query(None)):
 
 # User profile and data endpoints
 @router.get("/profile")
-async def get_profile(username: Optional[str] = Query(None)):
+async def get_profile(
+    username: Optional[str] = Query(None),
+    current_user: dict = Depends(require_authentication),
+):
     """Get Last.fm user profile"""
     try:
         if not lastfm_available:
@@ -252,6 +257,7 @@ async def get_top_artists(
     period: str = Query("overall", description="Time period"),
     limit: int = Query(50, ge=1, le=200, description="Number of results"),
     page: int = Query(1, ge=1, description="Page number"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get user's top artists from Last.fm"""
     try:
@@ -295,6 +301,7 @@ async def get_top_tracks(
     period: str = Query("overall", description="Time period"),
     limit: int = Query(50, ge=1, le=200, description="Number of results"),
     page: int = Query(1, ge=1, description="Page number"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get user's top tracks from Last.fm"""
     try:
@@ -339,6 +346,7 @@ async def get_recent_tracks(
     page: int = Query(1, ge=1, description="Page number"),
     from_timestamp: Optional[int] = Query(None, alias="from"),
     to_timestamp: Optional[int] = Query(None, alias="to"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get user's recent tracks from Last.fm"""
     try:
@@ -377,6 +385,7 @@ async def get_loved_tracks(
     username: Optional[str] = Query(None),
     limit: int = Query(50, ge=1, le=200, description="Number of results"),
     page: int = Query(1, ge=1, description="Page number"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get user's loved tracks from Last.fm"""
     try:
@@ -409,7 +418,11 @@ async def get_loved_tracks(
 
 
 @router.get("/artist/{artist_name}")
-async def get_artist_info(artist_name: str, username: Optional[str] = Query(None)):
+async def get_artist_info(
+    artist_name: str,
+    username: Optional[str] = Query(None),
+    current_user: dict = Depends(require_authentication),
+):
     """Get artist information from Last.fm"""
     try:
         if not lastfm_available:
@@ -433,6 +446,7 @@ async def get_artist_info(artist_name: str, username: Optional[str] = Query(None
 async def get_listening_stats(
     username: Optional[str] = Query(None),
     days: int = Query(30, ge=1, le=365, description="Number of days for stats"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get detailed listening statistics"""
     try:
@@ -513,7 +527,10 @@ async def import_top_artists(
 
 
 @router.post("/import/loved-tracks")
-async def import_loved_tracks(request: ImportTracksRequest):
+async def import_loved_tracks(
+    request: ImportTracksRequest,
+    current_user: dict = Depends(require_authentication),
+):
     """Import user's loved tracks and find music videos"""
     try:
         if not lastfm_available:
@@ -555,7 +572,10 @@ async def import_loved_tracks(request: ImportTracksRequest):
 
 
 @router.post("/sync-history")
-async def sync_history(request: SyncHistoryRequest):
+async def sync_history(
+    request: SyncHistoryRequest,
+    current_user: dict = Depends(require_authentication),
+):
     """Sync listening history from Last.fm"""
     try:
         if not lastfm_available:
@@ -598,7 +618,7 @@ async def sync_history(request: SyncHistoryRequest):
 
 
 @router.post("/disconnect")
-async def disconnect():
+async def disconnect(current_user: dict = Depends(require_admin)):
     """Disconnect from Last.fm"""
     try:
         if not lastfm_available:

--- a/src/api/fastapi/mobile_access.py
+++ b/src/api/fastapi/mobile_access.py
@@ -7,9 +7,10 @@ import json
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.services.local_network_share import get_local_network_share
 from src.services.performance_monitor import get_performance_monitor
 from src.utils.logger import get_logger
@@ -83,7 +84,9 @@ async def get_mobile_optimized_config(request: Request) -> Dict[str, Any]:
 
 
 @mobile_router.get("/discover")
-async def mobile_discover_server(request: Request):
+async def mobile_discover_server(
+    request: Request, current_user: dict = Depends(require_authentication)
+):
     """Discover MVidarr server capabilities for mobile apps"""
     try:
         config = await get_mobile_optimized_config(request)
@@ -124,7 +127,9 @@ async def mobile_discover_server(request: Request):
 
 
 @mobile_router.get("/status")
-async def get_mobile_server_status(request: Request):
+async def get_mobile_server_status(
+    request: Request, current_user: dict = Depends(require_authentication)
+):
     """Get server status optimized for mobile display"""
     try:
         config = await get_mobile_optimized_config(request)
@@ -162,6 +167,7 @@ async def get_mobile_collections(
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
     sort: str = Query("name", pattern="^(name|date|size|type)$"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get music video collections optimized for mobile"""
     try:
@@ -232,6 +238,7 @@ async def get_mobile_collection_videos(
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=50),
     quality: str = Query("auto", pattern="^(auto|low|medium|high)$"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get videos in collection optimized for mobile"""
     try:
@@ -299,6 +306,7 @@ async def mobile_search_videos(
     type: str = Query("all", pattern="^(all|videos|artists|albums)$"),
     page: int = Query(1, ge=1),
     limit: int = Query(10, ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Search music videos optimized for mobile"""
     try:
@@ -362,6 +370,7 @@ async def stream_video_mobile(
     request: Request,
     quality: str = Query("auto", pattern="^(auto|low|medium|high)$"),
     range_header: Optional[str] = Header(None, alias="range"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Stream video optimized for mobile devices"""
     try:
@@ -402,6 +411,7 @@ async def get_mobile_thumbnail(
     request: Request,
     size: str = Query("auto", pattern="^(auto|small|medium|large)$"),
     quality: str = Query("medium", pattern="^(low|medium|high)$"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get thumbnail optimized for mobile display"""
     try:
@@ -449,6 +459,7 @@ async def download_video_mobile(
     request: Request,
     quality: str = Query("medium", pattern="^(low|medium|high)$"),
     format: str = Query("mp4", pattern="^(mp4|webm)$"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Download video with mobile-optimized settings"""
     try:
@@ -492,7 +503,10 @@ async def download_video_mobile(
 
 @mobile_router.get("/playlists")
 async def get_mobile_playlists(
-    request: Request, page: int = Query(1, ge=1), limit: int = Query(10, ge=1, le=25)
+    request: Request,
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1, le=25),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get playlists optimized for mobile"""
     try:
@@ -555,6 +569,7 @@ async def get_mobile_playlist_videos(
     request: Request,
     page: int = Query(1, ge=1),
     limit: int = Query(15, ge=1, le=30),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get playlist videos optimized for mobile"""
     try:
@@ -610,7 +625,9 @@ async def get_mobile_playlist_videos(
 
 
 @mobile_router.get("/app", response_class=HTMLResponse)
-async def get_mobile_app_interface(request: Request):
+async def get_mobile_app_interface(
+    request: Request, current_user: dict = Depends(require_authentication)
+):
     """Get mobile web app interface"""
     try:
         config = await get_mobile_optimized_config(request)
@@ -841,7 +858,11 @@ async def get_mobile_app_manifest():
 
 
 @mobile_router.post("/register-device")
-async def register_mobile_device(request: Request, device_info: Dict[str, Any]):
+async def register_mobile_device(
+    request: Request,
+    device_info: Dict[str, Any],
+    current_user: dict = Depends(require_authentication),
+):
     """Register mobile device for optimized experience"""
     try:
         config = await get_mobile_optimized_config(request)

--- a/src/api/fastapi/spotify.py
+++ b/src/api/fastapi/spotify.py
@@ -6,9 +6,9 @@ Provides Spotify-specific API endpoints for artist search and metadata
 import asyncio
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-# from src.middleware.fastapi_auth_middleware import require_authentication  # Temporarily disabled
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.api.spotify")
@@ -36,6 +36,7 @@ except Exception as e:
 async def search_artists(
     q: str = Query(..., description="Artist search query"),
     limit: int = Query(10, description="Number of results to return", ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Search Spotify for artists using direct HTTP calls"""
     try:
@@ -109,6 +110,7 @@ async def search_artists(
 @router.get("/artist/{spotify_id}")
 async def get_artist(
     spotify_id: str,
+    current_user: dict = Depends(require_authentication),
 ):
     """Get detailed artist information from Spotify"""
     try:
@@ -135,6 +137,7 @@ async def get_artist(
 async def get_artist_albums(
     spotify_id: str,
     limit: int = Query(20, description="Number of albums to return", ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get artist's albums from Spotify"""
     try:
@@ -163,6 +166,7 @@ async def get_artist_albums(
 async def get_artist_top_tracks(
     spotify_id: str,
     market: str = Query("US", description="Market/country code"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get artist's top tracks from Spotify"""
     try:
@@ -188,6 +192,7 @@ async def get_artist_top_tracks(
 @router.get("/artist/{spotify_id}/related-artists")
 async def get_related_artists(
     spotify_id: str,
+    current_user: dict = Depends(require_authentication),
 ):
     """Get related artists from Spotify"""
     try:
@@ -214,6 +219,7 @@ async def get_related_artists(
 async def get_user_playlists(
     limit: int = Query(50, description="Number of playlists to return", ge=1, le=50),
     offset: int = Query(0, description="Offset for pagination", ge=0),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get current user's Spotify playlists"""
     try:
@@ -287,6 +293,7 @@ async def get_user_playlists(
 @router.get("/playlist/{playlist_id}")
 async def get_playlist(
     playlist_id: str,
+    current_user: dict = Depends(require_authentication),
 ):
     """Get specific Spotify playlist"""
     try:
@@ -316,6 +323,7 @@ async def get_playlist_tracks(
     playlist_id: str,
     limit: int = Query(20, description="Number of tracks to return", ge=1, le=100),
     offset: int = Query(0, description="Offset for pagination", ge=0),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get tracks from Spotify playlist"""
     try:
@@ -345,6 +353,7 @@ async def get_playlist_tracks(
 async def search_tracks(
     q: str = Query(..., description="Track search query"),
     limit: int = Query(10, description="Number of results to return", ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Search Spotify for tracks"""
     try:
@@ -368,6 +377,7 @@ async def search_tracks(
 async def search_albums(
     q: str = Query(..., description="Album search query"),
     limit: int = Query(10, description="Number of results to return", ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Search Spotify for albums"""
     try:
@@ -388,7 +398,7 @@ async def search_albums(
 
 
 @router.get("/me/profile")
-async def get_user_profile():
+async def get_user_profile(current_user: dict = Depends(require_authentication)):
     """Get current user's Spotify profile"""
     try:
         if not spotify_available:
@@ -415,7 +425,7 @@ async def get_user_profile():
 
 
 @router.get("/status")
-async def get_spotify_status():
+async def get_spotify_status(current_user: dict = Depends(require_authentication)):
     """Get Spotify service status - checks configuration and authentication"""
     try:
         if not spotify_available:
@@ -488,7 +498,7 @@ async def get_spotify_status():
 
 
 @router.post("/test")
-async def test_spotify_integration():
+async def test_spotify_integration(current_user: dict = Depends(require_admin)):
     """Test Spotify API connection"""
     try:
         if not spotify_available:
@@ -520,7 +530,9 @@ async def test_spotify_integration():
 
 
 @router.post("/authorize")
-async def authorize_spotify(request: Request):
+async def authorize_spotify(
+    request: Request, current_user: dict = Depends(require_admin)
+):
     """Get Spotify authorization URL for user authentication"""
     try:
         if not spotify_available:
@@ -577,6 +589,7 @@ async def spotify_callback(
     request: Request,
     code: Optional[str] = Query(None, description="Authorization code from Spotify"),
     error: Optional[str] = Query(None, description="Error from Spotify OAuth"),
+    current_user: dict = Depends(require_admin),
 ):
     """Handle Spotify OAuth callback"""
     try:
@@ -674,7 +687,7 @@ async def spotify_callback(
 
 
 @router.post("/disconnect")
-async def disconnect_spotify():
+async def disconnect_spotify(current_user: dict = Depends(require_admin)):
     """Disconnect from Spotify"""
     try:
         # Note: In FastAPI, session management is different from Flask
@@ -691,7 +704,9 @@ async def disconnect_spotify():
 
 
 @router.post("/playlists/{playlist_id}/import")
-async def import_playlist(playlist_id: str):
+async def import_playlist(
+    playlist_id: str, current_user: dict = Depends(require_authentication)
+):
     """Import artists from a Spotify playlist"""
     try:
         if not spotify_available:
@@ -721,7 +736,9 @@ async def import_playlist(playlist_id: str):
 
 
 @router.post("/import-playlists")
-async def import_all_playlists():
+async def import_all_playlists(
+    current_user: dict = Depends(require_authentication),
+):
     """Import all user playlists from Spotify"""
     try:
         if not spotify_available:
@@ -751,7 +768,9 @@ async def import_all_playlists():
 
 
 @router.post("/followed/sync")
-async def sync_followed_artists():
+async def sync_followed_artists(
+    current_user: dict = Depends(require_authentication),
+):
     """Sync user's followed artists from Spotify"""
     try:
         if not spotify_available:
@@ -785,6 +804,7 @@ async def get_top_artists(
         "medium_term", description="Time range: short_term, medium_term, or long_term"
     ),
     limit: int = Query(50, description="Number of top artists to return", ge=1, le=50),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get user's top artists from Spotify"""
     try:

--- a/src/api/fastapi/system_health.py
+++ b/src/api/fastapi/system_health.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from src.api.fastapi.auth_dependencies import require_admin
+from src.api.fastapi.template_system import require_admin as require_admin_page
 from src.api.fastapi.template_system import template_system
 from src.services.health_monitoring import (
     get_celery_status,
@@ -145,7 +146,7 @@ page_router = APIRouter(tags=["System Health Pages"])
 
 @page_router.get("/system-health", response_class=HTMLResponse)
 async def system_health_page(
-    request: Request, current_user: dict = Depends(require_admin)
+    request: Request, current_user: dict = Depends(require_admin_page)
 ):
     """Render the system health dashboard page."""
     context = {"page_title": "System Health"}

--- a/src/api/fastapi/system_health.py
+++ b/src/api/fastapi/system_health.py
@@ -7,9 +7,10 @@ Provides health monitoring endpoints for home self-hosters.
 import logging
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
+from src.api.fastapi.auth_dependencies import require_admin
 from src.api.fastapi.template_system import template_system
 from src.services.health_monitoring import (
     get_celery_status,
@@ -28,7 +29,7 @@ router = APIRouter(prefix="/api/system-health", tags=["System Health"])
 
 
 @router.get("/")
-async def get_health_summary() -> Dict:
+async def get_health_summary(current_user: dict = Depends(require_admin)) -> Dict:
     """
     Get overall system health summary.
 
@@ -42,26 +43,22 @@ async def get_health_summary() -> Dict:
 
 
 @router.get("/disk")
-async def get_disk_health(paths: Optional[str] = None) -> Dict:
+async def get_disk_health(current_user: dict = Depends(require_admin)) -> Dict:
     """
-    Get disk usage for specified paths.
-
-    Args:
-        paths: Comma-separated list of paths to check (optional)
+    Get disk usage for MVidarr's own fixed data paths.
 
     Returns:
         Disk usage information for each path
     """
     try:
-        path_list = paths.split(",") if paths else None
-        return {"disk_usage": get_disk_usage(path_list)}
+        return {"disk_usage": get_disk_usage()}
     except Exception as e:
         logger.error(f"Error getting disk health: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/memory")
-async def get_memory_health() -> Dict:
+async def get_memory_health(current_user: dict = Depends(require_admin)) -> Dict:
     """Get current memory usage."""
     try:
         return {"memory": get_memory_usage()}
@@ -71,7 +68,7 @@ async def get_memory_health() -> Dict:
 
 
 @router.get("/cpu")
-async def get_cpu_health() -> Dict:
+async def get_cpu_health(current_user: dict = Depends(require_admin)) -> Dict:
     """Get current CPU usage."""
     try:
         return {"cpu": get_cpu_usage(interval=0.1)}
@@ -81,7 +78,7 @@ async def get_cpu_health() -> Dict:
 
 
 @router.get("/database")
-async def get_db_health() -> Dict:
+async def get_db_health(current_user: dict = Depends(require_admin)) -> Dict:
     """Check database connection status."""
     try:
         return {"database": get_database_status()}
@@ -91,7 +88,7 @@ async def get_db_health() -> Dict:
 
 
 @router.get("/celery")
-async def get_celery_health() -> Dict:
+async def get_celery_health(current_user: dict = Depends(require_admin)) -> Dict:
     """Check Celery worker status."""
     try:
         return {"celery": get_celery_status()}
@@ -101,7 +98,7 @@ async def get_celery_health() -> Dict:
 
 
 @router.get("/redis")
-async def get_redis_health() -> Dict:
+async def get_redis_health(current_user: dict = Depends(require_admin)) -> Dict:
     """Check Redis connection status."""
     try:
         return {"redis": get_redis_status()}
@@ -111,7 +108,11 @@ async def get_redis_health() -> Dict:
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, log_file: Optional[str] = None) -> Dict:
+async def get_logs(
+    lines: int = 100,
+    log_file: Optional[str] = None,
+    current_user: dict = Depends(require_admin),
+) -> Dict:
     """
     Get recent log entries.
 
@@ -143,7 +144,9 @@ page_router = APIRouter(tags=["System Health Pages"])
 
 
 @page_router.get("/system-health", response_class=HTMLResponse)
-async def system_health_page(request: Request):
+async def system_health_page(
+    request: Request, current_user: dict = Depends(require_admin)
+):
     """Render the system health dashboard page."""
     context = {"page_title": "System Health"}
     return await template_system.render_response("system_health.html", request, context)

--- a/src/api/fastapi/videos_bulk.py
+++ b/src/api/fastapi/videos_bulk.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, joinedload
 
-from src.api.fastapi.auth_dependencies import get_current_user
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_models import (
     BulkDeleteRequest,
     BulkEditRequest,
@@ -44,7 +44,9 @@ logger = get_logger("mvidarr.api.fastapi.videos_bulk")
 
 @router.post("/bulk/delete")
 async def bulk_delete_videos(
-    request: BulkDeleteRequest = Body(...), session: Session = Depends(get_db_session)
+    request: BulkDeleteRequest = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Bulk delete videos"""
     try:
@@ -104,6 +106,7 @@ async def bulk_delete_videos(
 @router.post("/bulk/status")
 async def bulk_update_status(
     request: Dict[str, Any] = Body(...),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Bulk update video status"""
@@ -172,6 +175,7 @@ async def bulk_update_status(
 @router.post("/bulk/status-debug")
 async def bulk_update_status_debug(
     request: Dict[str, Any] = Body(...),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Working bulk status update bypassing validation issues"""
@@ -244,7 +248,9 @@ async def bulk_update_status_debug(
 
 @router.post("/bulk/edit")
 async def bulk_edit_videos(
-    request: BulkEditRequest = Body(...), session: Session = Depends(get_db_session)
+    request: BulkEditRequest = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Bulk edit videos with specified updates"""
     try:
@@ -323,7 +329,9 @@ async def bulk_edit_videos(
 
 @router.post("/bulk/organize")
 async def bulk_organize_videos(
-    request: BulkOrganizeRequest = Body(...), session: Session = Depends(get_db_session)
+    request: BulkOrganizeRequest = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Bulk organize video files into proper directory structure"""
     try:
@@ -458,7 +466,7 @@ async def bulk_organize_videos(
 @router.post("/refresh-thumbnails")
 async def refresh_video_thumbnails(
     body: Optional[dict] = Body(None),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Refresh thumbnails for videos by downloading from source URLs with progress tracking"""
@@ -554,7 +562,9 @@ async def refresh_video_thumbnails(
 
 @router.post("/bulk/refresh-all-thumbnails")
 async def bulk_refresh_all_thumbnails(
-    request: dict = Body(...), session: Session = Depends(get_db_session)
+    request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Refresh thumbnails for all videos of an artist"""
     try:

--- a/src/api/fastapi/videos_bulk.py
+++ b/src/api/fastapi/videos_bulk.py
@@ -11,7 +11,7 @@ These endpoints handle batch video operations:
 Extracted from videos.py as part of the API modularization effort.
 Uses Pydantic models from videos_models.py for request/response validation.
 
-Authentication: All endpoints require session-based authentication via get_current_user dependency.
+Authentication: All endpoints require session-based authentication via the require_authentication dependency.
 """
 
 import json

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -14,7 +14,7 @@ src.services.video_batch_service.resolve_video_url() (the real,
 working implementation) rather than defining its own resolution
 logic or importing from the parent module.
 
-Authentication: All endpoints require session-based authentication via get_current_user dependency.
+Authentication: All endpoints require session-based authentication via the require_authentication dependency.
 """
 
 import asyncio

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -26,7 +26,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from sqlalchemy.orm import Session, joinedload
 
-from src.api.fastapi.auth_dependencies import get_current_user
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_models import BulkDownloadRequest
 from src.database.connection import get_db_session
 from src.database.models import Artist, Download, Video, VideoStatus
@@ -87,7 +87,9 @@ BULK_URL_RESOLUTION_BUDGET_SECONDS = 60
 
 @router.post("/bulk/download")
 async def bulk_download_videos(
-    request: BulkDownloadRequest = Body(...), session: Session = Depends(get_db_session)
+    request: BulkDownloadRequest = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Bulk download videos"""
     try:
@@ -358,6 +360,7 @@ async def bulk_download_videos(
 async def queue_video_download(
     video_id: int = FastAPIPath(..., ge=1),
     request: Dict[str, Any] = Body(default={}),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Queue video download with flexible validation"""
@@ -541,6 +544,7 @@ async def queue_video_download(
 async def queue_video_download_debug(
     video_id: int = FastAPIPath(..., ge=1),
     request: Dict[str, Any] = Body(default={}),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Debug version of video download bypassing validation"""
@@ -592,6 +596,7 @@ async def queue_video_download_debug(
 @router.post("/{video_id}/queue-download")
 async def queue_download_video(
     video_id: int = FastAPIPath(..., ge=1),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Queue video download via Celery processor"""
@@ -751,7 +756,9 @@ async def queue_download_video(
 
 @router.post("/bulk/download-wanted")
 async def bulk_download_wanted_videos(
-    request: dict = Body(...), session: Session = Depends(get_db_session)
+    request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Download all videos with 'wanted' status"""
     try:

--- a/src/api/fastapi/videos_import.py
+++ b/src/api/fastapi/videos_import.py
@@ -18,7 +18,7 @@ from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from src.api.fastapi.auth_dependencies import get_current_user
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.database.connection import get_db_session
 from src.database.models import Artist, Video, VideoStatus
 from src.utils.logger import get_logger
@@ -63,7 +63,9 @@ def _find_existing_video_after_integrity_error(session: Session, imvdb_id, youtu
 
 @router.post("/import-from-youtube")
 async def import_from_youtube(
-    request: dict = Body(...), session: Session = Depends(get_db_session)
+    request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Import a video from YouTube"""
     try:
@@ -207,7 +209,9 @@ async def import_from_youtube(
 
 @router.post("/import-from-imvdb")
 async def import_from_imvdb(
-    request: dict = Body(...), session: Session = Depends(get_db_session)
+    request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Import a video from IMVDb"""
     try:

--- a/src/api/fastapi/videos_import.py
+++ b/src/api/fastapi/videos_import.py
@@ -8,7 +8,7 @@ These endpoints handle importing videos:
 
 Extracted from videos.py as part of the API modularization effort.
 
-Authentication: All endpoints require session-based authentication via get_current_user dependency.
+Authentication: All endpoints require session-based authentication via the require_authentication dependency.
 """
 
 from datetime import datetime

--- a/src/api/fastapi/videos_metadata.py
+++ b/src/api/fastapi/videos_metadata.py
@@ -21,7 +21,7 @@ from fastapi import Path as FastAPIPath
 from sqlalchemy import or_
 from sqlalchemy.orm import Session, joinedload
 
-from src.api.fastapi.auth_dependencies import get_current_user
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_models import BulkRefreshMetadataRequest
 from src.database.connection import get_db_session
 from src.database.models import Video
@@ -37,6 +37,7 @@ logger = get_logger("mvidarr.api.fastapi.videos_metadata")
 @router.post("/bulk/refresh-metadata")
 async def bulk_refresh_metadata(
     request: BulkRefreshMetadataRequest = Body(...),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Bulk refresh metadata for videos from various sources"""
@@ -142,7 +143,9 @@ async def bulk_refresh_metadata(
 
 @router.post("/bulk/enhanced-refresh-metadata")
 async def bulk_enhanced_refresh_metadata(
-    request: dict = Body(...), session: Session = Depends(get_db_session)
+    request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """Bulk enhanced metadata refresh for multiple videos"""
     try:
@@ -226,7 +229,9 @@ async def bulk_enhanced_refresh_metadata(
 
 @router.post("/enhanced-refresh-all-metadata")
 async def enhanced_refresh_all_metadata(
-    request: dict = Body(default={}), session: Session = Depends(get_db_session)
+    request: dict = Body(default={}),
+    current_user: dict = Depends(require_authentication),
+    session: Session = Depends(get_db_session),
 ):
     """
     Enhanced metadata refresh for all videos or specific video IDs using Celery background job.
@@ -322,6 +327,7 @@ async def enhanced_refresh_all_metadata(
 async def enhanced_refresh_metadata(
     video_id: int = FastAPIPath(..., ge=1),
     request: dict = Body(...),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """Enhanced metadata refresh for a single video from multiple sources including thumbnails"""
@@ -504,6 +510,7 @@ def _extract_year_from_video(video: Video) -> dict:
 async def extract_video_year(
     video_id: int = FastAPIPath(..., ge=1),
     force: bool = Body(False, embed=True),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """
@@ -598,6 +605,7 @@ async def bulk_extract_years(
     video_ids: list[int] = Body(None, embed=True),
     force: bool = Body(False, embed=True),
     all_videos: bool = Body(False, embed=True),
+    current_user: dict = Depends(require_authentication),
     session: Session = Depends(get_db_session),
 ):
     """

--- a/src/api/fastapi/videos_metadata.py
+++ b/src/api/fastapi/videos_metadata.py
@@ -11,7 +11,7 @@ These endpoints handle enriching video metadata from external sources:
 Extracted from videos.py as part of the API modularization effort.
 Uses Pydantic models from videos_models.py for request/response validation.
 
-Authentication: All endpoints require session-based authentication via get_current_user dependency.
+Authentication: All endpoints require session-based authentication via the require_authentication dependency.
 """
 
 from datetime import datetime, timedelta

--- a/src/api/fastapi/week29_integration.py
+++ b/src/api/fastapi/week29_integration.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.integrations.youtube_importer import (
     ImportType,
     VideoQuality,
@@ -23,13 +24,6 @@ from src.services.personal_backup import (
 from src.services.sync_manager import SyncDirection, get_sync_manager
 from src.utils.logger import get_logger
 
-
-# Simple auth function for consistency with other API modules
-async def require_auth():
-    """Simple auth dependency - placeholder for now since Week 29 services are basic"""
-    return {"user_id": "admin", "username": "admin", "role": "admin"}
-
-
 logger = get_logger("mvidarr.api.week29")
 
 # Create routers
@@ -42,7 +36,9 @@ sync_router = APIRouter(prefix="/sync", tags=["sync", "cloud"])
 
 
 @backup_router.get("/status")
-async def get_backup_service_status():
+async def get_backup_service_status(
+    current_user: dict = Depends(require_authentication),
+):
     """Get personal backup service status"""
     try:
         backup_service = await get_personal_backup_service()
@@ -74,7 +70,9 @@ async def get_backup_service_status():
 
 @backup_router.post("/configure/{provider}")
 async def configure_cloud_provider(
-    provider: str, credentials: Dict[str, str], user=Depends(require_auth)
+    provider: str,
+    credentials: Dict[str, str],
+    current_user: dict = Depends(require_admin),
 ):
     """Configure cloud provider credentials"""
     try:
@@ -103,7 +101,7 @@ async def configure_cloud_provider(
 async def create_backup_job(
     backup_request: Dict[str, Any],
     background_tasks: BackgroundTasks,
-    user=Depends(require_auth),
+    current_user: dict = Depends(require_admin),
 ):
     """Create a new backup job"""
     try:
@@ -152,7 +150,9 @@ async def create_backup_job(
 
 
 @backup_router.get("/jobs")
-async def list_backup_jobs(limit: int = 20, user=Depends(require_auth)):
+async def list_backup_jobs(
+    limit: int = 20, current_user: dict = Depends(require_authentication)
+):
     """List recent backup jobs"""
     try:
         backup_service = await get_personal_backup_service()
@@ -166,7 +166,9 @@ async def list_backup_jobs(limit: int = 20, user=Depends(require_auth)):
 
 
 @backup_router.get("/jobs/{job_id}")
-async def get_backup_job_status(job_id: str, user=Depends(require_auth)):
+async def get_backup_job_status(
+    job_id: str, current_user: dict = Depends(require_authentication)
+):
     """Get backup job status"""
     try:
         backup_service = await get_personal_backup_service()
@@ -187,7 +189,7 @@ async def get_backup_job_status(job_id: str, user=Depends(require_auth)):
 
 @youtube_router.post("/search")
 async def search_youtube_videos(
-    search_request: Dict[str, Any], user=Depends(require_auth)
+    search_request: Dict[str, Any], current_user: dict = Depends(require_admin)
 ):
     """Search YouTube for videos"""
     try:
@@ -262,7 +264,9 @@ async def search_youtube_videos(
 
 
 @youtube_router.get("/status")
-async def get_youtube_import_status():
+async def get_youtube_import_status(
+    current_user: dict = Depends(require_authentication),
+):
     """Get YouTube importer status"""
     try:
         youtube_importer = await get_youtube_importer()
@@ -296,7 +300,7 @@ async def get_youtube_import_status():
 async def create_youtube_import(
     import_request: Dict[str, Any],
     background_tasks: BackgroundTasks,
-    user=Depends(require_auth),
+    current_user: dict = Depends(require_admin),
 ):
     """Create YouTube import job"""
     try:
@@ -347,7 +351,9 @@ async def create_youtube_import(
 
 
 @youtube_router.get("/jobs")
-async def list_youtube_jobs(limit: int = 20, user=Depends(require_auth)):
+async def list_youtube_jobs(
+    limit: int = 20, current_user: dict = Depends(require_authentication)
+):
     """List recent YouTube import jobs"""
     try:
         youtube_importer = await get_youtube_importer()
@@ -361,7 +367,9 @@ async def list_youtube_jobs(limit: int = 20, user=Depends(require_auth)):
 
 
 @youtube_router.get("/jobs/{job_id}")
-async def get_youtube_job_status(job_id: str, user=Depends(require_auth)):
+async def get_youtube_job_status(
+    job_id: str, current_user: dict = Depends(require_authentication)
+):
     """Get YouTube import job status"""
     try:
         youtube_importer = await get_youtube_importer()
@@ -378,7 +386,7 @@ async def get_youtube_job_status(job_id: str, user=Depends(require_auth)):
 
 
 @youtube_router.post("/jobs/{job_id}/cancel")
-async def cancel_youtube_job(job_id: str, user=Depends(require_auth)):
+async def cancel_youtube_job(job_id: str, current_user: dict = Depends(require_admin)):
     """Cancel YouTube import job"""
     try:
         youtube_importer = await get_youtube_importer()
@@ -395,7 +403,9 @@ async def cancel_youtube_job(job_id: str, user=Depends(require_auth)):
 
 
 @network_router.get("/status")
-async def get_network_sharing_status():
+async def get_network_sharing_status(
+    current_user: dict = Depends(require_authentication),
+):
     """Get network sharing service status"""
     try:
         network_share = await get_local_network_share()
@@ -409,7 +419,9 @@ async def get_network_sharing_status():
 
 
 @network_router.get("/shares")
-async def list_network_shares(user=Depends(require_auth)):
+async def list_network_shares(
+    current_user: dict = Depends(require_authentication),
+):
     """List all network shares"""
     try:
         network_share = await get_local_network_share()
@@ -423,7 +435,9 @@ async def list_network_shares(user=Depends(require_auth)):
 
 
 @network_router.get("/devices")
-async def get_connected_devices(user=Depends(require_auth)):
+async def get_connected_devices(
+    current_user: dict = Depends(require_authentication),
+):
     """Get connected devices on network"""
     try:
         network_share = await get_local_network_share()
@@ -437,7 +451,7 @@ async def get_connected_devices(user=Depends(require_auth)):
 
 
 @network_router.get("/shares/{share_id}/qr")
-async def get_share_qr_code(share_id: str, user=Depends(require_auth)):
+async def get_share_qr_code(share_id: str, current_user: dict = Depends(require_admin)):
     """Get QR code for mobile access to share"""
     try:
         network_share = await get_local_network_share()
@@ -461,7 +475,9 @@ async def get_share_qr_code(share_id: str, user=Depends(require_auth)):
 
 
 @sync_router.get("/status")
-async def get_sync_service_status():
+async def get_sync_service_status(
+    current_user: dict = Depends(require_authentication),
+):
     """Get sync service status"""
     try:
         sync_manager = await get_sync_manager()
@@ -489,7 +505,9 @@ async def get_sync_service_status():
 
 
 @sync_router.get("/profiles")
-async def list_sync_profiles(user=Depends(require_auth)):
+async def list_sync_profiles(
+    current_user: dict = Depends(require_authentication),
+):
     """List sync profiles"""
     try:
         sync_manager = await get_sync_manager()
@@ -506,7 +524,7 @@ async def list_sync_profiles(user=Depends(require_auth)):
 async def create_sync_profile(
     profile_request: Dict[str, Any],
     background_tasks: BackgroundTasks,
-    user=Depends(require_auth),
+    current_user: dict = Depends(require_admin),
 ):
     """Create sync profile"""
     try:
@@ -555,7 +573,9 @@ async def create_sync_profile(
 
 @sync_router.post("/profiles/{profile_id}/sync")
 async def start_sync_job(
-    profile_id: str, background_tasks: BackgroundTasks, user=Depends(require_auth)
+    profile_id: str,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """Start sync job for profile"""
     try:
@@ -588,7 +608,9 @@ async def start_sync_job(
 
 
 @backup_router.get("/week29/status")
-async def get_week29_status():
+async def get_week29_status(
+    current_user: dict = Depends(require_authentication),
+):
     """Get comprehensive Week 29 features status"""
     try:
         # Get status from all services

--- a/src/services/health_monitoring.py
+++ b/src/services/health_monitoring.py
@@ -27,15 +27,24 @@ def get_disk_usage() -> Dict[str, Dict]:
     `paths` parameter let an unauthenticated caller probe arbitrary host
     filesystem paths for existence/usage stats).
 
+    Paths are anchored to this project's Config-based path constants
+    (the same approach get_recent_logs() uses via Config.LOGS_DIR)
+    rather than hardcoded `/app/data/...` strings, so this reports real
+    disk usage both in Docker (where Config.DATA_DIR resolves to
+    /app/data) and in a native-service/dev deployment (where it does
+    not) -- CLAUDE.md requires MVidarr run either way.
+
     Returns:
         Dict with path as key and usage info as value
     """
+    from src.config.config import Config
+
     paths = [
-        "/app/data",
-        "/app/data/musicvideos",
-        "/app/data/thumbnails",
-        "/app/data/database",
-        "/app/data/logs",
+        str(Config.DATA_DIR),
+        str(Config.MUSIC_VIDEOS_DIR),
+        str(Config.THUMBNAILS_DIR),
+        str(Config.DATA_DIR / "database"),
+        str(Config.LOGS_DIR),
     ]
 
     disk_info = {}

--- a/src/services/health_monitoring.py
+++ b/src/services/health_monitoring.py
@@ -19,25 +19,24 @@ import psutil
 logger = logging.getLogger(__name__)
 
 
-def get_disk_usage(paths: Optional[List[str]] = None) -> Dict[str, Dict]:
+def get_disk_usage() -> Dict[str, Dict]:
     """
-    Get disk usage for specified paths.
+    Get disk usage for MVidarr's own fixed set of data paths.
 
-    Args:
-        paths: List of paths to check. If None, checks common MVidarr paths.
+    Callers can no longer supply arbitrary paths (#386 follow-up: the old
+    `paths` parameter let an unauthenticated caller probe arbitrary host
+    filesystem paths for existence/usage stats).
 
     Returns:
         Dict with path as key and usage info as value
     """
-    if paths is None:
-        # Default paths for MVidarr
-        paths = [
-            "/app/data",
-            "/app/data/musicvideos",
-            "/app/data/thumbnails",
-            "/app/data/database",
-            "/app/data/logs",
-        ]
+    paths = [
+        "/app/data",
+        "/app/data/musicvideos",
+        "/app/data/thumbnails",
+        "/app/data/database",
+        "/app/data/logs",
+    ]
 
     disk_info = {}
 
@@ -261,7 +260,12 @@ def get_recent_logs(log_file: Optional[str] = None, lines: int = 100) -> List[st
     Get recent log entries.
 
     Args:
-        log_file: Path to log file. If None, searches for MVidarr log in common locations.
+        log_file: Path to log file. If None, searches for MVidarr log in
+            common locations. If provided, must resolve to a path inside
+            the application's logs directory (Config.LOGS_DIR) -- anything
+            outside it is rejected (#386 follow-up: this used to do a bare
+            open() on a fully caller-controlled path, a genuine arbitrary
+            file read).
         lines: Number of recent lines to return
 
     Returns:
@@ -290,6 +294,26 @@ def get_recent_logs(log_file: Optional[str] = None, lines: int = 100) -> List[st
                 "  - /tmp/mvidarr_dev.log",
                 "  - data/logs/mvidarr_structured.log",
             ]
+    else:
+        # Caller-supplied path: sandbox it inside the app's logs directory
+        from pathlib import Path
+
+        from src.config.config import Config
+
+        try:
+            logs_dir = Path(Config.LOGS_DIR).resolve()
+            resolved = Path(log_file).resolve()
+        except Exception as e:
+            logger.error(f"Error resolving log file path {log_file}: {e}")
+            return [f"Invalid log file path: {log_file}"]
+
+        if logs_dir != resolved and logs_dir not in resolved.parents:
+            logger.warning(
+                f"Rejected log_file outside logs directory: {log_file} -> {resolved}"
+            )
+            return ["Log file must be within the application logs directory"]
+
+        log_file = str(resolved)
 
     try:
         if not os.path.exists(log_file):

--- a/tests/playwright/tests/pages.spec.ts
+++ b/tests/playwright/tests/pages.spec.ts
@@ -238,28 +238,6 @@ test.describe('API Proxy Endpoints', () => {
   });
 });
 
-test.describe('Development Endpoints', () => {
-  test.beforeEach(async ({ page }) => {
-    await login(page);
-  });
-
-  test('should load template info endpoint', async ({ page }) => {
-    const response = await page.goto('/dev/template-info');
-    expect(response?.status()).toBe(200);
-
-    const info = await response?.json();
-    expect(info).toHaveProperty('template_system');
-  });
-
-  test('should load context preview endpoint', async ({ page }) => {
-    const response = await page.goto('/dev/context-preview');
-    expect(response?.status()).toBe(200);
-
-    const context = await response?.json();
-    expect(typeof context).toBe('object');
-  });
-});
-
 test.describe('Component Endpoints', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);

--- a/tests/unit/test_api_gateway_management_auth.py
+++ b/tests/unit/test_api_gateway_management_auth.py
@@ -1,0 +1,80 @@
+"""Tests for api_gateway_management.py's auth fix. All 13 routes (service
+registration/deregistration, routing-rule management) were unauthenticated
+infra-management endpoints. Gated behind require_admin.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.api_gateway_management import router as gateway_router
+from src.api.fastapi.auth_dependencies import require_admin
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "api_gateway_management.py"
+)
+
+EXPECTED_ADMIN_ROUTES = [
+    "register_service",
+    "list_services",
+    "deregister_service",
+    "check_service_health",
+    "create_route_rule",
+    "list_routes",
+    "delete_route_rule",
+    "get_gateway_statistics",
+    "gateway_health_check",
+    "list_api_versions",
+    "get_version_info",
+    "get_migration_recommendations",
+    "test_route_matching",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestApiGatewayAllRoutesAdmin:
+    def test_every_route_requires_admin(self):
+        for function_name in EXPECTED_ADMIN_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_admin)" in source
+            ), f"{function_name} should use Depends(require_admin), got:\n{source}"
+
+
+class TestApiGatewayBehavioralAuth:
+    def test_list_services_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(gateway_router)
+        client = TestClient(app)
+        response = client.get("/api/gateway/services")
+        assert response.status_code == 401
+
+    def test_list_services_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(gateway_router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.get("/api/gateway/services")
+        assert response.status_code != 401
+        assert response.status_code != 403

--- a/tests/unit/test_frontend_router_dev_endpoints_removed.py
+++ b/tests/unit/test_frontend_router_dev_endpoints_removed.py
@@ -7,6 +7,9 @@ removed entirely rather than gated.
 
 from pathlib import Path
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent
     / "src"
@@ -26,3 +29,29 @@ class TestDevEndpointsRemoved:
         source = SOURCE_PATH.read_text()
         assert "/dev/context-preview" not in source
         assert "template_context_preview" not in source
+
+
+class TestDevEndpointsActuallyReturn404:
+    """Source-string assertions above prove the route registrations were
+    deleted, but not that the routes are actually unreachable -- a route
+    registered elsewhere (or under a different decorator form the string
+    check missed) could still resolve. Confirm behaviorally via a real
+    TestClient request.
+    """
+
+    def _client(self):
+        from src.api.fastapi.frontend_router import frontend_router
+
+        app = FastAPI()
+        app.include_router(frontend_router)
+        return TestClient(app)
+
+    def test_template_info_returns_404(self):
+        client = self._client()
+        response = client.get("/dev/template-info")
+        assert response.status_code == 404
+
+    def test_context_preview_returns_404(self):
+        client = self._client()
+        response = client.get("/dev/context-preview")
+        assert response.status_code == 404

--- a/tests/unit/test_frontend_router_dev_endpoints_removed.py
+++ b/tests/unit/test_frontend_router_dev_endpoints_removed.py
@@ -1,0 +1,28 @@
+"""Tests proving frontend_router.py's two leftover debug endpoints are
+gone. /dev/template-info dumped internal Jinja2 template engine state;
+/dev/context-preview dumped the full per-request template context (which
+may include session/user data). No legitimate ongoing production use;
+removed entirely rather than gated.
+"""
+
+from pathlib import Path
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "frontend_router.py"
+)
+
+
+class TestDevEndpointsRemoved:
+    def test_template_info_route_gone(self):
+        source = SOURCE_PATH.read_text()
+        assert "/dev/template-info" not in source
+        assert "template_development_info" not in source
+
+    def test_context_preview_route_gone(self):
+        source = SOURCE_PATH.read_text()
+        assert "/dev/context-preview" not in source
+        assert "template_context_preview" not in source

--- a/tests/unit/test_frontend_router_search_auth.py
+++ b/tests/unit/test_frontend_router_search_auth.py
@@ -1,0 +1,58 @@
+"""Tests for frontend_router.py's GET /api/search auth fix. This proxies
+to the real search_all(q) service and returns live library search
+results, unauthenticated. Uses auth_dependencies.require_authentication
+(the JSON-API-style 401 variant), not template_system's redirect-style
+(302) require_authentication already used elsewhere in this file for HTML
+pages -- a 302 to a fetch() call would be followed transparently and
+return the login page's HTML where JSON was expected.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "frontend_router.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestFrontendSearchUsesApiStyleAuth:
+    def test_search_uses_the_401_variant_not_the_302_redirect_variant(self):
+        source = _function_source("frontend_search")
+        assert "require_api_authentication" in source
+
+    def test_frontend_router_imports_the_aliased_api_dependency(self):
+        source = SOURCE_PATH.read_text()
+        assert (
+            "from src.api.fastapi.auth_dependencies import" in source
+            and "require_authentication as require_api_authentication" in source
+        )
+
+
+class TestFrontendSearchBehavioralAuth:
+    def test_search_401s_without_session(self):
+        from src.api.fastapi.frontend_router import frontend_router
+
+        app = FastAPI()
+        app.include_router(frontend_router)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/api/search", params={"q": "test"})
+        assert response.status_code == 401

--- a/tests/unit/test_health_monitoring_log_sandboxing.py
+++ b/tests/unit/test_health_monitoring_log_sandboxing.py
@@ -66,5 +66,12 @@ class TestGetDiskUsageNoLongerAcceptsArbitraryPaths:
         assert "paths" not in sig.parameters
 
     def test_returns_the_fixed_default_paths(self):
+        # Anchored to Config.DATA_DIR (which resolves to /app/data in
+        # Docker, but not in a native-service/dev deployment -- see
+        # health_monitoring.py's get_disk_usage() docstring), not a
+        # hardcoded "/app/data" literal, so this must check against the
+        # real constant to hold in both environments.
+        from src.config.config import Config
+
         result = get_disk_usage()
-        assert "/app/data" in result
+        assert str(Config.DATA_DIR) in result

--- a/tests/unit/test_health_monitoring_log_sandboxing.py
+++ b/tests/unit/test_health_monitoring_log_sandboxing.py
@@ -1,0 +1,70 @@
+"""Tests for health_monitoring.py's get_recent_logs() path sandboxing fix.
+Live investigation found this did a bare open(log_file, ...) on a fully
+caller-controlled path with zero validation -- GET /api/health/logs?log_file=/etc/passwd
+(or any file the app process can read) would return its contents. Fixed by
+resolving the caller-supplied path and rejecting anything outside
+Config.LOGS_DIR.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.services.health_monitoring import get_disk_usage, get_recent_logs
+
+
+class TestGetRecentLogsSandboxing:
+    def test_path_outside_logs_directory_is_rejected(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("SECRET CONTENT\n")
+            outside_path = f.name
+
+        try:
+            result = get_recent_logs(log_file=outside_path, lines=10)
+            joined = "\n".join(result)
+            assert "SECRET CONTENT" not in joined
+        finally:
+            os.unlink(outside_path)
+
+    def test_path_traversal_attempt_is_rejected(self):
+        result = get_recent_logs(log_file="/etc/passwd", lines=10)
+        joined = "\n".join(result)
+        assert "root:" not in joined
+
+    def test_default_search_behavior_unchanged_when_log_file_is_none(self):
+        # Must not raise, and must still return SOME list (either found
+        # content or the "no log file found" message) -- proves the
+        # log_file=None branch's existing default-search logic is untouched.
+        result = get_recent_logs(log_file=None, lines=10)
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_path_inside_logs_directory_still_works(self):
+        from src.config.config import Config
+
+        logs_dir = Path(Config.LOGS_DIR)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        test_log = logs_dir / "test_sandboxing_probe.log"
+        test_log.write_text("line one\nline two\n")
+
+        try:
+            result = get_recent_logs(log_file=str(test_log), lines=10)
+            joined = "\n".join(result)
+            assert "line one" in joined
+            assert "line two" in joined
+        finally:
+            test_log.unlink()
+
+
+class TestGetDiskUsageNoLongerAcceptsArbitraryPaths:
+    def test_paths_parameter_removed(self):
+        import inspect
+
+        sig = inspect.signature(get_disk_usage)
+        assert "paths" not in sig.parameters
+
+    def test_returns_the_fixed_default_paths(self):
+        result = get_disk_usage()
+        assert "/app/data" in result

--- a/tests/unit/test_lastfm_auth.py
+++ b/tests/unit/test_lastfm_auth.py
@@ -1,0 +1,94 @@
+"""Tests for lastfm.py's auth fix (#386 follow-up). Same bug class and fix
+shape as spotify.py (see test_spotify_auth.py): OAuth-link-mutating routes
+get require_admin, read-only routes get require_authentication. Unlike
+spotify.py, this file already had require_authentication imported and
+applied to one route (import_top_artists) before this fix -- that route is
+untouched here.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
+from src.api.fastapi.lastfm import router as lastfm_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "lastfm.py"
+)
+
+EXPECTED_TIER = {
+    "get_lastfm_status": "auth",
+    "test_lastfm_connection": "admin",
+    "get_auth_url": "admin",
+    "handle_callback": "admin",
+    "get_profile": "auth",
+    "get_top_artists": "auth",
+    "get_top_tracks": "auth",
+    "get_recent_tracks": "auth",
+    "get_loved_tracks": "auth",
+    "get_artist_info": "auth",
+    "get_listening_stats": "auth",
+    "import_top_artists": "auth",  # already done pre-fix, unchanged
+    "import_loved_tracks": "auth",
+    "sync_history": "auth",
+    "disconnect": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestLastfmAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+
+class TestLastfmBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(lastfm_router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/lastfm/status")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/lastfm/auth/url")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(lastfm_router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.get("/api/lastfm/auth/url")
+        assert response.status_code != 401
+        assert response.status_code != 403

--- a/tests/unit/test_mobile_access_auth.py
+++ b/tests/unit/test_mobile_access_auth.py
@@ -1,0 +1,100 @@
+"""Tests for mobile_access.py's auth fix. 12 of 13 routes were
+unauthenticated -- most handlers are inert stubs (hardcoded sample data),
+but POST /register-device is real: it calls
+network_share.set_device_access_level(...), genuinely granting network
+streaming access to the caller's IP. All non-stub AND stub routes get
+require_authentication uniformly (cheap now, prevents a repeat of this bug
+class if a stub gets filled in later without anyone re-checking auth) --
+EXCEPT GET /manifest.json, deliberately left public (PWA manifest,
+no sensitive data, commonly fetched without credentials by browsers).
+"""
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# mobile_access.py imports src.services.local_network_share, which does a
+# module-level `import netifaces`. netifaces isn't installed in the test
+# venv (it's a real runtime dependency, just not present here), so a direct
+# import of mobile_access raises ModuleNotFoundError at import time. Shim it
+# out before importing -- this only affects import-time module resolution,
+# not any behavior under test.
+sys.modules.setdefault("netifaces", MagicMock())
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.mobile_access import mobile_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "mobile_access.py"
+)
+
+EXPECTED_AUTHENTICATED_ROUTES = [
+    "mobile_discover_server",
+    "get_mobile_server_status",
+    "get_mobile_collections",
+    "get_mobile_collection_videos",
+    "mobile_search_videos",
+    "stream_video_mobile",
+    "get_mobile_thumbnail",
+    "download_video_mobile",
+    "get_mobile_playlists",
+    "get_mobile_playlist_videos",
+    "get_mobile_app_interface",
+    "register_mobile_device",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestMobileAccessAllRoutesAuthenticated:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_AUTHENTICATED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_manifest_route_deliberately_left_unauthenticated(self):
+        source = _function_source("get_mobile_app_manifest")
+        assert "Depends(require_authentication)" not in source
+
+
+class TestMobileAccessBehavioralAuth:
+    def test_register_device_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(mobile_router)
+        client = TestClient(app)
+        response = client.post("/mobile/register-device", json={"device_name": "x"})
+        assert response.status_code == 401
+
+    def test_manifest_succeeds_without_session(self):
+        app = FastAPI()
+        app.include_router(mobile_router)
+        client = TestClient(app)
+        response = client.get("/mobile/manifest.json")
+        assert response.status_code != 401
+
+    def test_register_device_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(mobile_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/mobile/register-device", json={"device_name": "x"})
+        assert response.status_code != 401

--- a/tests/unit/test_spotify_auth.py
+++ b/tests/unit/test_spotify_auth.py
@@ -1,0 +1,113 @@
+"""Tests for spotify.py's auth fix (#386 follow-up). Zero routes were
+protected -- the file's only auth-related import was a dead, commented-out
+line referencing a different, disabled middleware module. Sibling file
+spotify_enhanced.py already did this correctly; this backports that
+pattern, split by sensitivity: routes that create/complete/destroy the
+shared instance-wide Spotify OAuth link use require_admin (mirroring
+auth.py's POST /credentials, hardened after a real dev-testing finding
+that any authenticated non-admin session could change instance-wide
+credentials); read-only routes use require_authentication.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
+from src.api.fastapi.spotify import router as spotify_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "spotify.py"
+)
+
+EXPECTED_TIER = {
+    "search_artists": "auth",
+    "get_artist": "auth",
+    "get_artist_albums": "auth",
+    "get_artist_top_tracks": "auth",
+    "get_related_artists": "auth",
+    "get_user_playlists": "auth",
+    "get_playlist": "auth",
+    "get_playlist_tracks": "auth",
+    "search_tracks": "auth",
+    "search_albums": "auth",
+    "get_user_profile": "auth",
+    "get_spotify_status": "auth",
+    "test_spotify_integration": "admin",
+    "authorize_spotify": "admin",
+    "spotify_callback": "admin",
+    "disconnect_spotify": "admin",
+    "import_playlist": "auth",
+    "import_all_playlists": "auth",
+    "sync_followed_artists": "auth",
+    "get_top_artists": "auth",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestSpotifyAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+
+class TestSpotifyBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(spotify_router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/spotify/status")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post("/api/spotify/authorize")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(spotify_router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/spotify/authorize")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(spotify_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/spotify/status")
+        assert response.status_code != 401

--- a/tests/unit/test_system_health_auth.py
+++ b/tests/unit/test_system_health_auth.py
@@ -1,0 +1,81 @@
+"""Tests for system_health.py's auth fix. All 9 routes exposed internal
+infra detail (disk/memory/CPU/DB/celery/redis, plus a genuine arbitrary
+file read via /logs -- see test_health_monitoring_log_sandboxing.py for
+that part) with zero authentication. Gated behind require_admin.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_admin
+from src.api.fastapi.system_health import page_router
+from src.api.fastapi.system_health import router as health_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "system_health.py"
+)
+
+EXPECTED_ADMIN_ROUTES = [
+    "get_health_summary",
+    "get_disk_health",
+    "get_memory_health",
+    "get_cpu_health",
+    "get_db_health",
+    "get_celery_health",
+    "get_redis_health",
+    "get_logs",
+    "system_health_page",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestSystemHealthAllRoutesAdmin:
+    def test_every_route_requires_admin(self):
+        for function_name in EXPECTED_ADMIN_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_admin)" in source
+            ), f"{function_name} should use Depends(require_admin), got:\n{source}"
+
+
+class TestSystemHealthBehavioralAuth:
+    def test_health_summary_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(health_router)
+        client = TestClient(app)
+        response = client.get("/api/system-health/")
+        assert response.status_code == 401
+
+    def test_logs_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(health_router)
+        client = TestClient(app)
+        response = client.get("/api/system-health/logs")
+        assert response.status_code == 401
+
+    def test_health_summary_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(health_router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.get("/api/system-health/")
+        assert response.status_code != 401
+        assert response.status_code != 403

--- a/tests/unit/test_system_health_auth.py
+++ b/tests/unit/test_system_health_auth.py
@@ -1,18 +1,30 @@
 """Tests for system_health.py's auth fix. All 9 routes exposed internal
 infra detail (disk/memory/CPU/DB/celery/redis, plus a genuine arbitrary
 file read via /logs -- see test_health_monitoring_log_sandboxing.py for
-that part) with zero authentication. Gated behind require_admin.
+that part) with zero authentication. The 8 JSON API routes are gated
+behind auth_dependencies.require_admin (401 JSON on failure).
+
+system_health_page is the exception: it renders an HTML page
+(response_class=HTMLResponse), so it must use
+template_system.require_admin instead (imported here under the alias
+require_admin_page, mirroring frontend_router.py's inverse alias of
+auth_dependencies.require_authentication as require_api_authentication).
+Using the JSON-style auth_dependencies.require_admin on an HTML page
+route meant a logged-out browser hitting /system-health saw a raw JSON
+401 blob instead of being redirected to /auth/login -- fixed in the
+final-review fix wave.
 """
 
 import ast
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from src.api.fastapi.auth_dependencies import require_admin
 from src.api.fastapi.system_health import page_router
 from src.api.fastapi.system_health import router as health_router
+from src.api.fastapi.template_system import require_admin as require_admin_page
 
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "system_health.py"
@@ -27,7 +39,6 @@ EXPECTED_ADMIN_ROUTES = [
     "get_celery_health",
     "get_redis_health",
     "get_logs",
-    "system_health_page",
 ]
 
 
@@ -50,6 +61,26 @@ class TestSystemHealthAllRoutesAdmin:
             assert (
                 "Depends(require_admin)" in source
             ), f"{function_name} should use Depends(require_admin), got:\n{source}"
+
+
+class TestSystemHealthPageUsesTemplateSystemAuth:
+    """system_health_page renders HTML and must redirect (302 to
+    /auth/login) on failure, not 401 with a JSON body -- the JSON
+    variant is for the file's other 8 (API) routes only.
+    """
+
+    def test_system_health_page_uses_the_aliased_page_dependency(self):
+        source = _function_source("system_health_page")
+        assert "Depends(require_admin_page)" in source
+        assert "Depends(require_admin)" not in source
+
+    def test_system_health_page_redirects_not_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(page_router)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/system-health")
+        assert response.status_code == 302
+        assert "/auth/login" in response.headers["location"]
 
 
 class TestSystemHealthBehavioralAuth:

--- a/tests/unit/test_videos_bulk_auth.py
+++ b/tests/unit/test_videos_bulk_auth.py
@@ -1,0 +1,62 @@
+"""Tests for videos_bulk.py's auth fix (closes #386's original scope).
+Includes normalizing the one route that already had SOME dependency
+(refresh_video_thumbnails, bare Depends(get_current_user)) to the real
+enforcing dependency, require_authentication -- get_current_user alone
+does not raise on an unauthenticated request.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.videos_bulk import router as videos_bulk_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "videos_bulk.py"
+)
+
+EXPECTED_AUTHENTICATED_ROUTES = [
+    "bulk_delete_videos",
+    "bulk_update_status",
+    "bulk_update_status_debug",
+    "bulk_edit_videos",
+    "bulk_organize_videos",
+    "bulk_refresh_all_thumbnails",
+    "refresh_video_thumbnails",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestVideosBulkAllRoutesAuthenticated:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_AUTHENTICATED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_refresh_video_thumbnails_no_longer_uses_bare_get_current_user(self):
+        source = _function_source("refresh_video_thumbnails")
+        assert "Depends(get_current_user)" not in source
+
+
+class TestVideosBulkBehavioralAuth:
+    def test_bulk_delete_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(videos_bulk_router)
+        client = TestClient(app)
+        response = client.post("/bulk/delete", json={"video_ids": [1]})
+        assert response.status_code == 401

--- a/tests/unit/test_videos_bulk_auth.py
+++ b/tests/unit/test_videos_bulk_auth.py
@@ -1,8 +1,13 @@
 """Tests for videos_bulk.py's auth fix (closes #386's original scope).
 Includes normalizing the one route that already had SOME dependency
-(refresh_video_thumbnails, bare Depends(get_current_user)) to the real
-enforcing dependency, require_authentication -- get_current_user alone
-does not raise on an unauthenticated request.
+(refresh_video_thumbnails, bare Depends(get_current_user)) to
+require_authentication.
+
+Note: refresh_video_thumbnails previously used bare
+Depends(get_current_user), which DOES enforce authentication (raises
+HTTPException(401)) on its own -- this was not a bug. It's normalized to
+require_authentication here purely for consistency with the rest of this
+file's routes, not because it was unprotected.
 """
 
 import ast
@@ -11,6 +16,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_bulk import router as videos_bulk_router
 
 SOURCE_PATH = (
@@ -60,3 +66,14 @@ class TestVideosBulkBehavioralAuth:
         client = TestClient(app)
         response = client.post("/bulk/delete", json={"video_ids": [1]})
         assert response.status_code == 401
+
+    def test_bulk_delete_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(videos_bulk_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/bulk/delete", json={"video_ids": [1]})
+        assert response.status_code != 401

--- a/tests/unit/test_videos_downloads_auth.py
+++ b/tests/unit/test_videos_downloads_auth.py
@@ -62,3 +62,14 @@ class TestVideosDownloadsBehavioralAuth:
         client = TestClient(app)
         response = client.post("/bulk/download", json={"video_ids": [1]})
         assert response.status_code == 401
+
+    def test_bulk_download_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(videos_downloads_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/bulk/download", json={"video_ids": [1]})
+        assert response.status_code != 401

--- a/tests/unit/test_videos_downloads_auth.py
+++ b/tests/unit/test_videos_downloads_auth.py
@@ -1,0 +1,64 @@
+"""Tests for videos_downloads.py's auth fix (closes #386's original
+scope). All 5 routes imported get_current_user but never applied it --
+every call was unauthenticated despite the module docstring claiming auth
+was required.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.videos_downloads import router as videos_downloads_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_downloads.py"
+)
+
+EXPECTED_AUTHENTICATED_ROUTES = [
+    "bulk_download_videos",
+    "queue_video_download",
+    "queue_video_download_debug",
+    "queue_download_video",
+    "bulk_download_wanted_videos",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestVideosDownloadsAllRoutesAuthenticated:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_AUTHENTICATED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_no_longer_imports_the_unused_get_current_user(self):
+        source = SOURCE_PATH.read_text()
+        assert "import get_current_user" not in source
+
+
+class TestVideosDownloadsBehavioralAuth:
+    def test_bulk_download_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(videos_downloads_router)
+        client = TestClient(app)
+        response = client.post("/bulk/download", json={"video_ids": [1]})
+        assert response.status_code == 401

--- a/tests/unit/test_videos_import_auth.py
+++ b/tests/unit/test_videos_import_auth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_import import router as videos_import_router
 
 SOURCE_PATH = (
@@ -41,3 +42,14 @@ class TestVideosImportBehavioralAuth:
         client = TestClient(app)
         response = client.post("/import-from-youtube", json={"url": "x"})
         assert response.status_code == 401
+
+    def test_import_from_youtube_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(videos_import_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/import-from-youtube", json={"url": "x"})
+        assert response.status_code != 401

--- a/tests/unit/test_videos_import_auth.py
+++ b/tests/unit/test_videos_import_auth.py
@@ -1,0 +1,43 @@
+"""Tests for videos_import.py's auth fix (closes #386's original scope)."""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.videos_import import router as videos_import_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "videos_import.py"
+)
+
+EXPECTED_AUTHENTICATED_ROUTES = ["import_from_youtube", "import_from_imvdb"]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestVideosImportAllRoutesAuthenticated:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_AUTHENTICATED_ROUTES:
+            source = _function_source(function_name)
+            assert "Depends(require_authentication)" in source
+
+
+class TestVideosImportBehavioralAuth:
+    def test_import_from_youtube_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(videos_import_router)
+        client = TestClient(app)
+        response = client.post("/import-from-youtube", json={"url": "x"})
+        assert response.status_code == 401

--- a/tests/unit/test_videos_metadata_auth.py
+++ b/tests/unit/test_videos_metadata_auth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_metadata import router as videos_metadata_router
 
 SOURCE_PATH = (
@@ -52,3 +53,14 @@ class TestVideosMetadataBehavioralAuth:
         client = TestClient(app)
         response = client.post("/bulk/refresh-metadata", json={"video_ids": [1]})
         assert response.status_code == 401
+
+    def test_bulk_refresh_metadata_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(videos_metadata_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/bulk/refresh-metadata", json={"video_ids": [1]})
+        assert response.status_code != 401

--- a/tests/unit/test_videos_metadata_auth.py
+++ b/tests/unit/test_videos_metadata_auth.py
@@ -1,0 +1,54 @@
+"""Tests for videos_metadata.py's auth fix (closes #386's original scope)."""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.videos_metadata import router as videos_metadata_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_metadata.py"
+)
+
+EXPECTED_AUTHENTICATED_ROUTES = [
+    "bulk_refresh_metadata",
+    "bulk_enhanced_refresh_metadata",
+    "enhanced_refresh_all_metadata",
+    "enhanced_refresh_metadata",
+    "extract_video_year",
+    "bulk_extract_years",
+]
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestVideosMetadataAllRoutesAuthenticated:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_AUTHENTICATED_ROUTES:
+            source = _function_source(function_name)
+            assert "Depends(require_authentication)" in source
+
+
+class TestVideosMetadataBehavioralAuth:
+    def test_bulk_refresh_metadata_401s_without_session(self):
+        app = FastAPI()
+        app.include_router(videos_metadata_router)
+        client = TestClient(app)
+        response = client.post("/bulk/refresh-metadata", json={"video_ids": [1]})
+        assert response.status_code == 401

--- a/tests/unit/test_week29_integration_auth.py
+++ b/tests/unit/test_week29_integration_auth.py
@@ -22,7 +22,11 @@ from fastapi.testclient import TestClient
 # resolution, not any behavior under test.
 sys.modules.setdefault("netifaces", MagicMock())
 
-from src.api.fastapi.auth_dependencies import require_admin, require_authentication
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
 from src.api.fastapi.week29_integration import (
     backup_router,
     network_router,
@@ -121,19 +125,22 @@ class TestWeek29BehavioralAuth:
     def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
         app = FastAPI()
         app.include_router(backup_router, prefix="/api")
-        app.dependency_overrides[require_authentication] = lambda: {
+        # require_admin depends on get_current_user directly (see
+        # auth_dependencies.py), not on require_authentication -- so to reach
+        # require_admin's own role-check branch we must override
+        # get_current_user itself, not require_authentication (overriding the
+        # latter would be a no-op for this route and this test would pass for
+        # the wrong reason, or rather not exercise the branch at all).
+        app.dependency_overrides[get_current_user] = lambda: {
             "authenticated": True,
             "role": "user",
+            "user_id": 1,
         }
         client = TestClient(app)
         response = client.post("/api/backup/configure/google_drive", json={})
-        # require_admin itself calls the real get_current_user dependency chain,
-        # not require_authentication, so overriding require_authentication alone
-        # does not satisfy it -- this proves the two are genuinely independent
-        # dependencies, not the same check applied twice. Expect 401 (no real
-        # session), confirming require_admin is NOT satisfied merely by also
-        # overriding require_authentication.
-        assert response.status_code == 401
+        # Authenticated but non-admin: require_admin's role check
+        # (role != ADMIN) must reject with 403, not 401.
+        assert response.status_code == 403
 
     def test_admin_tier_route_succeeds_for_admin_session(self):
         app = FastAPI()

--- a/tests/unit/test_week29_integration_auth.py
+++ b/tests/unit/test_week29_integration_auth.py
@@ -1,0 +1,160 @@
+"""Tests for week29_integration.py's auth fix. The require_auth() dependency
+used to be fake -- it unconditionally returned a hardcoded admin dict without
+inspecting the request at all, so every route using Depends(require_auth)
+looked protected in a code read but wasn't. Fixed by deleting require_auth()
+and applying the real require_authentication/require_admin dependencies
+(src.api.fastapi.auth_dependencies) directly, split by sensitivity.
+"""
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# week29_integration.py transitively imports src.services.local_network_share,
+# which does a module-level `import netifaces`. netifaces isn't installed in
+# the test venv (it's a real runtime dependency, just not present here), so a
+# direct import of week29_integration raises ModuleNotFoundError at import
+# time. Shim it out before importing -- this only affects import-time module
+# resolution, not any behavior under test.
+sys.modules.setdefault("netifaces", MagicMock())
+
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
+from src.api.fastapi.week29_integration import (
+    backup_router,
+    network_router,
+    sync_router,
+    youtube_router,
+)
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "week29_integration.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "get_backup_service_status": "auth",
+    "configure_cloud_provider": "admin",
+    "create_backup_job": "admin",
+    "list_backup_jobs": "auth",
+    "get_backup_job_status": "auth",
+    "search_youtube_videos": "admin",
+    "get_youtube_import_status": "auth",
+    "create_youtube_import": "admin",
+    "list_youtube_jobs": "auth",
+    "get_youtube_job_status": "auth",
+    "cancel_youtube_job": "admin",
+    "get_network_sharing_status": "auth",
+    "list_network_shares": "auth",
+    "get_connected_devices": "auth",
+    "get_share_qr_code": "admin",
+    "get_sync_service_status": "auth",
+    "list_sync_profiles": "auth",
+    "create_sync_profile": "admin",
+    "start_sync_job": "admin",
+    "get_week29_status": "auth",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestWeek29FakeAuthRemoved:
+    def test_require_auth_no_longer_defined(self):
+        source = SOURCE_PATH.read_text()
+        assert "async def require_auth(" not in source
+
+    def test_no_route_still_depends_on_require_auth(self):
+        source = SOURCE_PATH.read_text()
+        assert "Depends(require_auth)" not in source
+
+
+class TestWeek29AllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+
+class TestWeek29BehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(backup_router, prefix="/api")
+        app.include_router(youtube_router, prefix="/api")
+        app.include_router(network_router, prefix="/api")
+        app.include_router(sync_router, prefix="/api")
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/backup/status")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post("/api/backup/configure/google_drive", json={})
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(backup_router, prefix="/api")
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.post("/api/backup/configure/google_drive", json={})
+        # require_admin itself calls the real get_current_user dependency chain,
+        # not require_authentication, so overriding require_authentication alone
+        # does not satisfy it -- this proves the two are genuinely independent
+        # dependencies, not the same check applied twice. Expect 401 (no real
+        # session), confirming require_admin is NOT satisfied merely by also
+        # overriding require_authentication.
+        assert response.status_code == 401
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(backup_router, prefix="/api")
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/backup/configure/google_drive", json={"key": "x"})
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(backup_router, prefix="/api")
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/backup/status")
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary

Closes issue #386 (which grew from a targeted report about `videos_downloads.py` into a full project-wide FastAPI route-authentication audit — 705 total routes across 81 files, only ~347 protected). Phase 1 closes the confirmed-live, confirmed-dangerous subset: **8 files, ~111 routes**, all independently verified mounted and reachable in `fastapi_app.py`.

## What was fixed

1. **`week29_integration.py`** (20 routes) — `require_auth()` was **fake**: it unconditionally returned `{"role": "admin"}` without checking the request at all. Every route using it looked protected in a code review but wasn't. Deleted; replaced with real, role-split `require_authentication`/`require_admin`.
2. **`spotify.py`** (20 routes) — zero routes protected, including an OAuth-hijack risk (anyone could overwrite the server's shared Spotify link via the unauthenticated `/authorize`). Role-split auth added, mirroring the already-correct `spotify_enhanced.py`.
3. **`lastfm.py`** (14 of 15 routes) — same OAuth-hijack class of bug. Role-split auth added.
4. **`system_health.py` + `health_monitoring.py`** (9 routes) — admin-gated, plus a real bug: `get_recent_logs()` did a bare `open(log_file, ...)` on a fully caller-controlled path — genuine arbitrary file read (`GET /api/health/logs?log_file=/etc/passwd` returned its contents). Fixed via path-containment sandboxing to `Config.LOGS_DIR`. `get_disk_usage()`'s free-form `paths` param (milder existence-oracle risk) removed in favor of `Config`-anchored defaults.
5. **`api_gateway_management.py`** (13 routes) — zero protected, admin-gated all.
6. **`mobile_access.py`** (12 of 13 routes) — zero protected; mostly inert stubs, but `POST /register-device` really does grant network streaming access via caller IP. `GET /manifest.json` deliberately left public (PWA manifest, no sensitive data).
7. **`frontend_router.py`** — removed two leftover debug endpoints (`/dev/template-info`, `/dev/context-preview`) that dumped internal template engine state and full per-request context. Authenticated `GET /api/search` (real library search results, was unauthenticated).
8. **`videos_downloads.py`/`videos_import.py`/`videos_metadata.py`/`videos_bulk.py`** (19 routes + 1 normalized) — closes the original #386 scope: these files imported `get_current_user` but never applied it, despite docstrings claiming auth was required.

## Process

Brainstorm → design spec → implementation plan → 8 task dispatches (each with its own task-scoped review, one requiring a fix round) → final whole-branch review (opus) → one fix wave addressing 4 of 5 findings fully, 1 finding partially (adjudicated and parked with a filed follow-up, since the underlying security guarantee doesn't depend on it) → one scoped re-review.

## Follow-up issues filed from the final review

- #389 — non-admin users get no graceful UI degradation on the now admin-gated Spotify/Last.fm/system-health buttons
- #390 — the global 401 interceptor's `/auth/` substring match incidentally excludes `/api/lastfm/auth/url`
- #391 — `spotify_callback`'s custom OAuth-error redirect UX is now bypassed by the auth dependency raising before the route body runs
- #392 — Phase 2 tracking issue for the ~300 remaining unprotected routes across ~35 other files
- #393 — 4 new positive-auth tests added in this branch's own fix wave are non-hermetic and weakly asserted (test-quality only, no production impact — each covered route already has independent AST + negative-401 coverage proving it's genuinely enforced)

## Testing

411 tests passing (403 after the 8 tasks + 8 from the final-review fix wave). `black --check` / `isort --check-only` clean.

## Live verification still needed post-merge

- Restart `mvidarr-dev`, confirm `/api/health` still 200, confirm a logged-out request to a representative sample of the fixed routes now gets 401/302 as appropriate.
- Log in as admin, confirm the Spotify and Last.fm OAuth "Connect" flows still complete a real round-trip (flagged by every relevant task as needing live verification — `SameSite=Lax` cookie behavior on the redirect-back should work per code inspection, but wasn't and can't be unit-tested end-to-end).
- Confirm the mobile PWA manifest still loads without a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)