### PR TITLE
fix(security): personal_insights.py's 8 routes had zero authentication

### DIFF
--- a/src/api/fastapi/personal_insights.py
+++ b/src/api/fastapi/personal_insights.py
@@ -8,9 +8,10 @@ import logging
 from datetime import datetime
 from typing import Dict
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.template_system import template_system
 from src.services.personal_analytics import (
     export_collection_csv,
@@ -28,7 +29,9 @@ router = APIRouter(prefix="/api/analytics", tags=["Personal Analytics"])
 
 
 @router.get("/summary")
-async def get_summary() -> Dict:
+async def get_summary(
+    current_user: dict = Depends(require_authentication),
+) -> Dict:
     """
     Get comprehensive analytics summary.
 
@@ -43,7 +46,9 @@ async def get_summary() -> Dict:
 
 
 @router.get("/collection")
-async def get_collection_stats() -> Dict:
+async def get_collection_stats(
+    current_user: dict = Depends(require_authentication),
+) -> Dict:
     """
     Get collection statistics.
 
@@ -65,7 +70,9 @@ async def get_collection_stats() -> Dict:
 
 
 @router.get("/top-artists")
-async def get_top_artists_list(limit: int = 10) -> Dict:
+async def get_top_artists_list(
+    limit: int = 10, current_user: dict = Depends(require_authentication)
+) -> Dict:
     """
     Get top artists by video count.
 
@@ -91,7 +98,9 @@ async def get_top_artists_list(limit: int = 10) -> Dict:
 
 
 @router.get("/top-genres")
-async def get_top_genres_list(limit: int = 10) -> Dict:
+async def get_top_genres_list(
+    limit: int = 10, current_user: dict = Depends(require_authentication)
+) -> Dict:
     """
     Get top genres by video count.
 
@@ -117,7 +126,9 @@ async def get_top_genres_list(limit: int = 10) -> Dict:
 
 
 @router.get("/health")
-async def get_health() -> Dict:
+async def get_health(
+    current_user: dict = Depends(require_authentication),
+) -> Dict:
     """
     Get collection health assessment.
 
@@ -139,7 +150,11 @@ async def get_health() -> Dict:
 
 
 @router.get("/recent")
-async def get_recent(days: int = 30, limit: int = 10) -> Dict:
+async def get_recent(
+    days: int = 30,
+    limit: int = 10,
+    current_user: dict = Depends(require_authentication),
+) -> Dict:
     """
     Get recently added videos.
 
@@ -168,7 +183,9 @@ async def get_recent(days: int = 30, limit: int = 10) -> Dict:
 
 
 @router.get("/export/csv")
-async def export_csv():
+async def export_csv(
+    current_user: dict = Depends(require_authentication),
+):
     """
     Export collection as CSV file.
 
@@ -195,7 +212,9 @@ page_router = APIRouter(tags=["Analytics Pages"])
 
 
 @page_router.get("/analytics", response_class=HTMLResponse)
-async def analytics_page(request: Request):
+async def analytics_page(
+    request: Request, current_user: dict = Depends(require_authentication)
+):
     """Render the personal analytics page."""
     context = {"page_title": "Collection Analytics"}
     return await template_system.render_response(

--- a/tests/unit/test_personal_insights_auth.py
+++ b/tests/unit/test_personal_insights_auth.py
@@ -1,0 +1,89 @@
+"""Tests for personal_insights.py's auth fix (#392 Phase 2). All 8 routes
+had zero authentication. All are read-only collection-analytics queries
+(summary/stats/top-artists/top-genres/health/recent/CSV export) plus an
+accompanying page-shell route, none state-changing -- so every route
+gets the same require_authentication tier, no require_admin split
+needed. Matches maintenance.py's (#413) precedent for gating a page-shell
+route with the same Depends(require_authentication) mechanism as API
+routes.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.personal_insights import page_router, router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "personal_insights.py"
+)
+
+EXPECTED_ROUTES = {
+    "get_summary",
+    "get_collection_stats",
+    "get_top_artists_list",
+    "get_top_genres_list",
+    "get_health",
+    "get_recent",
+    "export_csv",
+    "analytics_page",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestPersonalInsightsAllRoutesRequireAuth:
+    def test_every_route_requires_authentication(self):
+        for function_name in EXPECTED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        route_function_names |= {
+            route.endpoint.__name__ for route in page_router.routes
+        }
+        assert route_function_names == EXPECTED_ROUTES
+
+
+class TestPersonalInsightsBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.include_router(page_router)
+        return TestClient(app)
+
+    def test_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/analytics/summary")
+        assert response.status_code == 401
+
+    def test_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/api/analytics/summary")
+        assert response.status_code != 401


### PR DESCRIPTION
Part of #392 (Phase 2 of the route-auth sweep).

## Summary

All 8 routes — collection summary/stats/top-artists/top-genres/health/recent-additions, CSV export, and the accompanying page-shell route — were reachable by anyone. All are read-only, none state-changing, so every route gets \`require_authentication\`, no admin split needed. Matches \`maintenance.py\`'s (#413) precedent for gating a page-shell route with the same \`Depends(...)\` mechanism as API routes.

## Testing

Real behavioral tests via FastAPI's \`TestClient\`. Verified RED (2 failures) before the fix, GREEN after. \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)