### PR TITLE
fix(security): performance.py's 7 routes had zero authentication

### DIFF
--- a/src/api/fastapi/performance.py
+++ b/src/api/fastapi/performance.py
@@ -9,9 +9,10 @@ from datetime import datetime
 from typing import List, Optional
 
 import psutil
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.services.media_cache_manager import MediaCacheManager
 from src.services.performance_monitor import get_performance_monitor
 from src.utils.logger import get_logger
@@ -165,7 +166,9 @@ async def get_cache_metrics() -> CacheMetrics:
 
 # API Endpoints
 @router.get("/", response_model=PerformanceOverview)
-async def get_performance_overview():
+async def get_performance_overview(
+    current_user: dict = Depends(require_admin),
+):
     """Get complete performance overview"""
     try:
         start_time = time.time()
@@ -224,20 +227,25 @@ async def get_performance_overview():
 
 
 @router.get("/system", response_model=SystemMetrics)
-async def get_system_performance():
+async def get_system_performance(
+    current_user: dict = Depends(require_admin),
+):
     """Get system resource metrics"""
     return await get_system_metrics()
 
 
 @router.get("/cache", response_model=CacheMetrics)
-async def get_cache_performance():
+async def get_cache_performance(
+    current_user: dict = Depends(require_authentication),
+):
     """Get cache performance metrics"""
     return await get_cache_metrics()
 
 
 @router.get("/endpoints", response_model=List[EndpointPerformance])
 async def get_endpoint_performance(
-    limit: int = Query(20, ge=1, le=100, description="Maximum endpoints to return")
+    limit: int = Query(20, ge=1, le=100, description="Maximum endpoints to return"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get performance metrics for individual endpoints"""
     try:
@@ -268,7 +276,8 @@ async def get_endpoint_performance(
 
 @router.get("/trends")
 async def get_performance_trends(
-    hours: int = Query(24, ge=1, le=168, description="Hours of trend data")
+    hours: int = Query(24, ge=1, le=168, description="Hours of trend data"),
+    current_user: dict = Depends(require_authentication),
 ):
     """Get performance trends over time"""
     try:
@@ -296,7 +305,9 @@ async def get_performance_trends(
 
 
 @router.post("/cache/clear")
-async def clear_performance_cache():
+async def clear_performance_cache(
+    current_user: dict = Depends(require_admin),
+):
     """Clear performance and response caches"""
     try:
         cache_manager = MediaCacheManager()
@@ -328,7 +339,9 @@ async def clear_performance_cache():
 
 
 @router.get("/health")
-async def performance_health_check():
+async def performance_health_check(
+    current_user: dict = Depends(require_admin),
+):
     """Quick performance health check"""
     start_time = time.time()
 

--- a/tests/unit/test_performance_auth.py
+++ b/tests/unit/test_performance_auth.py
@@ -1,0 +1,118 @@
+"""Tests for performance.py's auth fix (#392 Phase 2). All 7 routes had
+zero authentication. Any route that reveals host resource metrics
+(CPU/memory/disk percentages) is require_admin, matching health.py's
+(#407) precedent for the same category of info disclosure; the rest are
+require_authentication, except clear_performance_cache which is
+require_admin as a state-changing action.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.performance import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "performance.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "get_performance_overview": "admin",
+    "get_system_performance": "admin",
+    "get_cache_performance": "auth",
+    "get_endpoint_performance": "auth",
+    "get_performance_trends": "auth",
+    "clear_performance_cache": "admin",
+    "performance_health_check": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestPerformanceAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestPerformanceBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/performance/cache")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/performance/system")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.get("/api/performance/system")
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.get("/api/performance/system")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/performance/cache")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Any route that reveals host resource metrics (CPU/memory/disk percentages) is \`require_admin\`, matching \`health.py\`'s (#407) precedent for the same category of info disclosure — \`get_performance_overview\`, \`get_system_performance\`, and \`performance_health_check\` all include or directly return these. \`clear_performance_cache\` is also \`require_admin\` as a state-changing action. The remaining 3 (cache stats, per-endpoint stats, trends) are \`require_authentication\`.

## Testing

Real behavioral tests via FastAPI's \`TestClient\`, same \`EXPECTED_TIER\` + 401/403/success pattern as #406-#413. Verified RED (4 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)