### PR TITLE
fix(security): media_processing.py's 7 routes had zero authentication

### DIFF
--- a/src/api/fastapi/media_processing.py
+++ b/src/api/fastapi/media_processing.py
@@ -8,9 +8,10 @@ background jobs with real-time progress tracking via WebSocket.
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.jobs.ffmpeg_processing_tasks import (
     submit_bulk_metadata_task,
     submit_metadata_extraction_task,
@@ -136,6 +137,7 @@ class TaskCancellationResponse(BaseModel):
 async def extract_video_metadata(
     request: VideoMetadataExtractionRequest,
     user_id: Optional[str] = Query(None, description="User ID for tracking"),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Extract technical metadata from video file using FFprobe
@@ -190,6 +192,7 @@ async def extract_video_metadata(
 async def convert_video_format(
     request: VideoConversionRequest,
     user_id: Optional[str] = Query(None, description="User ID for tracking"),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Convert video file to different format using FFmpeg
@@ -256,6 +259,7 @@ async def convert_video_format(
 async def bulk_extract_metadata(
     request: BulkMetadataRequest,
     user_id: Optional[str] = Query(None, description="User ID for tracking"),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Extract metadata from multiple video files concurrently
@@ -324,6 +328,7 @@ async def bulk_extract_metadata(
 async def validate_video_file(
     request: VideoValidationRequest,
     user_id: Optional[str] = Query(None, description="User ID for tracking"),
+    current_user: dict = Depends(require_admin),
 ):
     """
     Validate video file integrity and playability
@@ -372,7 +377,9 @@ async def validate_video_file(
     summary="Cancel media processing task",
     description="Cancel an active FFmpeg processing operation",
 )
-async def cancel_media_processing(task_id: str):
+async def cancel_media_processing(
+    task_id: str, current_user: dict = Depends(require_admin)
+):
     """
     Cancel an active FFmpeg processing operation
 
@@ -413,7 +420,9 @@ async def cancel_media_processing(task_id: str):
     summary="Get active media processing operations",
     description="Get list of currently active FFmpeg processing operations",
 )
-async def get_active_processing():
+async def get_active_processing(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get list of currently active FFmpeg processing operations
 
@@ -480,7 +489,9 @@ async def get_active_processing():
     summary="Get available conversion options",
     description="Get common FFmpeg format conversion options and presets",
 )
-async def get_conversion_options():
+async def get_conversion_options(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Get available FFmpeg conversion options and presets
 

--- a/tests/unit/test_media_processing_auth.py
+++ b/tests/unit/test_media_processing_auth.py
@@ -1,0 +1,121 @@
+"""Tests for media_processing.py's auth fix (#392 Phase 2). All 7 routes
+had zero authentication -- including video-file processing endpoints
+(extract/convert/validate) that operate on arbitrary file paths via
+FFprobe/FFmpeg, the same risk class fixed for bulk_operations.py (#408),
+image_processing.py (#410), and advanced_image_processing.py (#411).
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.media_processing import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "media_processing.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "extract_video_metadata": "admin",
+    "convert_video_format": "admin",
+    "bulk_extract_metadata": "admin",
+    "validate_video_file": "admin",
+    "cancel_media_processing": "admin",
+    "get_active_processing": "auth",
+    "get_conversion_options": "auth",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestMediaProcessingAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestMediaProcessingBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/media/processing/active")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.delete("/api/media/processing/cancel/sometask")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.delete("/api/media/processing/cancel/sometask")
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.delete("/api/media/processing/cancel/sometask")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/media/processing/active")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Same risk class as \`bulk_operations.py\` (#408), \`image_processing.py\` (#410), and \`advanced_image_processing.py\` (#411): \`extract_video_metadata\`, \`convert_video_format\`, \`bulk_extract_metadata\`, and \`validate_video_file\` all operate on arbitrary video file paths via FFprobe/FFmpeg. All unauthenticated before this fix.

## Fix

\`require_admin\` on the 4 arbitrary-path-accepting routes plus \`cancel_media_processing\` (terminates an FFmpeg subprocess), \`require_authentication\` on the 2 read-only routes (active operations, conversion options).

## Testing

Real behavioral tests via FastAPI's \`TestClient\`, same \`EXPECTED_TIER\` + 401/403/success pattern as #406-#411. Verified RED (4 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)