### PR TITLE
fix(security): scheduled_jobs.py's 7 routes had zero authentication

### DIFF
--- a/src/api/fastapi/scheduled_jobs.py
+++ b/src/api/fastapi/scheduled_jobs.py
@@ -17,10 +17,11 @@ Endpoints:
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import func
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.database.connection import get_db
 from src.database.models import Artist, ScheduledJob
 from src.services.scheduler_service_v2 import scheduler_v2
@@ -80,6 +81,7 @@ async def get_all_scheduled_jobs(
     status: Optional[str] = Query(None, description="Filter by status"),
     job_type: Optional[str] = Query(None, description="Filter by job type"),
     artist_id: Optional[int] = Query(None, description="Filter by artist ID"),
+    current_user: dict = Depends(require_authentication),
 ) -> Dict[str, Any]:
     """
     Get all scheduled jobs with filtering and pagination
@@ -118,7 +120,9 @@ async def get_all_scheduled_jobs(
 
 
 @router.get("/scheduled/{job_id}")
-async def get_scheduled_job(job_id: int) -> Dict[str, Any]:
+async def get_scheduled_job(
+    job_id: int, current_user: dict = Depends(require_authentication)
+) -> Dict[str, Any]:
     """
     Get specific scheduled job by database ID
 
@@ -158,7 +162,9 @@ async def get_scheduled_job(job_id: int) -> Dict[str, Any]:
 
 
 @router.post("/scheduled/{job_id}/retry")
-async def retry_scheduled_job(job_id: int) -> Dict[str, Any]:
+async def retry_scheduled_job(
+    job_id: int, current_user: dict = Depends(require_admin)
+) -> Dict[str, Any]:
     """
     Retry a failed scheduled job
 
@@ -205,7 +211,9 @@ async def retry_scheduled_job(job_id: int) -> Dict[str, Any]:
 
 
 @router.post("/scheduled/{job_id}/cancel")
-async def cancel_scheduled_job(job_id: int) -> Dict[str, Any]:
+async def cancel_scheduled_job(
+    job_id: int, current_user: dict = Depends(require_admin)
+) -> Dict[str, Any]:
     """
     Cancel a pending or running scheduled job
 
@@ -254,6 +262,7 @@ async def get_job_history(
     job_type: Optional[str] = Query(None, description="Filter by job type"),
     status: Optional[str] = Query(None, description="Filter by status"),
     artist_id: Optional[int] = Query(None, description="Filter by artist ID"),
+    current_user: dict = Depends(require_authentication),
 ) -> Dict[str, Any]:
     """
     Get job history for specified time period
@@ -301,7 +310,8 @@ async def get_job_history(
 
 @router.get("/statistics", response_model=JobStatisticsResponse)
 async def get_job_statistics(
-    hours: int = Query(24, ge=1, le=720, description="Hours to calculate stats for")
+    hours: int = Query(24, ge=1, le=720, description="Hours to calculate stats for"),
+    current_user: dict = Depends(require_authentication),
 ) -> Dict[str, Any]:
     """
     Get job statistics for specified time period
@@ -381,7 +391,8 @@ async def get_job_statistics(
 
 @router.delete("/history/cleanup")
 async def cleanup_old_jobs(
-    days: int = Query(30, ge=1, le=365, description="Delete jobs older than N days")
+    days: int = Query(30, ge=1, le=365, description="Delete jobs older than N days"),
+    current_user: dict = Depends(require_admin),
 ) -> Dict[str, Any]:
     """
     Clean up old job history

--- a/tests/unit/test_scheduled_jobs_auth.py
+++ b/tests/unit/test_scheduled_jobs_auth.py
@@ -1,0 +1,120 @@
+"""Tests for scheduled_jobs.py's auth fix (#392 Phase 2). All 7 routes had
+zero authentication -- full read/write control over the scheduled-job
+system (retry/cancel any job, bulk-delete history), the same category
+already fixed for scheduler_v2.py (#406).
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.scheduled_jobs import router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "scheduled_jobs.py"
+)
+
+# function_name -> "admin" | "auth"
+EXPECTED_TIER = {
+    "get_all_scheduled_jobs": "auth",
+    "get_scheduled_job": "auth",
+    "retry_scheduled_job": "admin",
+    "cancel_scheduled_job": "admin",
+    "get_job_history": "auth",
+    "get_job_statistics": "auth",
+    "cleanup_old_jobs": "admin",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestScheduledJobsAllRoutesHaveCorrectTier:
+    def test_every_route_has_the_expected_dependency(self):
+        for function_name, tier in EXPECTED_TIER.items():
+            source = _function_source(function_name)
+            expected = (
+                "Depends(require_admin)"
+                if tier == "admin"
+                else "Depends(require_authentication)"
+            )
+            assert (
+                expected in source
+            ), f"{function_name} should use {expected}, got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == set(EXPECTED_TIER.keys())
+
+
+class TestScheduledJobsBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_authenticated_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/v2/jobs/scheduled")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_401s_without_session(self):
+        client = self._client()
+        response = client.post("/api/v2/jobs/scheduled/1/cancel")
+        assert response.status_code == 401
+
+    def test_admin_tier_route_403s_for_non_admin_authenticated_user(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/v2/jobs/scheduled/1/cancel")
+        assert response.status_code == 403
+
+    def test_admin_tier_route_succeeds_for_admin_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: {
+            "authenticated": True,
+            "role": "admin",
+            "user_id": 1,
+        }
+        client = TestClient(app)
+        response = client.post("/api/v2/jobs/scheduled/1/cancel")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_authenticated_tier_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/v2/jobs/scheduled")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

Full read/write control over the scheduled-job system (retry/cancel any job, bulk-delete history) was reachable by anyone — the same category already fixed for scheduler_v2.py (#406).

## Fix

require_authentication on the 4 read-only routes, require_admin on the 3 state-changing ones (retry, cancel, cleanup).

## Testing

Real behavioral tests via FastAPI's TestClient, same EXPECTED_TIER + 401/403/success pattern as #406-#414. Verified RED (4 failures) before the fix, GREEN after. black --check / isort --check-only clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)