### PR TITLE
fix(downloads): "Download Selected" always reported an error, even on success

### DIFF
--- a/frontend/templates/artist_detail.html
+++ b/frontend/templates/artist_detail.html
@@ -6607,12 +6607,32 @@ function bulkDownloadSelected() {
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            showSuccess(data.message);
+            // Build a message from the actual counts rather than the
+            // generic "Bulk download completed" -- a live-reported bug
+            // (2026-08-21) showed videos really were queued and
+            // downloaded while the button still reported an error,
+            // because this response never included a "success" key at
+            // all until now. Distinguishing queued/skipped/failed here
+            // also makes a re-click on already-queued videos (e.g. a
+            // double-click) read as informational, not a false error.
+            const parts = [];
+            if (data.queued_count > 0) parts.push(`${data.queued_count} queued`);
+            if (data.skipped_count > 0) parts.push(`${data.skipped_count} already downloaded or in progress`);
+            if (data.failed_count > 0) parts.push(`${data.failed_count} failed`);
+            const summary = parts.length ? parts.join(', ') : 'nothing to queue';
+
+            if (data.queued_count > 0) {
+                showSuccess(`Download started: ${summary}`);
+            } else if (data.failed_count > 0) {
+                showError(`Download failed: ${summary}`);
+            } else {
+                showInfo(`No new downloads: ${summary}`);
+            }
             // Clear selection and refresh
             deselectAllVideos();
             loadArtistDetails();
         } else {
-            showError('Error: ' + data.error);
+            showError('Error: ' + (data.error || 'Unknown error'));
         }
     })
     .catch(error => {

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -336,6 +336,16 @@ async def bulk_download_videos(
         )
 
         result = {
+            # Live-reported 2026-08-21: this response never included a
+            # "success" key, unlike every sibling endpoint in this file.
+            # The frontend's bulkDownloadSelected() (artist_detail.html)
+            # branches on `if (data.success)` -- with that key always
+            # undefined (falsy), it *always* showed "Error: undefined",
+            # even when the batch genuinely queued videos successfully.
+            # True here means "the batch ran to completion without a
+            # fatal server error" -- per-video outcomes are already
+            # reported via queued_count/skipped_count/failed_count.
+            "success": True,
             "message": "Bulk download completed",
             "queued_count": queued_count,
             "skipped_count": skipped_count,

--- a/tests/unit/test_bulk_download_response_includes_success_key.py
+++ b/tests/unit/test_bulk_download_response_includes_success_key.py
@@ -1,0 +1,157 @@
+"""Regression test for a live-reported bug: bulk_download_videos()
+(POST /api/videos/bulk/download, the "Download Selected" button on the
+artist page) never included a "success" key in its response, unlike
+every other endpoint in this file. The frontend
+(bulkDownloadSelected() in artist_detail.html) checks `if
+(data.success)` to decide whether to show a success or error toast --
+since that key was always undefined (falsy), it *always* took the
+error branch and showed "Error: undefined", even when the batch
+genuinely succeeded (live-reproduced 2026-08-21: 3 videos were queued
+and actually downloaded, but the button still reported an error).
+
+Fix: include "success": True on the endpoint's normal completion path,
+matching every sibling endpoint in this file (queue_video_download,
+queue_download_video, bulk_download_wanted_videos, etc. all already
+do this).
+"""
+
+import ast
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.api.fastapi.videos_downloads import bulk_download_videos
+from src.api.fastapi.videos_models import BulkDownloadRequest
+from src.database.connection import Base
+from src.database.models import Artist, Download, Video, VideoStatus
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "videos_downloads.py"
+)
+
+
+def _function_source() -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "bulk_download_videos"
+        ):
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError("Could not find bulk_download_videos in source")
+
+
+class TestBulkDownloadVideosResponseHasSuccessKey:
+    def test_final_result_dict_includes_a_success_key(self):
+        source = _function_source()
+        # "total_requested" only appears once, inside the final
+        # response dict (not the per-video dispatch `result` variable
+        # inside the loop, which is a different binding of the same
+        # name) -- anchor on it and look back to that dict's opening
+        # `result = {` for a "success" key.
+        total_requested_pos = source.index('"total_requested"')
+        dict_start = source.rindex("result = {", 0, total_requested_pos)
+        block = source[dict_start:total_requested_pos]
+        assert '"success"' in block
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
+    )
+    return sessionmaker(bind=engine)
+
+
+def _seed_video(session_factory, status=VideoStatus.WANTED):
+    session = session_factory()
+    artist = Artist(name="Test Artist")
+    session.add(artist)
+    session.commit()
+
+    video = Video(
+        artist_id=artist.id,
+        title="Test Song",
+        status=status,
+        url="https://youtube.com/watch?v=abc123",
+        youtube_id="abc123",
+    )
+    session.add(video)
+    session.commit()
+    video_id = video.id
+    session.close()
+    return video_id
+
+
+@contextmanager
+def _dispatch_success(session_factory):
+    """Shim the ytdlp_service import and fake claim_video_for_redownload()
+    to actually flip the video's status, mirroring
+    test_single_video_download_reverts_on_falsy_result.py's approach."""
+
+    def _fake_add_music_video_download(**kwargs):
+        return {"success": True, "id": 999}
+
+    def _fake_claim(video_id):
+        claim_session = session_factory()
+        try:
+            video = claim_session.query(Video).filter(Video.id == video_id).first()
+            if video is None or video.status == VideoStatus.DOWNLOADING:
+                return False
+            video.status = VideoStatus.DOWNLOADING
+            claim_session.commit()
+            return True
+        finally:
+            claim_session.close()
+
+    fake_module = types.ModuleType("src.services.download_service_adapter")
+    fake_module.ytdlp_service = types.SimpleNamespace(
+        add_music_video_download=_fake_add_music_video_download
+    )
+    with patch.dict(
+        sys.modules, {"src.services.download_service_adapter": fake_module}
+    ):
+        with patch(
+            "src.services.video_batch_service.claim_video_for_redownload",
+            side_effect=_fake_claim,
+        ):
+            yield
+
+
+class TestBulkDownloadVideosBehavioralSuccessKey:
+    def test_a_successful_batch_reports_success_true(self, session_factory):
+        video_id = _seed_video(session_factory, status=VideoStatus.WANTED)
+        session = session_factory()
+
+        with _dispatch_success(session_factory):
+            result = _run(
+                bulk_download_videos(
+                    request=BulkDownloadRequest(video_ids=[video_id]),
+                    current_user={"user_id": 1, "username": "test"},
+                    session=session,
+                )
+            )
+
+        assert result["success"] is True
+        assert result["queued_count"] == 1
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)


### PR DESCRIPTION
## Summary

Live-reported: selecting videos on the artist page and clicking "Download Selected" showed an error toast, but the videos actually downloaded. Confirmed via HAR + server logs: the backend genuinely queued the videos (\`queued_count > 0\`), but \`bulk_download_videos()\` (\`POST /api/videos/bulk/download\`) never included a \`"success"\` key in its response — unlike every other endpoint in this file. The frontend's \`bulkDownloadSelected()\` branches on \`if (data.success)\`; with that key always \`undefined\` (falsy), it always took the error branch and showed "Error: undefined", regardless of actual outcome.

## Fix

Add \`"success": true\` to the response on its normal completion path, matching the established convention already used by every sibling endpoint (\`queue_video_download\`, \`queue_download_video\`, \`bulk_download_wanted_videos\`, etc.).

Also improved the frontend toast to reflect the actual queued/skipped/failed counts instead of the generic "Bulk download completed" string — a re-click on already-queued videos (what actually happened in the live report: the first click succeeded but looked like an error, so a second click followed 9s later and correctly skipped all 3 as already-queued) now reads as an informational "No new downloads: N already downloaded or in progress" instead of a false success or false error.

## Testing

Static source-assertion test confirming the response dict sets \`"success"\`, plus a real behavioral test (SQLite-backed, \`sys.modules\`-shimmed \`ytdlp_service\` import, same pattern as #403) proving a genuinely successful batch reports \`success:true\` with the correct \`queued_count\`. Verified RED (\`KeyError: 'success'\`) before the fix, GREEN after. Broader regression sweep (41 tests across this file's other test suites) passes unchanged. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)