### PR TITLE
fix(security): advanced_image_processing.py's 6 routes had zero authentication

### DIFF
--- a/src/api/fastapi/advanced_image_processing.py
+++ b/src/api/fastapi/advanced_image_processing.py
@@ -6,9 +6,10 @@ REST API endpoints for advanced image operations and quality enhancement
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Body, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.jobs.advanced_image_tasks import (
     ImageFormat,
     analyze_large_image_collection,
@@ -114,7 +115,9 @@ class QualityEnhancementResponse(BaseModel):
 # Endpoints
 @router.post("/analyze/bulk", response_model=AdvancedAnalysisResponse)
 async def bulk_image_analysis(
-    request: BulkAnalysisRequest, background_tasks: BackgroundTasks
+    request: BulkAnalysisRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Perform bulk analysis of large image collections
@@ -170,7 +173,9 @@ async def bulk_image_analysis(
 
 @router.post("/convert/formats", response_model=FormatConversionResponse)
 async def convert_image_formats(
-    request: FormatConversionRequest, background_tasks: BackgroundTasks
+    request: FormatConversionRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Convert images to different formats concurrently
@@ -253,7 +258,9 @@ async def convert_image_formats(
 
 @router.post("/enhance/quality", response_model=QualityEnhancementResponse)
 async def enhance_image_quality(
-    request: QualityEnhancementRequest, background_tasks: BackgroundTasks
+    request: QualityEnhancementRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_admin),
 ):
     """
     Enhance image quality with automated improvements
@@ -340,7 +347,9 @@ async def enhance_image_quality(
 
 
 @router.get("/formats/supported")
-async def get_supported_formats():
+async def get_supported_formats(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get list of supported image formats for conversion
 
@@ -383,7 +392,9 @@ async def get_supported_formats():
 
 
 @router.get("/enhancement/options")
-async def get_enhancement_options():
+async def get_enhancement_options(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get available image enhancement options and their descriptions
 
@@ -434,6 +445,7 @@ async def analyze_image_quality_only(
     include_histograms: bool = Body(
         False, description="Include histogram data in response"
     ),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Analyze image quality without enhancement

--- a/tests/unit/test_advanced_image_processing_auth.py
+++ b/tests/unit/test_advanced_image_processing_auth.py
@@ -1,0 +1,129 @@
+"""Tests for advanced_image_processing.py's auth fix (#392 Phase 2). All 6
+routes had zero authentication -- including endpoints that accept
+arbitrary filesystem paths (image_paths/source_paths) for analysis,
+format conversion, and quality enhancement, the same risk class fixed for
+bulk_operations.py (#408) and image_processing.py (#410).
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.advanced_image_processing import router
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "advanced_image_processing.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "bulk_image_analysis": "admin",
+    "convert_image_formats": "admin",
+    "enhance_image_quality": "admin",
+    "get_supported_formats": "auth",
+    "get_enhancement_options": "auth",
+    "analyze_image_quality_only": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestAdvancedImageProcessingAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestAdvancedImageProcessingBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/advanced-image-processing/formats/supported")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post(
+            "/api/advanced-image-processing/analyze/bulk",
+            json={"image_paths": ["/tmp/x.jpg"]},
+        )
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post(
+            "/api/advanced-image-processing/analyze/bulk",
+            json={"image_paths": ["/tmp/x.jpg"]},
+        )
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post(
+            "/api/advanced-image-processing/analyze/bulk",
+            json={"image_paths": ["/tmp/x.jpg"]},
+        )
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/advanced-image-processing/formats/supported")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Same risk class as \`bulk_operations.py\` (#408) and \`image_processing.py\` (#410): \`bulk_image_analysis\`, \`convert_image_formats\`, \`enhance_image_quality\`, and \`analyze_image_quality_only\` all accept arbitrary \`image_paths\`/\`source_paths\` filesystem paths. All unauthenticated before this fix.

## Fix

\`require_admin\` on the 4 arbitrary-path-accepting routes, \`require_authentication\` on the 2 static-info routes (supported formats, enhancement options).

## Testing

Real behavioral tests via FastAPI's \`TestClient\`, same \`EXPECTED_TIER\` + 401/403/success pattern as #406-#410. Verified RED (4 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)