### PR TITLE
fix(migrations): idempotency/determinism gaps in 024 and 025 downgrade()

### DIFF
--- a/migrations/024_add_youtube_id_unique_constraint.py
+++ b/migrations/024_add_youtube_id_unique_constraint.py
@@ -84,12 +84,19 @@ def downgrade(connection):
     SQLAlchemy-generated name (upgrade() was already fixed to handle
     this asymmetry -- #377 Finding 6 -- but downgrade() was not).
     """
+    # #385: seq_in_index = 1 + ORDER BY make this deterministic. Without
+    # them, a composite unique index containing youtube_id as a
+    # non-first column (none exists today, but nothing prevents one
+    # being added later) could be nondeterministically selected instead
+    # of the intended single-column index.
     result = connection.execute(text("""
         SELECT index_name FROM information_schema.statistics
         WHERE table_schema = DATABASE()
         AND table_name = 'videos'
         AND column_name = 'youtube_id'
         AND non_unique = 0
+        AND seq_in_index = 1
+        ORDER BY index_name
         LIMIT 1
     """))
     row = result.fetchone()

--- a/migrations/025_drop_redundant_youtube_id_index.py
+++ b/migrations/025_drop_redundant_youtube_id_index.py
@@ -36,7 +36,22 @@ def upgrade(connection):
 
 
 def downgrade(connection):
-    """Recreate the old non-unique index"""
+    """Recreate the old non-unique index, if not already present.
+
+    #385: guards symmetrically with upgrade() above -- without this
+    check, re-running downgrade() (or downgrading when the index is
+    already present) errors with MariaDB 1061 (duplicate key name).
+    """
+    result = connection.execute(text("""
+        SELECT COUNT(*) FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+        AND table_name = 'videos'
+        AND index_name = 'idx_video_youtube_id'
+    """))
+    if result.scalar() > 0:
+        print("✅ idx_video_youtube_id already present (skipped)")
+        return
+
     connection.execute(text("""
         ALTER TABLE videos
         ADD INDEX idx_video_youtube_id (youtube_id)

--- a/tests/unit/test_migration_024_downgrade_is_name_agnostic.py
+++ b/tests/unit/test_migration_024_downgrade_is_name_agnostic.py
@@ -20,3 +20,21 @@ class TestMigration024DowngradeIsNameAgnostic:
         # with no lookup first. The fix must look up the actual index
         # name via information_schema before dropping.
         assert "information_schema.statistics" in downgrade_source
+
+
+class TestMigration024DowngradeIndexLookupSafety:
+    """#385: the index-name lookup filters on column_name and
+    non_unique alone, with no seq_in_index/ORDER BY safety. If a
+    composite unique index containing youtube_id as a non-first column
+    were ever added, this could nondeterministically pick the wrong
+    index to drop. Low likelihood today, cheap to tighten."""
+
+    def test_filters_to_the_first_column_position_in_the_index(self):
+        source = MIGRATION_PATH.read_text()
+        downgrade_source = source[source.index("def downgrade(connection):") :]
+        assert "seq_in_index = 1" in downgrade_source
+
+    def test_orders_results_for_determinism(self):
+        source = MIGRATION_PATH.read_text()
+        downgrade_source = source[source.index("def downgrade(connection):") :]
+        assert "order by" in downgrade_source.lower()

--- a/tests/unit/test_migration_025_drop_redundant_index.py
+++ b/tests/unit/test_migration_025_drop_redundant_index.py
@@ -29,3 +29,22 @@ class TestMigration025Structure:
         drop_pos = source.index("DROP INDEX idx_video_youtube_id")
         check_pos = source.index("information_schema.statistics")
         assert check_pos < drop_pos
+
+
+class TestMigration025DowngradeIsIdempotent:
+    """#385: downgrade() re-adds idx_video_youtube_id with no existence
+    guard -- re-running it, or downgrading when the index is already
+    present, errors with MariaDB 1061 (duplicate key name). upgrade()
+    already guards symmetrically; downgrade() should too."""
+
+    def test_downgrade_checks_for_existence_before_adding(self):
+        source = MIGRATION_PATH.read_text()
+        downgrade_source = source[source.index("def downgrade(connection):") :]
+        assert "information_schema.statistics" in downgrade_source
+
+    def test_downgrade_does_not_unconditionally_add_the_index(self):
+        source = MIGRATION_PATH.read_text()
+        downgrade_source = source[source.index("def downgrade(connection):") :]
+        add_pos = downgrade_source.index("ADD INDEX idx_video_youtube_id")
+        check_pos = downgrade_source.index("information_schema.statistics")
+        assert check_pos < add_pos


### PR DESCRIPTION
Closes #385

## Summary

Two small correctness gaps surfaced during #379/#380's final review, neither a live-migration blocker (downgrades aren't run automatically), both cheap to close:

1. **`migrations/025`'s `downgrade()`** had no existence guard before `ALTER TABLE videos ADD INDEX idx_video_youtube_id (youtube_id)` — re-running it, or downgrading when the index is already present, errored with MariaDB 1061 (duplicate key name). `upgrade()` already guards symmetrically via `information_schema.statistics`; `downgrade()` now does too.

2. **`migrations/024`'s `downgrade()`** (fixed by #379.5 to look up the real index name instead of hardcoding it) filtered only on `column_name` and `non_unique`, with no `seq_in_index`/`ORDER BY` safety. If a composite unique index containing `youtube_id` as a non-first column were ever added, this could nondeterministically pick the wrong index to drop. Added `AND seq_in_index = 1` and `ORDER BY index_name`.

## Testing

Extended the existing static source-assertion test files for both migrations — the established pattern for this domain, since these use MariaDB-specific DDL/`information_schema` syntax SQLite can't run (unlike the FastAPI route fixes in #401–#403, where real SQLite-backed behavioral tests were viable). Verified RED (4 new assertions failed against the pre-fix source) before the fix, GREEN after. `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)