### PR TITLE
fix(security): themes.py's 2 routes had zero authentication (#392 Phase 2 follow-up)

### DIFF
--- a/src/api/fastapi/themes.py
+++ b/src/api/fastapi/themes.py
@@ -443,6 +443,7 @@ async def get_theme(
 async def delete_theme(
     theme_id: int = FastAPIPath(..., description="Theme ID to delete"),
     db: Session = Depends(get_db_session),
+    current_user: dict = Depends(require_authentication),
 ):
     """
     Delete a custom theme
@@ -480,7 +481,10 @@ async def delete_theme(
 
 
 @router.get("/export/all")
-async def export_all_themes(db: Session = Depends(get_db_session)):
+async def export_all_themes(
+    db: Session = Depends(get_db_session),
+    current_user: dict = Depends(require_authentication),
+):
     """
     Export all custom themes as JSON
 

--- a/tests/unit/test_themes_auth.py
+++ b/tests/unit/test_themes_auth.py
@@ -1,0 +1,83 @@
+"""Regression test for residual auth gaps in themes.py (#392 Phase 2
+follow-up). Every other route in this file already requires
+authentication; delete_theme (DELETE /{theme_id}, a destructive
+state-changing action) and export_all_themes (GET /export/all, a bulk
+data export) were missed. Same tier as their siblings
+(require_authentication, no admin split anywhere else in this file).
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.themes import router
+from src.database.connection import get_db_session
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "themes.py"
+)
+
+NEWLY_GATED_ROUTES = {
+    "delete_theme",
+    "export_all_themes",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestThemesRoutesRequireAuth:
+    def test_every_newly_gated_route_requires_authentication(self):
+        for function_name in NEWLY_GATED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_every_route_in_file_requires_authentication(self):
+        # Guards against another route slipping through unnoticed.
+        for route in router.routes:
+            source = _function_source(route.endpoint.__name__)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{route.endpoint.__name__} is missing Depends(require_authentication)"
+
+
+class TestThemesBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_db_session] = lambda: iter([MagicMock()])
+        return TestClient(app)
+
+    def test_delete_theme_401s_without_session(self):
+        client = self._client()
+        response = client.delete("/api/themes/1")
+        assert response.status_code == 401
+
+    def test_export_all_themes_401s_without_session(self):
+        client = self._client()
+        response = client.get("/api/themes/export/all")
+        assert response.status_code == 401
+
+    def test_export_all_themes_succeeds_for_authenticated_session(self):
+        client = self._client()
+        client.app.dependency_overrides[require_authentication] = lambda: {
+            "authenticated": True,
+            "role": "user",
+        }
+        response = client.get("/api/themes/export/all")
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary
Follow-up to the #392 Phase 2 sweep, catching residual gaps missed in the earlier mechanical pass.

Every other route in `themes.py` already requires authentication; `delete_theme` (`DELETE /{theme_id}`, a destructive state-changing action) and `export_all_themes` (`GET /export/all`, a bulk data export) were missed. Same tier as their siblings (`require_authentication`, no admin split anywhere else in this file).

## Testing
`tests/unit/test_themes_auth.py`: static AST source assertions (including a file-wide guard that every route in this router requires auth) plus real behavioral tests via FastAPI's `TestClient`. Verified RED before the fix, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)