### PR TITLE
fix(downloads): single-video dispatch paths didn't revert on {"success": False} results

### DIFF
--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -547,10 +547,40 @@ async def queue_video_download(
                 download_id=download.id,
             )
 
+            # #383: revert on a falsy/{"success": False} dispatch result
+            # too, not just a raised exception -- DownloadServiceAdapter.
+            # add_music_video_download() wraps its whole body in
+            # try/except and returns {"success": False, "error": ...} on
+            # failure rather than propagating; the except block below
+            # only ever catches something *raised*. Without this check,
+            # a graceful dispatch failure left the video stuck at
+            # DOWNLOADING with a "queued" Download row forever. Mirrors
+            # bulk_download_videos()'s #379.6 fix and the identical fix
+            # in queue_download_video() below.
+            if not (result and result.get("success")):
+                dispatch_error_message = (
+                    result.get("error", "Unknown dispatch error")
+                    if result
+                    else "Unknown dispatch error"
+                )
+                logger.error(
+                    f"Dispatch failed for video {video_id}: {dispatch_error_message}"
+                )
+                video.status = original_status
+                download.status = "failed"
+                download.error_message = dispatch_error_message
+                session.commit()
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to start download: {dispatch_error_message}",
+                )
+
             logger.info(
                 f"Submitted download to unified service for video {video_id}: {result}"
             )
 
+        except HTTPException:
+            raise
         except Exception as download_error:
             logger.error(
                 f"Failed to submit download to unified service for video {video_id}: {download_error}"
@@ -561,6 +591,14 @@ async def queue_video_download(
             # retried FAILED video to WANTED would silently enroll it in the
             # auto-download queue.
             video.status = original_status
+            # Match the falsy-result branch above: mark the Download row
+            # failed here too, not just the video's status. Left as
+            # "queued" before this fix, a Download row from a raised
+            # (not merely falsy) dispatch failure would still show up as
+            # a phantom in-progress entry in the Download Queue widget
+            # for up to 2 hours (see metube.py's get_download_queue()).
+            download.status = "failed"
+            download.error_message = str(download_error)
             session.commit()
             raise HTTPException(
                 status_code=500,
@@ -798,6 +836,36 @@ async def queue_download_video(
                 download_id=download.id,
             )
 
+            # #383: revert on a falsy/{"success": False} dispatch result
+            # too, not just a raised exception -- DownloadServiceAdapter.
+            # add_music_video_download() wraps its whole body in
+            # try/except and returns {"success": False, "error": ...} on
+            # failure rather than propagating; the except block below
+            # only ever catches something *raised*. Without this check,
+            # a graceful dispatch failure left the video stuck at
+            # DOWNLOADING with a "queued" Download row forever, and this
+            # endpoint reported success anyway. Mirrors
+            # bulk_download_videos()'s #379.6 fix and the identical fix
+            # in queue_video_download() above.
+            if not (result and result.get("success")):
+                dispatch_error_message = (
+                    result.get("error", "Unknown dispatch error")
+                    if result
+                    else "Unknown dispatch error"
+                )
+                logger.error(
+                    f"Dispatch failed for video {video_id}: {dispatch_error_message}"
+                )
+                video.status = original_status
+                download.status = "failed"
+                download.error_message = dispatch_error_message
+                session.commit()
+                return {
+                    "success": False,
+                    "error": f"Failed to start download: {dispatch_error_message}",
+                    "video_id": video_id,
+                }
+
             logger.info(
                 f"Successfully submitted download {download.id} for video {video_id} to unified service: {result}"
             )
@@ -820,6 +888,11 @@ async def queue_download_video(
             # retried FAILED video to WANTED would silently enroll it in the
             # auto-download queue.
             video.status = original_status
+            # Match the falsy-result branch above: mark the Download row
+            # failed here too (see queue_video_download()'s identical
+            # comment above for why).
+            download.status = "failed"
+            download.error_message = str(download_error)
             session.commit()
             return {
                 "success": False,

--- a/tests/unit/test_single_video_download_reverts_on_falsy_result.py
+++ b/tests/unit/test_single_video_download_reverts_on_falsy_result.py
@@ -1,0 +1,230 @@
+"""Real behavioral tests for #383: queue_video_download() (POST
+/{video_id}/download) and queue_download_video() (POST
+/{video_id}/queue-download) must revert video.status -- and mark the
+staged Download row failed -- on a falsy/{"success": False} dispatch
+result from ytdlp_service.add_music_video_download(), not just on a
+raised exception. bulk_download_videos() already got this exact fix
+(#379.6); these two single-video siblings were explicitly left out of
+that fix's scope.
+
+Uses real SQLAlchemy models against an in-memory SQLite database
+rather than static source-text assertions (see #384): importing
+src.api.fastapi.videos_downloads succeeds fine in this test venv --
+the RuntimeError("yt-dlp executable not found") only fires from
+unified_download_service's real singleton construction, which is only
+reached via the function-local `from
+src.services.download_service_adapter import ytdlp_service` inside
+these routes' dispatch try blocks. A sys.modules pre-registration of a
+fake module bypasses that import entirely, so the route functions can
+be called directly and their real behavior verified end to end.
+"""
+
+import asyncio
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.api.fastapi.videos_downloads import (
+    queue_download_video,
+    queue_video_download,
+)
+from src.database.connection import Base
+from src.database.models import Artist, Download, Video, VideoStatus
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
+    )
+    return sessionmaker(bind=engine)
+
+
+def _seed_video(session_factory, status=VideoStatus.WANTED):
+    session = session_factory()
+    artist = Artist(name="Test Artist")
+    session.add(artist)
+    session.commit()
+
+    video = Video(
+        artist_id=artist.id,
+        title="Test Song",
+        status=status,
+        url="https://youtube.com/watch?v=abc123",
+        youtube_id="abc123",
+    )
+    session.add(video)
+    session.commit()
+    video_id = video.id
+    session.close()
+    return video_id
+
+
+@contextmanager
+def _dispatch_result(result, session_factory):
+    """Shim src.services.download_service_adapter.ytdlp_service so the
+    function-local import inside the route under test resolves to a
+    fake whose add_music_video_download() returns `result` (or raises
+    it, if it's an exception instance) instead of touching the real
+    yt-dlp-backed singleton.
+
+    Also fakes claim_video_for_redownload() -- in production it flips
+    video.status to DOWNLOADING on its own, separate DB connection
+    (see its docstring), so a bare `return_value=True` mock would never
+    actually touch this test's SQLite-backed video row. Instead, the
+    fake performs that same status flip for real, on a fresh session
+    from the same in-memory engine -- a faithful, fast stand-in for the
+    real separate-connection claim.
+    """
+
+    def _fake_add_music_video_download(**kwargs):
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def _fake_claim(video_id):
+        claim_session = session_factory()
+        try:
+            video = claim_session.query(Video).filter(Video.id == video_id).first()
+            if video is None or video.status == VideoStatus.DOWNLOADING:
+                return False
+            video.status = VideoStatus.DOWNLOADING
+            claim_session.commit()
+            return True
+        finally:
+            claim_session.close()
+
+    fake_module = types.ModuleType("src.services.download_service_adapter")
+    fake_module.ytdlp_service = types.SimpleNamespace(
+        add_music_video_download=_fake_add_music_video_download
+    )
+    with patch.dict(
+        sys.modules, {"src.services.download_service_adapter": fake_module}
+    ):
+        with patch(
+            "src.services.video_batch_service.claim_video_for_redownload",
+            side_effect=_fake_claim,
+        ):
+            yield
+
+
+class TestQueueDownloadVideoRevertsOnFalsyResult:
+    """POST /{video_id}/queue-download"""
+
+    def test_reverts_video_status_and_marks_download_failed_on_falsy_result(
+        self, session_factory
+    ):
+        video_id = _seed_video(session_factory, status=VideoStatus.WANTED)
+        session = session_factory()
+
+        with _dispatch_result(
+            {"success": False, "error": "yt-dlp exploded"}, session_factory
+        ):
+            result = asyncio.run(
+                queue_download_video(
+                    video_id=video_id,
+                    current_user={"user_id": 1, "username": "test"},
+                    session=session,
+                )
+            )
+
+        assert result["success"] is False
+        assert "yt-dlp exploded" in result["error"]
+
+        session.expire_all()
+        video = session.query(Video).filter(Video.id == video_id).first()
+        assert video.status == VideoStatus.WANTED
+
+        download = session.query(Download).filter(Download.video_id == video_id).first()
+        assert download is not None
+        assert download.status == "failed"
+        assert download.error_message == "yt-dlp exploded"
+
+    def test_succeeds_normally_on_a_truthy_result(self, session_factory):
+        video_id = _seed_video(session_factory, status=VideoStatus.WANTED)
+        session = session_factory()
+
+        with _dispatch_result({"success": True, "id": 999}, session_factory):
+            result = asyncio.run(
+                queue_download_video(
+                    video_id=video_id,
+                    current_user={"user_id": 1, "username": "test"},
+                    session=session,
+                )
+            )
+
+        assert result["success"] is True
+
+        session.expire_all()
+        video = session.query(Video).filter(Video.id == video_id).first()
+        assert video.status == VideoStatus.DOWNLOADING
+
+        download = session.query(Download).filter(Download.video_id == video_id).first()
+        assert download is not None
+        assert download.status == "queued"
+
+
+class TestQueueVideoDownloadRevertsOnFalsyResult:
+    """POST /{video_id}/download"""
+
+    def test_reverts_video_status_and_marks_download_failed_on_falsy_result(
+        self, session_factory
+    ):
+        video_id = _seed_video(session_factory, status=VideoStatus.WANTED)
+        session = session_factory()
+
+        with _dispatch_result(
+            {"success": False, "error": "yt-dlp exploded"}, session_factory
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    queue_video_download(
+                        video_id=video_id,
+                        request={},
+                        current_user={"user_id": 1, "username": "test"},
+                        session=session,
+                    )
+                )
+
+        assert exc_info.value.status_code == 500
+        assert "yt-dlp exploded" in exc_info.value.detail
+
+        session.expire_all()
+        video = session.query(Video).filter(Video.id == video_id).first()
+        assert video.status == VideoStatus.WANTED
+
+        download = session.query(Download).filter(Download.video_id == video_id).first()
+        assert download is not None
+        assert download.status == "failed"
+        assert download.error_message == "yt-dlp exploded"
+
+    def test_succeeds_normally_on_a_truthy_result(self, session_factory):
+        video_id = _seed_video(session_factory, status=VideoStatus.WANTED)
+        session = session_factory()
+
+        with _dispatch_result({"success": True, "id": 999}, session_factory):
+            result = asyncio.run(
+                queue_video_download(
+                    video_id=video_id,
+                    request={},
+                    current_user={"user_id": 1, "username": "test"},
+                    session=session,
+                )
+            )
+
+        assert result["video_id"] == video_id
+
+        session.expire_all()
+        video = session.query(Video).filter(Video.id == video_id).first()
+        assert video.status == VideoStatus.DOWNLOADING
+
+        download = session.query(Download).filter(Download.video_id == video_id).first()
+        assert download is not None
+        assert download.status == "queued"


### PR DESCRIPTION
Closes #383

## Summary

`bulk_download_videos()` already reverts `video.status` (and marks the `Download` row failed) on ANY dispatch failure — both a raised exception and a falsy/`{"success": False}` return from `ytdlp_service.add_music_video_download()` (#379.6). That fix was explicitly scoped to the bulk endpoint only.

Its two single-video siblings — `queue_video_download()` (`POST /{video_id}/download`) and `queue_download_video()` (`POST /{video_id}/queue-download`) — still only handled a *raised* exception. `DownloadServiceAdapter.add_music_video_download()` wraps its entire body in try/except and returns `{"success": False, "error": ...}` on failure rather than propagating, so this dispatch failure mode never raises at all: the video was left stuck at `DOWNLOADING` with its `Download` row stuck at `"queued"` forever, and both endpoints reported success anyway.

## Fix

Check `result.get("success")` after the dispatch call in both functions, mirroring `bulk_download_videos()`'s already-correct pattern. Also extended the pre-existing exception-path revert in both functions to mark the `Download` row `"failed"` (previously it only reverted `video.status`), for consistency with the new falsy-result branch — otherwise an exception-triggered revert would leave the `Download` row lying at `"queued"` for up to 2 hours (`metube.py`'s `get_download_queue()` recency window), showing as a phantom in-progress entry in the Download Queue widget (the exact class of bug fixed for a different root cause in #402).

## Testing (also makes progress on #384)

New real behavioral tests (`tests/unit/test_single_video_download_reverts_on_falsy_result.py`) — SQLite-backed, with a `sys.modules` shim for the `ytdlp_service` import — rather than static source-assertion tests, per #384's finding that importing this module directly works fine in this test venv: the yt-dlp `RuntimeError` only fires from the function-local import at dispatch time, which the shim bypasses.

4 test cases (2 functions × truthy-success / falsy-revert):
- Verified RED before the fix: the 2 falsy-result cases correctly failed (proving the bug), the 2 truthy-success cases already passed (confirming the shim/claim-fake test infrastructure itself is sound, not just tautologically green).
- GREEN after the fix.

Broader regression sweep (72 tests across all `videos_downloads.py`/`metube.py`-adjacent test files) passes. `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)