### PR TITLE
fix(security): frontend_router.py's main content pages had zero authentication (#392 Phase 2 follow-up)

### DIFF
--- a/src/api/fastapi/frontend_router.py
+++ b/src/api/fastapi/frontend_router.py
@@ -32,7 +32,7 @@ frontend_router = APIRouter(
 
 
 @frontend_router.get("/", response_class=HTMLResponse, name="frontend_index")
-async def index(request: Request):
+async def index(request: Request, user=Depends(require_authentication)):
     """Dashboard/Index page"""
     try:
         return await template_routes.index(request)
@@ -44,13 +44,13 @@ async def index(request: Request):
 @frontend_router.get(
     "/dashboard", response_class=HTMLResponse, name="frontend_dashboard"
 )
-async def dashboard(request: Request):
+async def dashboard(request: Request, user=Depends(require_authentication)):
     """Dashboard page (redirect to index)"""
     return RedirectResponse(url="/", status_code=302)
 
 
 @frontend_router.get("/videos", response_class=HTMLResponse, name="frontend_videos")
-async def videos(request: Request):
+async def videos(request: Request, user=Depends(require_authentication)):
     """Videos management page"""
     try:
         return await template_routes.videos(request)
@@ -62,7 +62,9 @@ async def videos(request: Request):
 @frontend_router.get(
     "/videos/{video_id}", response_class=HTMLResponse, name="frontend_video_detail"
 )
-async def video_detail(request: Request, video_id: int):
+async def video_detail(
+    request: Request, video_id: int, user=Depends(require_authentication)
+):
     """Video detail page (plural URL)"""
     try:
         context = {"video_id": video_id, "page_title": "Video Details"}
@@ -79,7 +81,9 @@ async def video_detail(request: Request, video_id: int):
     response_class=HTMLResponse,
     name="frontend_video_detail_singular",
 )
-async def video_detail_singular(request: Request, video_id: int):
+async def video_detail_singular(
+    request: Request, video_id: int, user=Depends(require_authentication)
+):
     """Video detail page (singular URL)"""
     try:
         context = {"video_id": video_id, "page_title": "Video Details"}
@@ -92,7 +96,7 @@ async def video_detail_singular(request: Request, video_id: int):
 
 
 @frontend_router.get("/artists", response_class=HTMLResponse, name="frontend_artists")
-async def artists(request: Request):
+async def artists(request: Request, user=Depends(require_authentication)):
     """Artists management page"""
     try:
         return await template_routes.artists(request)
@@ -104,7 +108,11 @@ async def artists(request: Request):
 @frontend_router.get(
     "/artist/{artist_id}", response_class=HTMLResponse, name="frontend_artist_detail"
 )
-async def artist_detail(request: Request, artist_id: int = Path(..., ge=1)):
+async def artist_detail(
+    request: Request,
+    artist_id: int = Path(..., ge=1),
+    user=Depends(require_authentication),
+):
     """Artist detail page"""
     try:
         return await template_routes.artist_detail(request, artist_id)
@@ -116,7 +124,7 @@ async def artist_detail(request: Request, artist_id: int = Path(..., ge=1)):
 @frontend_router.get(
     "/playlists", response_class=HTMLResponse, name="frontend_playlists"
 )
-async def playlists(request: Request):
+async def playlists(request: Request, user=Depends(require_authentication)):
     """Playlists management page"""
     try:
         return await template_routes.playlists(request)
@@ -130,7 +138,11 @@ async def playlists(request: Request):
     response_class=HTMLResponse,
     name="frontend_playlist_detail",
 )
-async def playlist_detail(request: Request, playlist_id: int = Path(..., ge=1)):
+async def playlist_detail(
+    request: Request,
+    playlist_id: int = Path(..., ge=1),
+    user=Depends(require_authentication),
+):
     """Playlist detail page"""
     try:
         context = {"playlist_id": playlist_id, "page_title": "Playlist Details"}
@@ -145,7 +157,11 @@ async def playlist_detail(request: Request, playlist_id: int = Path(..., ge=1)):
 
 
 @frontend_router.get("/discover", response_class=HTMLResponse, name="frontend_discover")
-async def discover(request: Request, q: Optional[str] = Query(None)):
+async def discover(
+    request: Request,
+    q: Optional[str] = Query(None),
+    user=Depends(require_authentication),
+):
     """Universal search/discover page"""
     try:
         context = {"page_title": "Discover Music Videos", "search_query": q or ""}
@@ -156,7 +172,11 @@ async def discover(request: Request, q: Optional[str] = Query(None)):
 
 
 @frontend_router.get("/mvtv", response_class=HTMLResponse, name="frontend_mvtv")
-async def mvtv(request: Request, playlist: Optional[int] = Query(None)):
+async def mvtv(
+    request: Request,
+    playlist: Optional[int] = Query(None),
+    user=Depends(require_authentication),
+):
     """MvTV continuous video player page"""
     try:
         context = {
@@ -170,7 +190,7 @@ async def mvtv(request: Request, playlist: Optional[int] = Query(None)):
 
 
 @frontend_router.get("/jobs", response_class=HTMLResponse, name="frontend_jobs")
-async def jobs(request: Request):
+async def jobs(request: Request, user=Depends(require_authentication)):
     """Background Jobs Dashboard"""
     try:
         context = {"page_title": "Background Jobs"}
@@ -458,7 +478,9 @@ async def admin_user_details(
     response_class=HTMLResponse,
     name="component_add_video_modal",
 )
-async def add_video_modal_component(request: Request):
+async def add_video_modal_component(
+    request: Request, user=Depends(require_authentication)
+):
     """Add video modal component"""
     try:
         context = {"modal_only": True, "component_name": "add_video_modal"}
@@ -475,7 +497,9 @@ async def add_video_modal_component(request: Request):
     response_class=HTMLResponse,
     name="component_job_dashboard_modal",
 )
-async def job_dashboard_modal_component(request: Request):
+async def job_dashboard_modal_component(
+    request: Request, user=Depends(require_authentication)
+):
     """Job dashboard modal component"""
     try:
         context = {"modal_only": True, "component_name": "job_dashboard_modal"}
@@ -518,7 +542,9 @@ async def frontend_search(
 
 
 @frontend_router.get("/api/navigation", name="frontend_navigation")
-async def frontend_navigation(request: Request):
+async def frontend_navigation(
+    request: Request, current_user: dict = Depends(require_api_authentication)
+):
     """Get navigation structure for frontend"""
     try:
         navigation = {

--- a/tests/unit/test_frontend_router_page_auth.py
+++ b/tests/unit/test_frontend_router_page_auth.py
@@ -1,0 +1,151 @@
+"""Tests for frontend_router.py's remaining unauthenticated content pages
+(#392 Phase 2 follow-up). 9 sibling pages in this same file already use
+template_system.require_authentication (settings, scheduler dashboard/
+jobs, youtube-playlists, spotify/lastfm/webhooks/lidarr managers,
+enrichment, 2FA setup) -- the app's own main content pages (the actual
+dashboard/videos/artists/playlists/discover/mvtv/jobs pages, plus the two
+modal-fragment components embedded in them) had no such gate at all,
+showing full page content to fully anonymous visitors.
+
+Left deliberately public (not touched here):
+- wizard_page (/wizard): explicitly pre-setup, no admin account can exist
+  yet to authenticate as. Tracked separately (#405).
+- login_page, simple_login_page: must be reachable to log in at all.
+- logout: safe regardless of auth state -- clears whatever session
+  exists (or none) and redirects to login either way.
+- not_found_handler, internal_server_error_handler: framework exception
+  handlers (not @frontend_router-decorated routes), must render for any
+  visitor including anonymous ones hitting a bad URL.
+- frontend_health (/health) and web_app_manifest (/manifest.json):
+  neither reveals sensitive data (booleans about template/static dirs
+  existing; static app branding metadata) and both match established
+  public-probe/PWA-manifest conventions (health.py's own public liveness/
+  readiness routes; browsers fetch PWA manifests before a user has ever
+  logged in, e.g. to evaluate installability from the login page itself).
+
+frontend_navigation (/api/navigation) is a JSON API endpoint returning
+static menu structure, not an HTML page (mirrors frontend_search, its
+sibling in this same file, already fixed with the API-style 401 variant
+in an earlier PR) -- gated the same way, not with the redirect-style
+dependency the HTML pages use, since a 302 to a fetch() call would be
+followed transparently and return the login page's HTML where JSON was
+expected.
+"""
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.fastapi.frontend_router import frontend_router
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "api"
+    / "fastapi"
+    / "frontend_router.py"
+)
+
+PAGE_STYLE_ROUTES = {
+    "index": "/",
+    "dashboard": "/dashboard",
+    "videos": "/videos",
+    "video_detail": "/videos/1",
+    "video_detail_singular": "/video/1",
+    "artists": "/artists",
+    "artist_detail": "/artist/1",
+    "playlists": "/playlists",
+    "playlist_detail": "/playlist/1",
+    "discover": "/discover",
+    "mvtv": "/mvtv",
+    "jobs": "/jobs",
+    "add_video_modal_component": "/components/add-video-modal",
+    "job_dashboard_modal_component": "/components/job-dashboard-modal",
+}
+
+API_STYLE_ROUTES = {
+    "frontend_navigation": "/api/navigation",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestFrontendRouterPagesRequireAuth:
+    def test_every_page_style_route_uses_template_systems_require_authentication(
+        self,
+    ):
+        for function_name in PAGE_STYLE_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_every_api_style_route_uses_the_401_variant(self):
+        for function_name in API_STYLE_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_api_authentication)" in source
+            ), f"{function_name} should use Depends(require_api_authentication), got:\n{source}"
+
+
+class TestFrontendRouterPagesBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(frontend_router)
+        return TestClient(app, follow_redirects=False)
+
+    def test_every_page_style_route_redirects_anonymous_visitors_to_login(self):
+        client = self._client()
+        for function_name, path in PAGE_STYLE_ROUTES.items():
+            response = client.get(path)
+            assert response.status_code == 302, (
+                f"{function_name} ({path}) should 302 for an anonymous "
+                f"visitor, got {response.status_code}"
+            )
+            assert response.headers["location"] == "/auth/login"
+
+    def test_every_api_style_route_401s_for_anonymous_visitors(self):
+        client = self._client()
+        for function_name, path in API_STYLE_ROUTES.items():
+            response = client.get(path)
+            assert response.status_code == 401, (
+                f"{function_name} ({path}) should 401 for an anonymous "
+                f"visitor, got {response.status_code}"
+            )
+
+
+class TestDeliberatelyPublicRoutesStayPublic:
+    """Regression guard: none of these should ever pick up an auth
+    dependency by accident during future edits to this file."""
+
+    def _client(self):
+        app = FastAPI()
+        app.include_router(frontend_router)
+        return TestClient(app, follow_redirects=False)
+
+    def test_wizard_page_stays_reachable_without_a_session(self):
+        client = self._client()
+        response = client.get("/wizard")
+        assert response.status_code != 302
+
+    def test_login_page_stays_reachable_without_a_session(self):
+        client = self._client()
+        response = client.get("/auth/login")
+        assert response.status_code != 302
+
+    def test_logout_stays_reachable_without_a_session(self):
+        client = self._client()
+        response = client.get("/auth/logout")
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary
Continues the #392 Phase 2 sweep. This was the last big scoping decision left pending from earlier in the sweep — the "22 unauthenticated HTML pages need a deliberate public/auth split" item.

9 sibling pages in this same file already use `template_system`'s `require_authentication` (settings, scheduler dashboard/jobs, youtube-playlists, spotify/lastfm/webhooks/lidarr managers, enrichment, 2FA setup) — but the app's own main content pages had no such gate at all, showing full page content to fully anonymous visitors: `index` (`"/"`), `dashboard`, `videos`, `video_detail` (both URL forms), `artists`, `artist_detail`, `playlists`, `playlist_detail`, `discover`, `mvtv`, `jobs`, and the two modal-fragment components embedded in them (`add-video-modal`, `job-dashboard-modal`). All 13 now use the same redirect-style `require_authentication` dependency as their siblings.

Also fixed `frontend_navigation` (`/api/navigation`) — a JSON API endpoint, not an HTML page. Gated it with the API-style `require_api_authentication` variant instead (same choice already made for its sibling `frontend_search`): a 302 to a `fetch()` call would be followed transparently and return the login page's HTML where JSON was expected.

## Left deliberately public (evaluated, not touched)
- `wizard_page` (`/wizard`): pre-setup, no admin account can exist yet. Tracked separately (#405).
- `login_page`, `simple_login_page`: must be reachable to log in at all.
- `logout`: safe regardless of auth state.
- `not_found_handler`, `internal_server_error_handler`: framework exception handlers, must render for anonymous visitors too.
- `frontend_health` (`/health`) and `web_app_manifest` (`/manifest.json`): no sensitive data, match established public-probe/PWA-manifest conventions.

## Testing
`tests/unit/test_frontend_router_page_auth.py`: static AST assertions plus real end-to-end behavioral tests via FastAPI's `TestClient` with `follow_redirects=False` — every page-style route 302s to `/auth/login`, the API-style route 401s. No mocking needed — the underlying dependency chain (`SettingsService.get_bool()`, `get_current_user_session()`) fails safe to secure defaults without a real database. Includes a regression guard confirming the deliberately-public routes stay reachable. Verified RED before the fix, GREEN after — 14 tests across this file and its siblings pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)