### PR TITLE
fix(security): GET /credentials leaked the instance login username unauthenticated

### DIFF
--- a/src/api/fastapi/auth.py
+++ b/src/api/fastapi/auth.py
@@ -563,8 +563,15 @@ async def oauth_callback(
 
 
 @router.get("/credentials")
-async def get_credentials():
-    """Get current stored username for simple auth"""
+async def get_credentials(current_user: dict = Depends(require_admin)):
+    """Get current stored username for simple auth (requires ADMIN role).
+
+    Leaked the instance-wide login username to any unauthenticated caller
+    before this fix. Only ever called from the admin-only credentials-
+    change form on settings.html (frontend/static/main.js's
+    loadCurrentCredentials()), matching its POST sibling below -- never
+    from the login page.
+    """
     try:
         from src.services.simple_auth_service import SimpleAuthService
 
@@ -693,8 +700,9 @@ async def auth_health():
 
 
 @legacy_router.get("/credentials")
-async def get_credentials_legacy():
-    """Get current stored username for simple auth (legacy endpoint)"""
+async def get_credentials_legacy(current_user: dict = Depends(require_admin)):
+    """Get current stored username for simple auth (legacy endpoint,
+    requires ADMIN role -- see get_credentials() above)."""
     try:
         from src.services.simple_auth_service import SimpleAuthService
 

--- a/tests/unit/test_auth_credentials_leak.py
+++ b/tests/unit/test_auth_credentials_leak.py
@@ -1,0 +1,45 @@
+"""Test for a real gap in auth.py's otherwise-correctly-scoped auth (#392
+Phase 2). Most of this file's routes are intentionally public by design
+(login, logout, OAuth flows, health check -- you can't require a session to
+log in) and POST /credentials is already correctly require_admin-gated
+(fixed ahead of v1.0.0, per its own docstring: any authenticated
+USER/MANAGER/READONLY session could previously change the instance-wide
+login credentials).
+
+GET /credentials (and its legacy twin, GET /auth/credentials) were missed:
+they leak the stored simple-auth username to any unauthenticated caller.
+frontend/static/main.js's loadCurrentCredentials() confirms this is only
+ever called from the admin-only credentials-change form on settings.html
+(pre-filling the username field before an admin edits it) -- never from
+the login page -- so gating it with require_admin, matching its POST
+sibling, breaks nothing.
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "auth.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestGetCredentialsNoLongerLeaksUsername:
+    def test_primary_route_requires_admin(self):
+        source = _function_source("get_credentials")
+        assert "Depends(require_admin)" in source
+
+    def test_legacy_route_requires_admin(self):
+        source = _function_source("get_credentials_legacy")
+        assert "Depends(require_admin)" in source


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

\`auth.py\`'s routes are mostly correctly public by design (login, logout, OAuth flows, health check — you can't require a session to log in), and \`POST /credentials\` is already \`require_admin\`-gated (fixed ahead of v1.0.0: any authenticated USER/MANAGER/READONLY session could previously change the instance-wide login credentials). \`GET /credentials\` (and its legacy twin, \`GET /auth/credentials\`) were missed: they leaked the stored simple-auth username to any unauthenticated caller.

\`frontend/static/main.js\`'s \`loadCurrentCredentials()\` confirms this is only ever called from the admin-only credentials-change form on \`settings.html\` (pre-filling the username field before an admin edits it) — never from the login page — so gating it with \`require_admin\`, matching its POST sibling, breaks nothing.

## Testing

Static source-assertion tests (matches this file's existing pattern for \`POST /credentials\`' own docstring-documented fix; a full TestClient-based behavioral harness felt like more risk than value for a 2-line fix in a file with heavier OAuth/session-store dependencies). Verified RED before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)