### PR TITLE
fix(security): bulk_operations.py's 9 REST routes had zero authentication

### DIFF
--- a/src/api/fastapi/bulk_operations.py
+++ b/src/api/fastapi/bulk_operations.py
@@ -13,12 +13,14 @@ from fastapi import (
     APIRouter,
     BackgroundTasks,
     Body,
+    Depends,
     HTTPException,
     WebSocket,
     WebSocketDisconnect,
 )
 from pydantic import BaseModel, Field, validator
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.jobs.bulk_media_tasks import (
     BulkMediaProcessor,
     BulkOperationStatus,
@@ -197,7 +199,9 @@ async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
 # Bulk Operations Endpoints
 @router.post("/metadata/enrich", response_model=OperationResponse)
 async def enrich_metadata_bulk(
-    request: BulkMetadataEnrichmentRequest, background_tasks: BackgroundTasks
+    request: BulkMetadataEnrichmentRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Enrich metadata for large collections of media files
@@ -265,7 +269,9 @@ async def enrich_metadata_bulk(
 
 @router.post("/collections/import", response_model=OperationResponse)
 async def import_collection(
-    request: CollectionImportRequest, background_tasks: BackgroundTasks
+    request: CollectionImportRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Import large media collections from directories
@@ -334,7 +340,9 @@ async def import_collection(
 
 @router.post("/collections/cleanup", response_model=OperationResponse)
 async def cleanup_collection(
-    request: CollectionCleanupRequest, background_tasks: BackgroundTasks
+    request: CollectionCleanupRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Perform cleanup operations on media collections
@@ -393,7 +401,9 @@ async def cleanup_collection(
 
 # Status and Management Endpoints
 @router.get("/operations/{operation_id}/status", response_model=ProgressResponse)
-async def get_operation_status(operation_id: str):
+async def get_operation_status(
+    operation_id: str, current_user: dict = Depends(require_authentication)
+):
     """Get current status of a bulk operation"""
     try:
         processor = active_processors.get(operation_id)
@@ -432,7 +442,9 @@ async def get_operation_status(operation_id: str):
 
 
 @router.post("/operations/{operation_id}/cancel", response_model=OperationResponse)
-async def cancel_operation(operation_id: str):
+async def cancel_operation(
+    operation_id: str, current_user: dict = Depends(require_admin)
+):
     """Cancel a running bulk operation"""
     try:
         processor = active_processors.get(operation_id)
@@ -463,7 +475,9 @@ async def cancel_operation(operation_id: str):
 
 
 @router.get("/operations/active", response_model=List[Dict[str, Any]])
-async def get_active_operations():
+async def get_active_operations(
+    current_user: dict = Depends(require_authentication),
+):
     """Get list of all active bulk operations"""
     try:
         active_ops = []
@@ -489,6 +503,7 @@ async def create_collection(
     config: Optional[CollectionProcessingConfigRequest] = Body(
         None, description="Processing configuration"
     ),
+    current_user: dict = Depends(require_admin),
 ):
     """Create a new media collection"""
     try:
@@ -534,7 +549,9 @@ async def create_collection(
 
 
 @router.get("/collections/{collection_id}/statistics", response_model=Dict[str, Any])
-async def get_collection_statistics(collection_id: str):
+async def get_collection_statistics(
+    collection_id: str, current_user: dict = Depends(require_authentication)
+):
     """Get comprehensive statistics for a collection"""
     try:
         manager = active_managers.get(collection_id)
@@ -554,7 +571,9 @@ async def get_collection_statistics(collection_id: str):
 
 
 @router.get("/system/statistics", response_model=Dict[str, Any])
-async def get_system_statistics():
+async def get_system_statistics(
+    current_user: dict = Depends(require_authentication),
+):
     """Get overall system statistics for bulk operations"""
     try:
         total_active_operations = sum(
@@ -584,7 +603,9 @@ async def get_system_statistics():
 
 
 @router.delete("/operations/{operation_id}/cleanup")
-async def cleanup_operation(operation_id: str):
+async def cleanup_operation(
+    operation_id: str, current_user: dict = Depends(require_admin)
+):
     """Clean up completed operation resources"""
     try:
         # Remove from active processors

--- a/tests/unit/test_bulk_operations_auth.py
+++ b/tests/unit/test_bulk_operations_auth.py
@@ -1,0 +1,169 @@
+"""Tests for bulk_operations.py's auth fix (#392 Phase 2). All 9 REST
+routes had zero authentication -- including endpoints that accept
+arbitrary filesystem paths (media_paths, source_directory,
+target_directory) and destructive cleanup_rules, letting an
+unauthenticated caller scan, import, or clean up directories anywhere
+readable by the app process.
+
+The 10th route on this router, the WebSocket progress endpoint
+(/progress/{operation_id}), is intentionally NOT covered here.
+WebSocket routes use different dependency-injection machinery than
+regular HTTP routes -- require_authentication ultimately depends on
+`Request`-typed cookie access, and FastAPI's WebSocket routes provide
+a `WebSocket`-typed scope instead, so the same Depends(...) pattern
+used on every other route in this sweep isn't guaranteed to resolve
+correctly there without dedicated testing this sweep doesn't have
+time for right now. Its risk is materially lower than the 9 REST
+routes fixed here: it can only observe progress for an operation_id
+that must already be known (a UUID, not enumerable), not start or
+control any operation.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.bulk_operations import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "bulk_operations.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "enrich_metadata_bulk": "admin",
+    "import_collection": "admin",
+    "cleanup_collection": "admin",
+    "get_operation_status": "auth",
+    "cancel_operation": "admin",
+    "get_active_operations": "auth",
+    "create_collection": "admin",
+    "get_collection_statistics": "auth",
+    "get_system_statistics": "auth",
+    "cleanup_operation": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestBulkOperationsAllRestRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_rest_routes_are_covered_by_this_mapping(self):
+        # The websocket route (websocket_progress_updates) is
+        # deliberately excluded -- see module docstring.
+        rest_route_names = {
+            route.endpoint.__name__
+            for route in router.routes
+            if hasattr(route, "methods")  # excludes the WebSocketRoute
+        }
+        assert rest_route_names == set(EXPECTED_TIER.keys())
+
+
+class TestBulkOperationsBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get(
+            "/api/bulk-operations/collections/somecollection/statistics"
+        )
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post(
+            "/api/bulk-operations/collections/cleanup",
+            json={
+                "collection_id": "x",
+                "target_directory": "/tmp",
+                "cleanup_rules": {},
+            },
+        )
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post(
+            "/api/bulk-operations/collections/cleanup",
+            json={
+                "collection_id": "x",
+                "target_directory": "/tmp",
+                "cleanup_rules": {},
+            },
+        )
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post(
+            "/api/bulk-operations/collections/cleanup",
+            json={
+                "collection_id": "x",
+                "target_directory": "/tmp",
+                "cleanup_rules": {},
+            },
+        )
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get(
+            "/api/bulk-operations/collections/somecollection/statistics"
+        )
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Genuinely high-risk: `enrich_metadata_bulk`, `import_collection`, and `cleanup_collection` all accept arbitrary filesystem paths (`media_paths`, `source_directory`, `target_directory`) plus a free-form `cleanup_rules` dict for the destructive cleanup path — an unauthenticated caller could scan, import, or clean up any directory readable by the app process.

## Fix

`require_authentication` on the 3 read-only status/statistics routes, `require_admin` on the 6 state-changing routes (the 3 arbitrary-path operations above, plus cancel/create/cleanup).

## Deliberately not covered

The 10th route on this router, the WebSocket progress endpoint (`/progress/{operation_id}`). WebSocket routes use different dependency-injection machinery than regular HTTP routes — `require_authentication` ultimately depends on `Request`-typed cookie access, and FastAPI's WebSocket routes provide a `WebSocket`-typed scope instead, so the same `Depends(...)` pattern isn't guaranteed to resolve correctly there without dedicated testing this sweep doesn't have time for right now. Its risk is materially lower than the 9 REST routes fixed here: it can only observe progress for an `operation_id` that must already be known (a UUID, not enumerable), not start or control any operation.

## Testing

Real behavioral tests via FastAPI's `TestClient`, same `EXPECTED_TIER` mapping + 401/403/success pattern as #406/#407, scoped to the 9 REST routes only (asserted explicitly, excluding the `WebSocketRoute`). Verified RED (4 failures) before the fix, GREEN after. `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)