### PR TITLE
fix(security): themes.py's delete/export routes had no ownership checks (IDOR)

### DIFF
--- a/src/api/fastapi/themes.py
+++ b/src/api/fastapi/themes.py
@@ -448,9 +448,11 @@ async def delete_theme(
     """
     Delete a custom theme
 
-    Only custom themes can be deleted, not built-in themes.
+    Only custom themes can be deleted, not built-in themes, and only by
+    the theme's own creator.
     """
     try:
+        user_id = current_user.get("user_id", 6)
         theme = db.query(CustomTheme).filter(CustomTheme.id == theme_id).first()
 
         if not theme:
@@ -459,6 +461,19 @@ async def delete_theme(
         # Prevent deletion of built-in themes
         if theme.is_built_in:
             raise HTTPException(status_code=403, detail="Cannot delete built-in themes")
+
+        # Only the creator can delete their theme. A private theme
+        # belonging to someone else 404s (matches get_theme()'s own
+        # not-found-for-invisible-theme behavior, so this doesn't confirm
+        # a private theme id even exists); a public one 403s, since its
+        # existence is already visible via GET /api/themes.
+        if theme.created_by != user_id:
+            if theme.is_public:
+                raise HTTPException(
+                    status_code=403,
+                    detail="You don't have permission to delete this theme",
+                )
+            raise HTTPException(status_code=404, detail="Theme not found")
 
         # Delete the theme
         db.delete(theme)
@@ -488,12 +503,27 @@ async def export_all_themes(
     """
     Export all custom themes as JSON
 
-    Returns a JSON file containing all custom (non-built-in) themes
-    that can be imported into another instance.
+    Returns a JSON file containing the caller's own custom (non-built-in)
+    themes plus any public ones, that can be imported into another
+    instance.
     """
     try:
-        # Get all custom themes (exclude built-in)
-        themes = db.query(CustomTheme).filter(CustomTheme.is_built_in == False).all()
+        user_id = current_user.get("user_id", 6)
+        # Exclude built-in themes, and scope to the caller's own themes
+        # plus public ones -- matches get_themes()'s existing visibility
+        # filter. Without this, any authenticated user could export
+        # every other user's private theme data.
+        themes = (
+            db.query(CustomTheme)
+            .filter(
+                CustomTheme.is_built_in == False,
+                or_(
+                    CustomTheme.created_by == user_id,
+                    CustomTheme.is_public == True,
+                ),
+            )
+            .all()
+        )
 
         # Build export data structure (even if empty)
         export_data = {

--- a/tests/unit/test_themes_ownership.py
+++ b/tests/unit/test_themes_ownership.py
@@ -1,0 +1,178 @@
+"""Regression test for an IDOR/authorization gap in themes.py, flagged by
+background security review right after #392 Phase 2 follow-up PR #429
+added the missing require_authentication baseline to delete_theme and
+export_all_themes -- but neither route actually checked *whose* theme it
+was touching.
+
+CustomTheme already carries created_by and is_public columns, and
+get_theme()/get_themes() already establish the intended ownership model
+(a user can see their own themes, public themes, and built-in themes) --
+delete_theme and export_all_themes just never applied it:
+
+- delete_theme let ANY authenticated user delete ANY other user's custom
+  theme, public or private (broken authorization / IDOR).
+- export_all_themes returned every custom theme in the system, including
+  other users' private (non-public) themes (information disclosure via
+  IDOR).
+
+Fix:
+- delete_theme now 404s for another user's private theme (matching
+  get_theme's own not-found-for-invisible-theme behavior -- doesn't
+  confirm whether a private theme id even exists) and 403s for another
+  user's public theme (the theme's existence is already visible via
+  GET /api/themes, so a 403 here doesn't leak anything new; it just says
+  "yes, but you can't delete this one").
+- export_all_themes now only includes the caller's own themes plus
+  public ones, matching get_themes()'s existing filter.
+"""
+
+import json
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.api.fastapi.themes import delete_theme, export_all_themes
+from src.database.connection import Base
+from src.database.models import CustomTheme
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[CustomTheme.__table__])
+    return sessionmaker(bind=engine)
+
+
+def _seed_theme(session_factory, *, created_by, is_public=False, is_built_in=False):
+    session = session_factory()
+    theme = CustomTheme(
+        name=f"theme-{created_by}-{is_public}-{is_built_in}",
+        display_name="Test Theme",
+        created_by=created_by,
+        is_public=is_public,
+        is_built_in=is_built_in,
+        theme_data={"--color": "#000"},
+    )
+    session.add(theme)
+    session.commit()
+    theme_id = theme.id
+    session.close()
+    return theme_id
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+class TestDeleteThemeOwnership:
+    def test_owner_can_delete_their_own_private_theme(self, session_factory):
+        theme_id = _seed_theme(session_factory, created_by=1, is_public=False)
+        session = session_factory()
+
+        result = _run(
+            delete_theme(
+                theme_id=theme_id,
+                db=session,
+                current_user={"user_id": 1, "username": "owner"},
+            )
+        )
+
+        assert result["success"] is True
+        assert session.query(CustomTheme).filter_by(id=theme_id).first() is None
+
+    def test_non_owner_cannot_delete_someone_elses_private_theme(self, session_factory):
+        theme_id = _seed_theme(session_factory, created_by=1, is_public=False)
+        session = session_factory()
+
+        with pytest.raises(HTTPException) as exc_info:
+            _run(
+                delete_theme(
+                    theme_id=theme_id,
+                    db=session,
+                    current_user={"user_id": 2, "username": "attacker"},
+                )
+            )
+
+        # Doesn't confirm whether a private theme id even exists --
+        # matches get_theme()'s own not-found-for-invisible-theme
+        # behavior.
+        assert exc_info.value.status_code == 404
+        assert session.query(CustomTheme).filter_by(id=theme_id).first() is not None
+
+    def test_non_owner_cannot_delete_someone_elses_public_theme(self, session_factory):
+        theme_id = _seed_theme(session_factory, created_by=1, is_public=True)
+        session = session_factory()
+
+        with pytest.raises(HTTPException) as exc_info:
+            _run(
+                delete_theme(
+                    theme_id=theme_id,
+                    db=session,
+                    current_user={"user_id": 2, "username": "attacker"},
+                )
+            )
+
+        # A public theme's existence is already visible via GET
+        # /api/themes, so 403 (as opposed to 404) doesn't leak anything
+        # new here.
+        assert exc_info.value.status_code == 403
+        assert session.query(CustomTheme).filter_by(id=theme_id).first() is not None
+
+    def test_built_in_theme_still_blocked_regardless_of_owner(self, session_factory):
+        # Regression guard: the pre-existing is_built_in check must keep
+        # working even for the theme's own creator.
+        theme_id = _seed_theme(
+            session_factory, created_by=1, is_public=True, is_built_in=True
+        )
+        session = session_factory()
+
+        with pytest.raises(HTTPException) as exc_info:
+            _run(
+                delete_theme(
+                    theme_id=theme_id,
+                    db=session,
+                    current_user={"user_id": 1, "username": "owner"},
+                )
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "built-in" in exc_info.value.detail.lower()
+
+
+class TestExportAllThemesOwnership:
+    def test_export_includes_own_and_public_themes_only(self, session_factory):
+        own_theme_id = _seed_theme(session_factory, created_by=1, is_public=False)
+        public_theme_id = _seed_theme(session_factory, created_by=2, is_public=True)
+        other_private_theme_id = _seed_theme(
+            session_factory, created_by=2, is_public=False
+        )
+        session = session_factory()
+
+        response = _run(
+            export_all_themes(
+                db=session,
+                current_user={"user_id": 1, "username": "owner"},
+            )
+        )
+        result = json.loads(response.body)
+
+        exported_names = {t["name"] for t in result["themes"]}
+        session2 = session_factory()
+        own_name = session2.query(CustomTheme).filter_by(id=own_theme_id).first().name
+        public_name = (
+            session2.query(CustomTheme).filter_by(id=public_theme_id).first().name
+        )
+        other_private_name = (
+            session2.query(CustomTheme)
+            .filter_by(id=other_private_theme_id)
+            .first()
+            .name
+        )
+
+        assert own_name in exported_names
+        assert public_name in exported_names
+        assert other_private_name not in exported_names


### PR DESCRIPTION
## Summary
Flagged by background security review right after #392 Phase 2 follow-up PR #429 added the missing `require_authentication` baseline to `delete_theme` and `export_all_themes` — but neither route actually checked *whose* theme it was touching.

`CustomTheme` already carries `created_by` and `is_public` columns, and `get_theme()`/`get_themes()` already establish the intended ownership model (a user can see their own themes, public themes, and built-in themes) — `delete_theme` and `export_all_themes` just never applied it:

- `delete_theme` let ANY authenticated user delete ANY other user's custom theme, public or private (broken authorization / IDOR).
- `export_all_themes` returned every custom theme in the system, including other users' private (non-public) themes (information disclosure via IDOR).

## Fix
- `delete_theme` now 404s for another user's private theme (matching `get_theme`'s own not-found-for-invisible-theme behavior — doesn't confirm whether a private theme id even exists) and 403s for another user's public theme (the theme's existence is already visible via `GET /api/themes`, so a 403 here doesn't leak anything new).
- `export_all_themes` now only includes the caller's own themes plus public ones, matching `get_themes()`'s existing filter.

## Testing
`tests/unit/test_themes_ownership.py`: real behavioral tests against an in-memory SQLite-backed `CustomTheme` table, calling the route functions directly. Covers: owner deleting their own theme (succeeds), non-owner attempting a private theme (404), non-owner attempting a public theme (403), built-in themes staying blocked regardless of owner (regression guard), and export correctly including own + public themes while excluding other users' private ones. Verified RED before the fix, GREEN after — all 5 new tests plus the existing 5 `test_themes_auth.py` tests pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)