### PR TITLE
fix(security): scheduler_v2.py's 11 API routes had zero authentication

### DIFF
--- a/src/api/fastapi/scheduler_v2.py
+++ b/src/api/fastapi/scheduler_v2.py
@@ -23,9 +23,10 @@ import asyncio
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.database.connection import get_db
 from src.database.models import ScheduledJob
 from src.services.scheduler_service_v2 import scheduler_v2
@@ -92,7 +93,9 @@ class HealthResponse(BaseModel):
 
 
 @router.get("/status", response_model=SchedulerStatusResponse)
-async def get_scheduler_status() -> Dict[str, Any]:
+async def get_scheduler_status(
+    current_user: dict = Depends(require_authentication),
+) -> Dict[str, Any]:
     """
     Get current scheduler status
 
@@ -108,7 +111,9 @@ async def get_scheduler_status() -> Dict[str, Any]:
 
 
 @router.post("/start")
-async def start_scheduler() -> Dict[str, Any]:
+async def start_scheduler(
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Start the Scheduler V2 service
 
@@ -130,7 +135,9 @@ async def start_scheduler() -> Dict[str, Any]:
 
 
 @router.post("/stop")
-async def stop_scheduler() -> Dict[str, Any]:
+async def stop_scheduler(
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Stop the Scheduler V2 service
 
@@ -155,6 +162,7 @@ async def stop_scheduler() -> Dict[str, Any]:
 async def trigger_discovery(
     background_tasks: BackgroundTasks,
     request: TriggerDiscoveryRequest = None,
+    current_user: dict = Depends(require_admin),
 ) -> Dict[str, Any]:
     """
     Manually trigger video discovery
@@ -191,7 +199,10 @@ async def trigger_discovery(
 
 
 @router.post("/trigger/downloads", response_model=TriggerResponse)
-async def trigger_downloads(background_tasks: BackgroundTasks) -> Dict[str, Any]:
+async def trigger_downloads(
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Manually trigger video downloads
 
@@ -308,6 +319,7 @@ async def get_job_history(
     job_type: Optional[str] = Query(
         None, description="Filter by job type (discovery, download)"
     ),
+    current_user: dict = Depends(require_authentication),
 ) -> Dict[str, Any]:
     """
     Get scheduled job history
@@ -329,7 +341,10 @@ async def get_job_history(
 
 
 @router.get("/jobs/{job_id}")
-async def get_job_details(job_id: str) -> Dict[str, Any]:
+async def get_job_details(
+    job_id: str,
+    current_user: dict = Depends(require_authentication),
+) -> Dict[str, Any]:
     """
     Get specific job details by Celery task ID
 
@@ -359,7 +374,10 @@ async def get_job_details(job_id: str) -> Dict[str, Any]:
 
 
 @router.post("/jobs/{job_id}/retry")
-async def retry_job(job_id: str) -> Dict[str, Any]:
+async def retry_job(
+    job_id: str,
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Retry a failed job
 
@@ -411,7 +429,10 @@ async def retry_job(job_id: str) -> Dict[str, Any]:
 
 
 @router.delete("/jobs/{job_id}")
-async def cancel_job(job_id: str) -> Dict[str, Any]:
+async def cancel_job(
+    job_id: str,
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Cancel a pending or running job
 
@@ -446,7 +467,9 @@ async def cancel_job(job_id: str) -> Dict[str, Any]:
 
 
 @router.get("/health", response_model=HealthResponse)
-async def get_scheduler_health() -> Dict[str, Any]:
+async def get_scheduler_health(
+    current_user: dict = Depends(require_authentication),
+) -> Dict[str, Any]:
     """
     Get scheduler health status
 
@@ -462,7 +485,9 @@ async def get_scheduler_health() -> Dict[str, Any]:
 
 
 @router.post("/settings/reload")
-async def reload_settings() -> Dict[str, Any]:
+async def reload_settings(
+    current_user: dict = Depends(require_admin),
+) -> Dict[str, Any]:
     """
     Reload scheduler settings from database
 

--- a/tests/unit/test_scheduler_v2_auth.py
+++ b/tests/unit/test_scheduler_v2_auth.py
@@ -1,0 +1,137 @@
+"""Tests for scheduler_v2.py's auth fix (#392 Phase 2). Every route in this
+file had zero authentication -- full scheduler control (start/stop/trigger
+discovery/trigger downloads/retry-or-cancel any job/reload settings) was
+reachable by anyone who could hit the app. Fixed by applying the real
+require_authentication/require_admin dependencies (src.api.fastapi.
+auth_dependencies), split by sensitivity: read-only routes get
+require_authentication, state-changing routes get require_admin --
+mirroring the same split already used in settings.py and Phase 1's other
+fixed files.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.scheduler_v2 import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "scheduler_v2.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "get_scheduler_status": "auth",
+    "start_scheduler": "admin",
+    "stop_scheduler": "admin",
+    "trigger_discovery": "admin",
+    "trigger_downloads": "admin",
+    "get_job_history": "auth",
+    "get_job_details": "auth",
+    "retry_job": "admin",
+    "cancel_job": "admin",
+    "get_scheduler_health": "auth",
+    "reload_settings": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestSchedulerV2AllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_eleven_routes_are_covered_by_this_mapping(self):
+        # Guards against a route being added/renamed without updating
+        # EXPECTED_TIER above -- every route on the live router must
+        # appear in the mapping, and vice versa.
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestSchedulerV2BehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/v2/scheduler/status")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post("/api/v2/scheduler/start")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        # require_admin depends on get_current_user directly (see
+        # auth_dependencies.py), not on require_authentication -- so to
+        # reach require_admin's own role-check branch we must override
+        # get_current_user itself, not require_authentication (overriding
+        # the latter would be a no-op for this route and this test would
+        # pass for the wrong reason, or rather not exercise the branch at
+        # all).
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/v2/scheduler/start")
+        # Authenticated but non-admin: require_admin's role check
+        # (role != ADMIN) must reject with 403, not 401.
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/v2/scheduler/start")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/v2/scheduler/status")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Phase 1 (PR #394) closed #386 by fixing 8 confirmed-live, confirmed-dangerous files. Two corrections to #392's own triage table, found while scoping this PR:

- **`analytics_reporting.py`** (listed as a top Phase 2 target, 20 routes) is dead code — never imported or mounted in `fastapi_app.py`. A router-variable-name collision (`analytics_router`, shared with the actually-mounted `personal_insights.py`) likely explains the stale listing. Dropped from scope; no security value in fixing unreachable code.
- **`settings.py`** (listed as another top target, 9 unprotected routes) is already fully protected — all 13 routes have `require_authentication` or `require_admin`, fixed separately in PR #336 (OAuth provider admin UI), unrelated to this sweep. No further work needed there.

That leaves **`scheduler_v2.py`** as the only genuinely live, unprotected target from the original three: all 11 routes had zero auth — anyone reaching the app could start/stop the scheduler, trigger discovery or downloads, retry or cancel any job, and reload settings.

## Fix

Applied `require_authentication` to the 4 read-only routes (`/status`, `/jobs`, `/jobs/{job_id}`, `/health`) and `require_admin` to the 7 state-changing routes (`/start`, `/stop`, `/trigger/discovery`, `/trigger/downloads`, `/jobs/{job_id}/retry`, `DELETE /jobs/{job_id}`, `/settings/reload`) — the same read/write split already used in `settings.py` and every Phase 1 file.

## Also found, filed separately

`wizard.py` is only partially self-disabling post-setup — see #405. Not fixed here (different fix shape).

## Testing

Real behavioral tests via FastAPI's `TestClient` (401 without a session, 403 for an authenticated non-admin on admin routes, success for the correct role) plus an AST-based `EXPECTED_TIER` mapping covering all 11 routes — mirrors the exact pattern already proven in Phase 1's `test_week29_integration_auth.py`. Verified RED (4 failures) before the fix, GREEN after. `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)