### PR TITLE
fix(security): production_monitoring.py's 6 routes had zero authentication (#392 Phase 2)

### DIFF
--- a/src/api/fastapi/production_monitoring.py
+++ b/src/api/fastapi/production_monitoring.py
@@ -10,10 +10,11 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import psutil
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from src.api.fastapi.auth_dependencies import require_admin, require_authentication
 from src.database.async_connection import get_async_db_manager
 from src.middleware.auto_scaling_middleware import get_scaling_status
 from src.services.media_cache_manager import MediaCacheManager
@@ -248,7 +249,9 @@ async def get_cache_health() -> Dict[str, Any]:
 
 # API Endpoints
 @router.get("/health", response_model=HealthCheckResponse)
-async def comprehensive_health_check():
+async def comprehensive_health_check(
+    current_user: dict = Depends(require_admin),
+):
     """Comprehensive health check for production monitoring"""
     start_time = time.time()
 
@@ -335,7 +338,9 @@ async def comprehensive_health_check():
 
 
 @router.get("/status", response_model=SystemStatusResponse)
-async def get_system_status():
+async def get_system_status(
+    current_user: dict = Depends(require_admin),
+):
     """Get overall system status overview"""
     try:
         # Get auto-scaling status
@@ -384,7 +389,9 @@ async def get_system_status():
 
 
 @router.get("/metrics", response_model=MetricsResponse)
-async def get_detailed_metrics():
+async def get_detailed_metrics(
+    current_user: dict = Depends(require_admin),
+):
     """Get detailed system and application metrics"""
     try:
         timestamp = datetime.utcnow()
@@ -463,6 +470,7 @@ async def get_detailed_metrics():
 async def get_active_alerts(
     severity: Optional[str] = Query(None, description="Filter by severity level"),
     limit: int = Query(50, ge=1, le=200, description="Maximum alerts to return"),
+    current_user: dict = Depends(require_admin),
 ):
     """Get active system alerts"""
     try:
@@ -535,7 +543,9 @@ async def get_active_alerts(
 
 
 @router.get("/readiness")
-async def readiness_probe():
+async def readiness_probe(
+    current_user: dict = Depends(require_authentication),
+):
     """Kubernetes-style readiness probe"""
     try:
         # Quick checks for readiness
@@ -559,7 +569,9 @@ async def readiness_probe():
 
 
 @router.get("/liveness")
-async def liveness_probe():
+async def liveness_probe(
+    current_user: dict = Depends(require_authentication),
+):
     """Kubernetes-style liveness probe"""
     try:
         # Basic liveness check - application is running

--- a/tests/unit/test_production_monitoring_auth.py
+++ b/tests/unit/test_production_monitoring_auth.py
@@ -1,0 +1,137 @@
+"""Tests for production_monitoring.py's auth fix (#392 Phase 2). All 6
+routes had zero authentication. Four reveal host/system resource details
+(CPU/memory/disk, DB pool stats, security-alert counts) -- the same class
+of data health.py (#407) and performance.py (#414) gated with
+require_admin: comprehensive_health_check, get_system_status,
+get_detailed_metrics, get_active_alerts. The other two (readiness_probe,
+liveness_probe) look like Kubernetes-style infra probes, but unlike
+health.py's public 3 (which Docker's own HEALTHCHECK genuinely depends
+on -- see Dockerfile), nothing in this repo's Docker/Compose config calls
+these specific routes. With no infra reason to leave them open, and a
+nonzero leak (DB-up/down status, process pid), they get
+require_authentication rather than staying public.
+"""
+
+import ast
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+# security_audit_service.py instantiates a module-level SecurityAuditService()
+# that unconditionally mkdir()s a hardcoded "/app/data/logs/security" path at
+# import time -- fine in the real Docker container (which runs as /app), but
+# fatal here since this dev checkout isn't rooted at /app. Shimming the
+# module before production_monitoring imports it avoids that unrelated
+# import-time side effect without touching production code for an auth-only
+# change.
+_MODULE_NAME = "src.services.security_audit_service"
+_already_imported = _MODULE_NAME in sys.modules
+if not _already_imported:
+    _fake_security_audit_service = types.ModuleType(_MODULE_NAME)
+    _fake_security_audit_service.get_security_audit_service = AsyncMock()
+    sys.modules[_MODULE_NAME] = _fake_security_audit_service
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import (
+    get_current_user,
+    require_admin,
+    require_authentication,
+)
+from src.api.fastapi.production_monitoring import router
+
+# production_monitoring already bound its own reference to
+# get_security_audit_service via the shimmed module above -- remove the
+# shim afterwards so it doesn't leak into other test modules collected in
+# the same pytest session that need the real thing.
+if not _already_imported:
+    del sys.modules[_MODULE_NAME]
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "production_monitoring.py"
+)
+
+ADMIN_ROUTES = {
+    "comprehensive_health_check",
+    "get_system_status",
+    "get_detailed_metrics",
+    "get_active_alerts",
+}
+
+AUTH_ROUTES = {
+    "readiness_probe",
+    "liveness_probe",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestProductionMonitoringRoutesRequireAuth:
+    def test_host_metric_routes_require_admin(self):
+        for function_name in ADMIN_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_admin)" in source
+            ), f"{function_name} should use Depends(require_admin), got:\n{source}"
+
+    def test_probe_routes_require_authentication(self):
+        for function_name in AUTH_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_all_six_routes_are_accounted_for(self):
+        route_function_names = {route.endpoint.__name__ for route in router.routes}
+        assert route_function_names == (ADMIN_ROUTES | AUTH_ROUTES)
+
+
+class TestProductionMonitoringBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_admin_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/monitoring/metrics")
+        assert response.status_code == 401
+
+    def test_admin_route_403s_for_non_admin_session(self):
+        client = self._client()
+        client.app.dependency_overrides[get_current_user] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        response = client.get("/api/monitoring/metrics")
+        assert response.status_code == 403
+
+    def test_auth_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/monitoring/liveness")
+        assert response.status_code == 401
+
+    def test_auth_route_succeeds_for_authenticated_session(self):
+        client = self._client()
+        client.app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        response = client.get("/api/monitoring/liveness")
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary
Continues the #392 Phase 2 FastAPI route-authentication sweep.

All 6 routes on `production_monitoring.py`'s router (`/api/monitoring/*`) were completely unauthenticated:
- `comprehensive_health_check`, `get_system_status`, `get_detailed_metrics`, `get_active_alerts` → `require_admin` — these reveal host/system resource details (CPU/memory/disk, DB pool stats, security-alert counts), the same class of data `health.py` (#407) and `performance.py` (#414) gated with `require_admin`.
- `readiness_probe`, `liveness_probe` → `require_authentication` — these look like Kubernetes-style infra probes, matching `health.py`'s 3 public routes on the surface. But unlike those, nothing in this repo's Docker/Compose config actually calls these specific routes (Docker's own `HEALTHCHECK` depends on `health.py`'s `/api/health/`, confirmed via grep). With no infra reason to leave them open, and a nonzero leak (DB-up/down status, process pid), they get `require_authentication` instead of staying public.

## Testing
`tests/unit/test_production_monitoring_auth.py`: static AST source assertions plus real behavioral tests via FastAPI's `TestClient` (401 without a session, 403 for an authenticated non-admin via overriding `get_current_user`, success for correct role). Verified RED before the fix, GREEN after.

One test-environment wrinkle: importing this router pulls in `security_audit_service`, which instantiates a module-level `SecurityAuditService()` that unconditionally `mkdir()`s a hardcoded `/app/data/logs/security` path at import time — fine in the real Docker container, fatal in this dev checkout. Shimmed that one module in `sys.modules` for the duration of the import (restored immediately after) rather than touching production code for an auth-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)