### PR TITLE
fix(security): maintenance.py's 7 routes had zero authentication

### DIFF
--- a/src/api/fastapi/maintenance.py
+++ b/src/api/fastapi/maintenance.py
@@ -7,9 +7,10 @@ Provides simple cleanup and optimization tools for home self-hosters.
 import logging
 from typing import Dict, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.api.fastapi.template_system import template_system
 from src.services.maintenance_tasks import (
     cleanup_old_job_history,
@@ -26,7 +27,9 @@ router = APIRouter(prefix="/api/maintenance", tags=["Maintenance"])
 
 
 @router.get("/summary")
-async def get_summary() -> Dict:
+async def get_summary(
+    current_user: dict = Depends(require_authentication),
+) -> Dict:
     """
     Get summary of what all maintenance tasks would find (dry run).
 
@@ -42,7 +45,10 @@ async def get_summary() -> Dict:
 
 @router.post("/logs/cleanup")
 async def cleanup_logs(
-    days_to_keep: int = 30, dry_run: bool = False, log_directory: Optional[str] = None
+    days_to_keep: int = 30,
+    dry_run: bool = False,
+    log_directory: Optional[str] = None,
+    current_user: dict = Depends(require_admin),
 ) -> Dict:
     """
     Clean up old log files.
@@ -76,7 +82,9 @@ async def cleanup_logs(
 
 
 @router.post("/database/optimize")
-async def optimize_db() -> Dict:
+async def optimize_db(
+    current_user: dict = Depends(require_admin),
+) -> Dict:
     """
     Optimize all database tables.
 
@@ -101,7 +109,9 @@ async def optimize_db() -> Dict:
 
 @router.post("/thumbnails/cleanup")
 async def cleanup_thumbnails(
-    dry_run: bool = False, thumbnails_path: Optional[str] = None
+    dry_run: bool = False,
+    thumbnails_path: Optional[str] = None,
+    current_user: dict = Depends(require_admin),
 ) -> Dict:
     """
     Clean up orphaned thumbnail files.
@@ -134,7 +144,9 @@ async def cleanup_thumbnails(
 
 
 @router.post("/temp-files/cleanup")
-async def cleanup_temp(dry_run: bool = False) -> Dict:
+async def cleanup_temp(
+    dry_run: bool = False, current_user: dict = Depends(require_admin)
+) -> Dict:
     """
     Clean up temporary files and cache.
 
@@ -161,7 +173,11 @@ async def cleanup_temp(dry_run: bool = False) -> Dict:
 
 
 @router.post("/jobs/cleanup")
-async def cleanup_jobs(days_to_keep: int = 30, dry_run: bool = False) -> Dict:
+async def cleanup_jobs(
+    days_to_keep: int = 30,
+    dry_run: bool = False,
+    current_user: dict = Depends(require_admin),
+) -> Dict:
     """
     Clean up old job history from Redis.
 
@@ -193,7 +209,9 @@ page_router = APIRouter(tags=["Maintenance Pages"])
 
 
 @page_router.get("/maintenance", response_class=HTMLResponse)
-async def maintenance_page(request: Request):
+async def maintenance_page(
+    request: Request, current_user: dict = Depends(require_authentication)
+):
     """Render the maintenance tools page."""
     context = {"page_title": "Maintenance Tools"}
     return await template_system.render_response("maintenance.html", request, context)

--- a/tests/unit/test_maintenance_auth.py
+++ b/tests/unit/test_maintenance_auth.py
@@ -1,0 +1,127 @@
+"""Tests for maintenance.py's auth fix (#392 Phase 2). All 7 routes had
+zero authentication -- including 5 destructive cleanup/optimize actions
+(log/thumbnail/temp-file/job-history deletion, database optimization) plus
+an accompanying page-shell route, all callable by anyone.
+
+maintenance_page is gated with require_authentication (matching the
+already-established pattern for other authenticated page-shell routes,
+e.g. frontend_router.py's /settings -- confirmed the same Depends(...)
+mechanism works for HTML page routes, not just API routes) rather than
+left unauthenticated or deferred alongside the broader frontend_router.py
+public/auth split decision, since it's unambiguously an admin tool page.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.maintenance import page_router, router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "maintenance.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "get_summary": "auth",
+    "cleanup_logs": "admin",
+    "optimize_db": "admin",
+    "cleanup_thumbnails": "admin",
+    "cleanup_temp": "admin",
+    "cleanup_jobs": "admin",
+    "maintenance_page": "auth",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestMaintenanceAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        route_function_names |= {
+            route.endpoint.__name__ for route in page_router.routes
+        }
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestMaintenanceBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.include_router(page_router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/maintenance/summary")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post("/api/maintenance/database/optimize")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/maintenance/database/optimize")
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/maintenance/database/optimize")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/maintenance/summary")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

5 of the 6 API routes are destructive: \`cleanup_logs\`, \`optimize_db\`, \`cleanup_thumbnails\`, \`cleanup_temp\`, and \`cleanup_jobs\` all delete files or modify the database. All unauthenticated before this fix, along with the page-shell route that renders the maintenance tools UI.

## Fix

\`require_admin\` on the 5 destructive routes, \`require_authentication\` on \`get_summary\` (read-only) and \`maintenance_page\` (matches the already-established pattern for authenticated page-shell routes — confirmed \`frontend_router.py\`'s \`/settings\` uses the identical \`Depends(require_authentication)\` mechanism for an HTML route, not just API routes — so this doesn't need to wait on the broader \`frontend_router.py\` public/auth split decision; it's unambiguously an admin tool page).

## Testing

Real behavioral tests via FastAPI's \`TestClient\`, same \`EXPECTED_TIER\` + 401/403/success pattern as #406-#412. Verified RED (4 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)