### PR TITLE
fix(downloads): manually-queued downloads showed twice in Download Queue widget

### DIFF
--- a/src/api/fastapi/metube.py
+++ b/src/api/fastapi/metube.py
@@ -158,6 +158,49 @@ async def test_connection(
         )
 
 
+def _dedupe_recent_db_downloads(
+    queue_items: List[Dict[str, Any]],
+    recent_downloads: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge recently-created Download rows into an in-memory download
+    queue without duplicating an entry already represented there.
+
+    A given download can appear in queue_items two ways: keyed by its
+    Download.id (a "db_download_id" field) or -- for a video flipped to
+    DOWNLOADING with no live Download row tracked in memory -- keyed by
+    its Video.id (a "video_id" field; see unified_download_service.
+    get_download_queue()). That first source never sets
+    "db_download_id", so a dedup check against only that field is a
+    permanent no-op: any download normally represented by both sources
+    (the common case -- claiming a video sets it DOWNLOADING *and*
+    creates a matching Download row) gets appended a second time.
+    Live-reported 2026-08-20: every manual download showed up twice in
+    the Download Queue widget once downloads started actually
+    completing quickly instead of self-deadlocking for ~50s (#401).
+
+    Dedupe by both db_download_id and video_id so either source
+    matching is enough to skip the duplicate.
+    """
+    existing_db_ids = {
+        item["db_download_id"] for item in queue_items if item.get("db_download_id")
+    }
+    existing_video_ids = {
+        item["video_id"] for item in queue_items if item.get("video_id") is not None
+    }
+
+    merged = list(queue_items)
+    for entry in recent_downloads:
+        if entry.get("db_download_id") in existing_db_ids:
+            continue
+        if (
+            entry.get("video_id") is not None
+            and entry["video_id"] in existing_video_ids
+        ):
+            continue
+        merged.append(entry)
+    return merged
+
+
 @router.get("/queue", response_model=QueueResponse)
 async def get_download_queue(
     current_user: dict = Depends(require_authentication),
@@ -172,13 +215,6 @@ async def get_download_queue(
         # Get queue from ytdlp service (in-memory downloads)
         legacy_result = ytdlp_service.get_queue()
         queue_items = legacy_result.get("queue", [])
-
-        # Track database download IDs already in the in-memory queue to avoid duplicates
-        existing_db_ids = set()
-        for item in queue_items:
-            db_download_id = item.get("db_download_id")
-            if db_download_id:
-                existing_db_ids.add(db_download_id)
 
         # Also check for recent downloads that might be processing but not in memory
         try:
@@ -201,26 +237,29 @@ async def get_download_queue(
                 .all()
             )
 
-            # Only add downloads that aren't already in the in-memory queue
-            for download, artist_name in recent_downloads:
-                if download.id not in existing_db_ids:
-                    queue_entry = {
-                        "id": f"db_{download.id}",
-                        "title": download.title,
-                        "artist": artist_name,
-                        "url": download.original_url,
-                        "status": download.status,
-                        "progress": download.progress or 0,
-                        "quality": download.quality or "best",
-                        "created_at": (
-                            download.created_at.isoformat()
-                            if download.created_at
-                            else None
-                        ),
-                        "task_type": "database",
-                        "db_download_id": download.id,
-                    }
-                    queue_items.append(queue_entry)
+            recent_entries = [
+                {
+                    "id": f"db_{download.id}",
+                    "title": download.title,
+                    "artist": artist_name,
+                    "url": download.original_url,
+                    "status": download.status,
+                    "progress": download.progress or 0,
+                    "quality": download.quality or "best",
+                    "created_at": (
+                        download.created_at.isoformat() if download.created_at else None
+                    ),
+                    "task_type": "database",
+                    "db_download_id": download.id,
+                    "video_id": download.video_id,
+                }
+                for download, artist_name in recent_downloads
+            ]
+
+            # Merge without duplicating a download already represented
+            # in the in-memory queue -- see _dedupe_recent_db_downloads()
+            # for why this can't be a plain db_download_id-only check.
+            queue_items = _dedupe_recent_db_downloads(queue_items, recent_entries)
 
         except Exception as db_error:
             logger.warning(f"Failed to get recent database downloads: {db_error}")

--- a/tests/unit/test_download_queue_dedup.py
+++ b/tests/unit/test_download_queue_dedup.py
@@ -1,0 +1,89 @@
+"""Regression test for a live-reported bug: a manually-queued download
+showed up TWICE in the Download Queue dashboard widget while it was
+downloading (both entries reading "Downloading (0%)"), even though the
+`downloads` table only ever had one row for it.
+
+Root cause: GET /api/metube/queue (get_download_queue() in metube.py)
+merges two sources -- unified_download_service.get_download_queue()
+(one entry per Video.status == DOWNLOADING, id "video_{video.id}",
+carrying a "video_id" field but no "db_download_id") and a direct scan
+of recent Download rows in ["queued", "downloading"] status (id
+"db_{download.id}", carrying "db_download_id"). The merge's dedup check
+only ever looked at "db_download_id" -- a key the first source never
+sets -- so it was permanently a no-op: every download normally
+represented by *both* sources (the common case, since claiming a video
+sets it DOWNLOADING and always creates a matching Download row) was
+appended twice.
+
+This went unnoticed before #401 because queue_download_video() was
+self-deadlocking on every genuinely-new download (~50s per attempt),
+so a download rarely got far enough, fast enough, for both sources to
+report it as in-progress at the same moment a user looked.
+
+Fix: dedup by video_id in addition to db_download_id, since the first
+source always sets video_id even though it never sets db_download_id.
+"""
+
+from src.api.fastapi.metube import _dedupe_recent_db_downloads
+
+
+class TestDedupeRecentDbDownloads:
+    def test_skips_a_db_row_whose_video_id_is_already_queued(self):
+        """The exact live-reported shape: a video-status entry (no
+        db_download_id) and a recent Download row for the same video."""
+        queue_items = [
+            {
+                "id": "video_149",
+                "title": "My Spirit Animal Ate Your Spirit Animal",
+                "artist": "Dead Pioneers",
+                "status": "downloading",
+                "video_id": 149,
+            }
+        ]
+        recent_downloads = [
+            {
+                "id": "db_95",
+                "title": "My Spirit Animal Ate Your Spirit Animal",
+                "artist": "Dead Pioneers",
+                "status": "downloading",
+                "db_download_id": 95,
+                "video_id": 149,
+            }
+        ]
+
+        merged = _dedupe_recent_db_downloads(queue_items, recent_downloads)
+
+        assert len(merged) == 1
+        assert merged[0]["id"] == "video_149"
+
+    def test_skips_a_db_row_whose_download_id_is_already_queued(self):
+        """Belt-and-braces: still dedupes the original db_download_id
+        match too, for whichever source (if any) ever sets it."""
+        queue_items = [{"id": "db_95", "db_download_id": 95, "video_id": 149}]
+        recent_downloads = [{"id": "db_95", "db_download_id": 95, "video_id": 149}]
+
+        merged = _dedupe_recent_db_downloads(queue_items, recent_downloads)
+
+        assert len(merged) == 1
+
+    def test_keeps_a_genuinely_different_download(self):
+        """Two unrelated downloads (different videos) must both survive
+        the merge -- the fix must not over-dedupe."""
+        queue_items = [{"id": "video_149", "video_id": 149}]
+        recent_downloads = [{"id": "db_96", "db_download_id": 96, "video_id": 200}]
+
+        merged = _dedupe_recent_db_downloads(queue_items, recent_downloads)
+
+        assert len(merged) == 2
+        assert {item["id"] for item in merged} == {"video_149", "db_96"}
+
+    def test_recent_download_with_no_video_id_is_not_dropped(self):
+        """A Download row with no video_id (nullable in the schema)
+        must never accidentally match every video-less queue_item on a
+        shared `None` key."""
+        queue_items = [{"id": "video_149", "video_id": 149}]
+        recent_downloads = [{"id": "db_97", "db_download_id": 97, "video_id": None}]
+
+        merged = _dedupe_recent_db_downloads(queue_items, recent_downloads)
+
+        assert len(merged) == 2


### PR DESCRIPTION
## Summary

Fixes a live-reported bug (found immediately after #401): a video sent to download appeared **twice** in the dashboard's Download Queue widget while downloading, both reading "Downloading (0%)" — even though the `downloads` table only ever had one row for it (confirmed directly against the DB).

## Root cause

`GET /api/metube/queue` (`get_download_queue()` in `metube.py`) merges two sources:

1. `unified_download_service.get_download_queue()` — one entry per `Video.status == DOWNLOADING`, id `"video_{video.id}"`, carrying a `video_id` field but **never** a `db_download_id`.
2. A direct scan of recent `Download` rows in `["queued", "downloading"]` status, id `"db_{download.id}"`, carrying `db_download_id`.

The merge's dedup check only ever compared `db_download_id` — a key the first source never sets — so it was a **permanent no-op**: any download represented by both sources (the common case, since claiming a video sets it `DOWNLOADING` *and* creates a matching `Download` row) got appended a second time.

This went unnoticed before #401 because `queue_download_video()` was self-deadlocking on every genuinely-new download (~50s per attempt), so downloads rarely got far enough, fast enough, for both sources to report the same download as in-progress at the same moment a user looked.

## Fix

Extracted the merge into a pure, unit-testable `_dedupe_recent_db_downloads()` helper and dedupe by `video_id` in addition to `db_download_id`, since the video-status source always sets `video_id` even though it never sets `db_download_id`.

## Testing

- New test (`tests/unit/test_download_queue_dedup.py`), 4 cases: the exact live-reported shape (video-status entry + matching DB row → 1 result), the original `db_download_id` match path still works, two genuinely different downloads both survive, and a `Download` row with a null `video_id` doesn't get incorrectly matched against every video-less entry. Verified RED (ImportError, helper didn't exist) before the fix, GREEN after.
- Sibling `test_metube_queue_id_parsing.py` (the only other existing test touching this file) still passes unchanged.
- `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)