### PR TITLE
fix(security): image_processing.py's 8 routes had zero authentication

### DIFF
--- a/src/api/fastapi/image_processing.py
+++ b/src/api/fastapi/image_processing.py
@@ -6,9 +6,10 @@ REST API for concurrent image processing operations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.jobs.image_processing_tasks import (
     ThumbnailSpec,
     submit_bulk_thumbnail_generation,
@@ -96,7 +97,9 @@ class ImageProcessingStatsResponse(BaseModel):
 # Endpoints
 @router.post("/thumbnails/generate", response_model=Dict[str, str])
 async def generate_thumbnails(
-    request: ThumbnailGenerationRequest, background_tasks: BackgroundTasks
+    request: ThumbnailGenerationRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Generate thumbnails for multiple images concurrently
@@ -172,7 +175,9 @@ async def generate_thumbnails(
 
 @router.post("/images/optimize", response_model=Dict[str, str])
 async def optimize_images(
-    request: ImageOptimizationRequest, background_tasks: BackgroundTasks
+    request: ImageOptimizationRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Optimize multiple images concurrently
@@ -214,7 +219,9 @@ async def optimize_images(
 
 @router.post("/images/analyze", response_model=Dict[str, str])
 async def analyze_images(
-    request: ImageAnalysisRequest, background_tasks: BackgroundTasks
+    request: ImageAnalysisRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Analyze multiple images concurrently
@@ -252,7 +259,9 @@ async def analyze_images(
 
 
 @router.get("/stats", response_model=ImageProcessingStatsResponse)
-async def get_processing_stats():
+async def get_processing_stats(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get image processing performance statistics
 
@@ -270,7 +279,9 @@ async def get_processing_stats():
 
 
 @router.get("/presets", response_model=Dict[str, Dict])
-async def get_thumbnail_presets():
+async def get_thumbnail_presets(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get available thumbnail presets
 
@@ -304,6 +315,7 @@ async def generate_preset_thumbnails(
     presets: List[str] = Body(
         ["small", "medium", "large"], description="Preset names to generate"
     ),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Generate thumbnails using predefined presets
@@ -359,7 +371,8 @@ async def generate_preset_thumbnails(
 
 @router.delete("/cache/thumbnails")
 async def clear_thumbnail_cache(
-    output_dir: str = Query(..., description="Thumbnail output directory")
+    output_dir: str = Query(..., description="Thumbnail output directory"),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Clear thumbnail cache
@@ -382,7 +395,8 @@ async def clear_thumbnail_cache(
 
 @router.get("/cache/stats")
 async def get_cache_stats(
-    output_dir: str = Query(..., description="Thumbnail output directory")
+    output_dir: str = Query(..., description="Thumbnail output directory"),
+    current_user: dict = Depends(require_authentication),
 ):
     """
     Get thumbnail cache statistics

--- a/tests/unit/test_image_processing_auth.py
+++ b/tests/unit/test_image_processing_auth.py
@@ -1,0 +1,127 @@
+"""Tests for image_processing.py's auth fix (#392 Phase 2). All 8 routes
+had zero authentication -- including endpoints that accept arbitrary
+filesystem paths (source_paths, output_dir) and write or delete files at
+them, the same risk class fixed for bulk_operations.py in #408.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.image_processing import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "image_processing.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "generate_thumbnails": "admin",
+    "optimize_images": "admin",
+    "analyze_images": "admin",
+    "get_processing_stats": "auth",
+    "get_thumbnail_presets": "auth",
+    "generate_preset_thumbnails": "admin",
+    "clear_thumbnail_cache": "admin",
+    "get_cache_stats": "auth",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestImageProcessingAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestImageProcessingBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/image-processing/presets")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.delete(
+            "/api/image-processing/cache/thumbnails?output_dir=/tmp"
+        )
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.delete(
+            "/api/image-processing/cache/thumbnails?output_dir=/tmp"
+        )
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.delete(
+            "/api/image-processing/cache/thumbnails?output_dir=/tmp"
+        )
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/image-processing/presets")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Same risk class as \`bulk_operations.py\` (#408): \`generate_thumbnails\`, \`optimize_images\`, \`analyze_images\`, and \`generate_preset_thumbnails\` all accept arbitrary \`source_paths\`/\`output_dir\` filesystem paths and write files there; \`clear_thumbnail_cache\` accepts an arbitrary \`output_dir\` and deletes files in it. All unauthenticated before this fix.

## Fix

\`require_admin\` on the 5 path-accepting/state-changing routes, \`require_authentication\` on the 3 read-only ones (stats, presets, cache stats).

## Testing

Real behavioral tests via FastAPI's \`TestClient\`, same \`EXPECTED_TIER\` + 401/403/success pattern as #406-#409. Verified RED (4 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)