### PR TITLE
fix(security): video_indexing_page.py's route had zero authentication (#392 Phase 2)

### DIFF
--- a/src/api/fastapi/video_indexing_page.py
+++ b/src/api/fastapi/video_indexing_page.py
@@ -6,9 +6,10 @@ Provides the video indexing management interface.
 
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.template_system import template_system
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,10 @@ page_router = APIRouter(tags=["Video Indexing Pages"])
 
 
 @page_router.get("/video-indexing", response_class=HTMLResponse)
-async def video_indexing_page(request: Request):
+async def video_indexing_page(
+    request: Request,
+    current_user: dict = Depends(require_authentication),
+):
     """Render the video indexing management page."""
     context = {"page_title": "Video Indexing"}
     return await template_system.render_response(

--- a/tests/unit/test_video_indexing_page_auth.py
+++ b/tests/unit/test_video_indexing_page_auth.py
@@ -1,0 +1,71 @@
+"""Tests for video_indexing_page.py's auth fix (#392 Phase 2). Its single
+route (video_indexing_page) is a page-shell route serving the video
+indexing management HTML page -- same class of route as maintenance.py's
+maintenance_page (#413) and personal_insights.py's analytics_page (#418),
+both gated with require_authentication to match frontend_router.py's
+precedent for management-page routes.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.video_indexing_page import page_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "video_indexing_page.py"
+)
+
+EXPECTED_ROUTES = {"video_indexing_page"}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestVideoIndexingPageRequiresAuth:
+    def test_route_requires_authentication(self):
+        source = _function_source("video_indexing_page")
+        assert "Depends(require_authentication)" in source
+
+    def test_all_routes_are_covered_by_this_mapping(self):
+        route_function_names = {route.endpoint.__name__ for route in page_router.routes}
+        assert route_function_names == EXPECTED_ROUTES
+
+
+class TestVideoIndexingPageBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(page_router)
+        return TestClient(app)
+
+    def test_route_401s_without_session(self):
+        client = self._client()
+        response = client.get("/video-indexing")
+        assert response.status_code == 401
+
+    def test_route_succeeds_for_authenticated_session(self):
+        app = FastAPI()
+        app.include_router(page_router)
+        app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        client = TestClient(app)
+        response = client.get("/video-indexing")
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary
Continues the #392 Phase 2 FastAPI route-authentication sweep.

Its single route (`video_indexing_page`) is a page-shell route serving the video indexing management HTML page — same class of route as `maintenance.py`'s `maintenance_page` (#413) and `personal_insights.py`'s `analytics_page` (#418), both gated with `require_authentication` to match `frontend_router.py`'s precedent for management-page routes.

## Testing
`tests/unit/test_video_indexing_page_auth.py`: static AST source assertion plus real behavioral tests via FastAPI's `TestClient` (401 without a session, success with one). Verified RED before the fix, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)