### PR TITLE
fix(downloads): claim-failure error was silently swallowed as misleading 'already downloading'

### DIFF
--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -456,8 +456,34 @@ async def queue_video_download(
         from src.services.video_batch_service import claim_video_for_redownload
 
         if not claim_video_for_redownload(video_id):
+            # claim_video_for_redownload() returns False both when the
+            # video genuinely lost a race to a concurrent claim AND when
+            # the claim attempt itself errored (live-observed: a
+            # transient `Lock wait timeout exceeded` DB error) -- it
+            # can't distinguish the two from its own return value alone.
+            # Re-check the video's actual status to tell them apart:
+            # only a real DOWNLOADING status means "someone else is
+            # already downloading this." Anything else means the claim
+            # failed for an unrelated reason, and telling the caller
+            # "it's already downloading" would be actively misleading --
+            # nothing is actually in progress, and the user is left with
+            # no record of the failed attempt at all.
+            session.refresh(video, attribute_names=["status"])
+            if video.status == VideoStatus.DOWNLOADING:
+                return {
+                    "message": "Video is currently downloading",
+                    "video_id": video_id,
+                    "download_id": None,
+                }
+            # Not a genuine race loss -- discard the staged (uncommitted)
+            # Download row explicitly, rather than relying on it being
+            # implicitly rolled back when the session closes, and report
+            # a real, retriable error so the failure is visible instead
+            # of silent.
+            session.rollback()
             return {
-                "message": "Video is currently downloading",
+                "success": False,
+                "error": "Failed to claim video for download (a database error occurred). Please try again.",
                 "video_id": video_id,
                 "download_id": None,
             }
@@ -686,11 +712,30 @@ async def queue_download_video(
         from src.services.video_batch_service import claim_video_for_redownload
 
         if not claim_video_for_redownload(video_id):
+            # See queue_video_download()'s identical comment above:
+            # claim_video_for_redownload() returning False doesn't by
+            # itself distinguish a genuine race loss from an unrelated
+            # claim error (live-observed: a transient DB lock-wait
+            # timeout). Re-check the video's real status before deciding
+            # which message is actually true.
+            session.refresh(video, attribute_names=["status"])
+            if video.status == VideoStatus.DOWNLOADING:
+                return {
+                    "success": True,
+                    "message": "Video is currently downloading",
+                    "video_id": video_id,
+                    "status": "already_downloading",
+                }
+            # Not a genuine race loss -- discard the staged (uncommitted)
+            # Download row explicitly and report a real, retriable error
+            # instead of a misleading "already downloading" message with
+            # no trace of the failure anywhere.
+            session.rollback()
             return {
-                "success": True,
-                "message": "Video is currently downloading",
+                "success": False,
+                "error": "Failed to claim video for download (a database error occurred). Please try again.",
                 "video_id": video_id,
-                "status": "already_downloading",
+                "download_id": None,
             }
 
         # Submit download to unified service via ytdlp_service adapter

--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -117,6 +117,41 @@ def claim_video_for_redownload(video_id: int) -> bool:
             return result.rowcount == 1
     except Exception as e:
         logger.error(f"Failed to claim video {video_id} for redownload: {e}")
+        # Live-reported (2026-08-20): this call intermittently blocks for
+        # the full innodb_lock_wait_timeout and fails with error 1205,
+        # recurring in bursts across multiple unrelated videos. Direct
+        # live investigation (manual reproduction, polling
+        # information_schema.innodb_trx between failures) could never
+        # catch the blocking transaction in the act -- by the time a
+        # failure was noticed, the lock had already cleared. Capture
+        # what else was active on the DB at the moment of THIS failure,
+        # so the next occurrence leaves hard evidence instead of
+        # requiring another live chase. Best-effort and diagnostic-only
+        # -- must never raise past this function or change its return
+        # value, and must not assume a MariaDB backend (information_
+        # schema.innodb_trx doesn't exist on SQLite, used in tests).
+        if "1205" in str(e) or "Lock wait timeout" in str(e):
+            try:
+                from sqlalchemy import text
+
+                with engine.connect() as diag_conn:
+                    trx_rows = diag_conn.execute(
+                        text(
+                            "SELECT trx_id, trx_state, trx_started, "
+                            "trx_mysql_thread_id, trx_query "
+                            "FROM information_schema.innodb_trx"
+                        )
+                    ).fetchall()
+                    logger.error(
+                        f"Lock-wait-timeout diagnostics for video {video_id}: "
+                        f"{len(trx_rows)} active InnoDB transaction(s) at "
+                        f"failure time: {trx_rows}"
+                    )
+            except Exception as diag_error:
+                logger.error(
+                    f"Could not gather lock-wait-timeout diagnostics for "
+                    f"video {video_id}: {diag_error}"
+                )
         return False
 
 

--- a/tests/unit/test_claim_failure_distinguishes_error_from_race_loss.py
+++ b/tests/unit/test_claim_failure_distinguishes_error_from_race_loss.py
@@ -1,0 +1,103 @@
+"""Tests for a live-reported bug: queue_video_download() and
+queue_download_video() both treated ANY claim_video_for_redownload()
+failure identically -- reporting "Video is currently downloading" to
+the caller, with no trace left in download history. In practice this
+message is only accurate when the video genuinely lost a race to a
+concurrent claim (its status really is DOWNLOADING). If the claim call
+instead failed because of a transient DB error (live-observed:
+`pymysql.err.OperationalError` 1205 "Lock wait timeout exceeded"),
+the video's status is NOT DOWNLOADING -- but the caller reported the
+same misleading message anyway, and the staged (uncommitted) Download
+row was silently discarded when the session closed, leaving the user
+with no record that anything was attempted at all.
+
+Fix: after a claim failure, re-check the video's actual status. Only
+report "already downloading" when it genuinely is. Otherwise, roll back
+the staged Download row explicitly and report a real, retriable error.
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_downloads.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestQueueVideoDownloadDistinguishesClaimFailureCause:
+    FUNCTION_NAME = "queue_video_download"
+
+    def test_rechecks_video_status_after_claim_failure(self):
+        source = _function_source(self.FUNCTION_NAME)
+        claim_pos = source.index("if not claim_video_for_redownload(")
+        refresh_pos = source.index('session.refresh(video, attribute_names=["status"])')
+        assert claim_pos < refresh_pos
+
+    def test_only_reports_already_downloading_when_status_genuinely_downloading(self):
+        source = _function_source(self.FUNCTION_NAME)
+        assert "if video.status == VideoStatus.DOWNLOADING:" in source
+
+    def test_reports_a_real_error_when_status_is_not_downloading(self):
+        source = _function_source(self.FUNCTION_NAME)
+        # After the genuine-race-loss branch, the fallback path must
+        # report success: False with a real, non-misleading message --
+        # not silently return the same "currently downloading" text.
+        downloading_check_pos = source.index(
+            "if video.status == VideoStatus.DOWNLOADING:"
+        )
+        tail = source[downloading_check_pos:]
+        assert '"success": False' in tail
+
+    def test_explicitly_discards_the_staged_download_row_on_claim_error(self):
+        source = _function_source(self.FUNCTION_NAME)
+        downloading_check_pos = source.index(
+            "if video.status == VideoStatus.DOWNLOADING:"
+        )
+        tail = source[downloading_check_pos:]
+        assert "session.rollback()" in tail
+
+
+class TestQueueDownloadVideoDistinguishesClaimFailureCause:
+    FUNCTION_NAME = "queue_download_video"
+
+    def test_rechecks_video_status_after_claim_failure(self):
+        source = _function_source(self.FUNCTION_NAME)
+        claim_pos = source.index("if not claim_video_for_redownload(")
+        refresh_pos = source.index('session.refresh(video, attribute_names=["status"])')
+        assert claim_pos < refresh_pos
+
+    def test_only_reports_already_downloading_when_status_genuinely_downloading(self):
+        source = _function_source(self.FUNCTION_NAME)
+        assert "if video.status == VideoStatus.DOWNLOADING:" in source
+
+    def test_reports_a_real_error_when_status_is_not_downloading(self):
+        source = _function_source(self.FUNCTION_NAME)
+        downloading_check_pos = source.index(
+            "if video.status == VideoStatus.DOWNLOADING:"
+        )
+        tail = source[downloading_check_pos:]
+        assert '"success": False' in tail
+
+    def test_explicitly_discards_the_staged_download_row_on_claim_error(self):
+        source = _function_source(self.FUNCTION_NAME)
+        downloading_check_pos = source.index(
+            "if video.status == VideoStatus.DOWNLOADING:"
+        )
+        tail = source[downloading_check_pos:]
+        assert "session.rollback()" in tail

--- a/tests/unit/test_claim_video_lock_timeout_diagnostics.py
+++ b/tests/unit/test_claim_video_lock_timeout_diagnostics.py
@@ -1,0 +1,107 @@
+"""Tests for diagnostic instrumentation added to
+claim_video_for_redownload() after a live-reported bug: multiple videos
+(106, 133, others) intermittently failed to claim with
+`pymysql.err.OperationalError (1205, 'Lock wait timeout exceeded')`,
+recurring in bursts over several minutes. Direct investigation (manual
+reproduction, live information_schema.innodb_trx queries between
+failures) could not catch the blocking transaction in the act -- by the
+time each failure was noticed, the lock had already cleared.
+
+Since the root cause couldn't be pinned down after live investigation,
+this adds diagnostic capture: when a lock-wait-timeout is caught, query
+information_schema.innodb_trx / processlist via a fresh connection and
+log what else was active at that moment, so the NEXT occurrence leaves
+hard evidence instead of requiring another live chase. This is
+diagnostic-only and must never itself raise past this function or
+change its return value -- claim_video_for_redownload() must keep
+behaving exactly as before on every path.
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "services" / "video_batch_service.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestDiagnosticCaptureIsPresent:
+    def test_detects_lock_wait_timeout_specifically(self):
+        source = _function_source("claim_video_for_redownload")
+        assert "1205" in source or "Lock wait timeout" in source
+
+    def test_queries_innodb_trx_for_diagnostics(self):
+        source = _function_source("claim_video_for_redownload")
+        assert "innodb_trx" in source
+
+    def test_diagnostic_capture_is_itself_exception_safe(self):
+        """The diagnostic query must be wrapped in its own try/except --
+        a failure to gather diagnostics (e.g. against non-MariaDB
+        backends, or a second connection failure) must never escape and
+        must never replace the original error being diagnosed."""
+        source = _function_source("claim_video_for_redownload")
+        # Count try/except pairs: the original function had exactly one
+        # (the outer claim try/except). Adding diagnostic capture with
+        # its own safety net means there must now be at least two.
+        try_count = source.count("try:")
+        assert try_count >= 2
+
+
+class TestDiagnosticCaptureNeverChangesBehavior:
+    def test_still_returns_false_on_any_claim_failure(self):
+        source = _function_source("claim_video_for_redownload")
+        assert "return False" in source
+
+    def test_original_error_still_logged(self):
+        source = _function_source("claim_video_for_redownload")
+        assert "Failed to claim video" in source
+
+
+class TestDiagnosticCaptureBehavioral:
+    """Real behavioral test: force claim_video_for_redownload() to hit
+    a lock-wait-timeout-shaped exception and confirm the function still
+    returns False cleanly even if the diagnostic-gathering code itself
+    also raises (e.g. because this test's fake DB has no
+    information_schema.innodb_trx to query)."""
+
+    def test_returns_false_even_if_diagnostic_query_itself_fails(self):
+        import src.database.connection as db_connection
+        from src.services.video_batch_service import claim_video_for_redownload
+
+        class FakeConn:
+            def execute(self, *args, **kwargs):
+                raise Exception("(1205, 'Lock wait timeout exceeded')")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        class FakeEngine:
+            def begin(self):
+                return FakeConn()
+
+            def connect(self):
+                raise Exception("diagnostic connection also failed")
+
+        fake_db_manager = MagicMock()
+        fake_db_manager.create_engine.return_value = FakeEngine()
+
+        with patch.object(db_connection, "db_manager", fake_db_manager):
+            result = claim_video_for_redownload(999999)
+
+        assert result is False


### PR DESCRIPTION
## Summary

Live-reported bug: clicking Download on a video (repro'd on video 106, and confirmed by the user to also affect 133 and others) repeatedly failed. First attempt showed no message; a later one showed a generic "Error starting download" toast; nothing ever appeared in download queue or history.

## Root cause

`claim_video_for_redownload()` returns `False` for two very different situations, indistinguishable from its return value alone:
1. The video genuinely lost a race to a concurrent claim (a real "already downloading" case).
2. The claim attempt itself errored — live-observed as `pymysql.err.OperationalError (1205, 'Lock wait timeout exceeded')`.

Both `queue_video_download()` and `queue_download_video()` (`src/api/fastapi/videos_downloads.py`) treated any `False` return identically, reporting "Video is currently downloading" even when the true cause was a transient DB error — actively misleading, since nothing was actually in progress. Worse, the staged (uncommitted) `Download` row was silently discarded when the request's session closed, leaving zero trace of the attempt anywhere.

## Fix 1 — distinguish the two cases

After a claim failure, both functions now re-check the video's actual status. Only a genuine `DOWNLOADING` status gets the "already downloading" message; anything else explicitly rolls back the staged row and returns a real, retriable `success: false` error.

## Fix 2 — diagnostic instrumentation for the open question

I could not pin down *why* the lock-wait-timeout itself recurs. Extensive live investigation (direct reproduction, polling `information_schema.innodb_trx` between failures, code review of every DB-writing path touching video rows) found no active blocking transaction at any point I checked, and no architectural smoking gun — `download_video()` correctly runs in a background thread rather than holding a session open across the yt-dlp subprocess call, and every DB write I reviewed uses short-lived, promptly-committed transactions. The lock had always already cleared by the time I could inspect it.

Rather than guess further, `claim_video_for_redownload()` now captures `information_schema.innodb_trx` state via a fresh connection specifically when it hits a 1205 error, logging what else was active at that exact moment. Diagnostic-only, wrapped in its own exception handler — never raises past the function or changes its return value. If this recurs, the logs will show what's actually holding the lock instead of requiring another live chase after the fact.

## Testing

425 tests passing: 411 baseline (post Phase-1 route-auth-sweep) + 8 new for the claim-failure fix + 6 new for the diagnostic instrumentation. `black --check` / `isort --check-only` clean.

## Follow-up

If the diagnostic logging surfaces a real blocking transaction next time this recurs, that's a separate fix to file once we have evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)