### PR TITLE
fix(security): themes.py's user_id extraction had a fail-open default (HIGH)

### DIFF
--- a/src/api/fastapi/themes.py
+++ b/src/api/fastapi/themes.py
@@ -78,6 +78,23 @@ class ApplyThemeRequest(BaseModel):
 # Hardcoded theme functions removed - all themes now stored in database
 
 
+def _require_user_id(current_user: dict) -> int:
+    """Extract the authenticated user's id strictly -- no fail-open
+    default. Flagged by background security review (HIGH, Authorization
+    / Fail-Open Default User ID): every route below used to extract this
+    via `current_user.get("user_id", 6)`, which would have silently
+    attributed the action to a fixed, unrelated user id (6) if the field
+    were ever absent, instead of failing closed. Since delete_theme and
+    export_all_themes gate real deletion/export access on this exact
+    value (#392 IDOR fix), a fail-open default here would undermine that
+    fix outright.
+    """
+    user_id = current_user.get("user_id")
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user_id
+
+
 # ========================================================================================
 # THEME MANAGEMENT ENDPOINTS
 # ========================================================================================
@@ -90,7 +107,7 @@ async def get_themes(
 ):
     """Get all available themes (built-in and custom)"""
     try:
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
         logger.info(f"Loading themes for user {user_id}")
 
         # Get custom themes from database
@@ -230,7 +247,7 @@ async def apply_theme(
     """Apply a theme"""
     try:
         theme_identifier = request.theme_name
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
 
         logger.info(f"Applying theme '{theme_identifier}' for user {user_id}")
 
@@ -345,7 +362,7 @@ async def create_theme(
 ):
     """Create a new custom theme"""
     try:
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
 
         # Check if theme name already exists
         existing = (
@@ -401,7 +418,7 @@ async def get_theme(
 ):
     """Get a specific theme by ID"""
     try:
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
 
         theme = (
             session.query(CustomTheme)
@@ -452,7 +469,7 @@ async def delete_theme(
     the theme's own creator.
     """
     try:
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
         theme = db.query(CustomTheme).filter(CustomTheme.id == theme_id).first()
 
         if not theme:
@@ -508,7 +525,7 @@ async def export_all_themes(
     instance.
     """
     try:
-        user_id = current_user.get("user_id", 6)
+        user_id = _require_user_id(current_user)
         # Exclude built-in themes, and scope to the caller's own themes
         # plus public ones -- matches get_themes()'s existing visibility
         # filter. Without this, any authenticated user could export

--- a/tests/unit/test_themes_auth.py
+++ b/tests/unit/test_themes_auth.py
@@ -78,6 +78,10 @@ class TestThemesBehavioralAuth:
         client.app.dependency_overrides[require_authentication] = lambda: {
             "authenticated": True,
             "role": "user",
+            # user_id is required since #392's fail-open-default fix
+            # (_require_user_id): a session dict missing it now 401s
+            # instead of silently defaulting to a fixed fallback user.
+            "user_id": 1,
         }
         response = client.get("/api/themes/export/all")
         assert response.status_code != 401

--- a/tests/unit/test_themes_user_id_fail_open.py
+++ b/tests/unit/test_themes_user_id_fail_open.py
@@ -1,0 +1,82 @@
+"""Regression test for a HIGH-severity fail-open default flagged by
+background security review right after #392 Phase 2's IDOR fix (PR #431):
+every route in themes.py extracted the caller's id via
+`current_user.get("user_id", 6)` -- if "user_id" were ever absent from
+the session dict (a future refactor changing its shape, a bug elsewhere),
+this would silently attribute the action to a fixed, unrelated user id
+(6) instead of failing closed. Since delete_theme and export_all_themes
+now gate real deletion/export access on this exact value (#392 IDOR fix,
+PR #431), a fail-open default here would have undermined that fix
+outright: anyone hitting the fallback would be silently treated as user
+6, able to delete or export user 6's themes.
+
+Every route in this file (get_themes, apply_theme, create_theme,
+get_theme, delete_theme, export_all_themes) used the same pattern --
+fixed uniformly via a shared _require_user_id() helper that raises 401
+instead of defaulting.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.fastapi.themes import _require_user_id
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "themes.py"
+)
+
+ROUTES_USING_USER_ID = {
+    "get_themes",
+    "apply_theme",
+    "create_theme",
+    "get_theme",
+    "delete_theme",
+    "export_all_themes",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestNoRouteHasAFailOpenDefault:
+    def test_no_route_defaults_user_id_to_a_fixed_fallback(self):
+        # Checked per-route-function, not against the whole file's text --
+        # _require_user_id's own docstring legitimately quotes the old
+        # pattern to explain what it replaced.
+        for function_name in ROUTES_USING_USER_ID:
+            source = _function_source(function_name)
+            assert 'current_user.get("user_id", 6)' not in source
+
+    def test_every_route_that_needs_user_id_uses_the_strict_helper(self):
+        for function_name in ROUTES_USING_USER_ID:
+            source = _function_source(function_name)
+            assert (
+                "_require_user_id(current_user)" in source
+            ), f"{function_name} should call _require_user_id(current_user), got:\n{source}"
+
+
+class TestRequireUserIdHelper:
+    def test_returns_the_user_id_when_present(self):
+        assert _require_user_id({"user_id": 42, "authenticated": True}) == 42
+
+    def test_raises_401_when_user_id_is_missing(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _require_user_id({"authenticated": True})
+        assert exc_info.value.status_code == 401
+
+    def test_raises_401_when_user_id_is_none(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _require_user_id({"user_id": None, "authenticated": True})
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary
Flagged by background security review right after #392's IDOR fix (PR #431): every route in this file extracted the caller's id via `current_user.get("user_id", 6)`. If `"user_id"` were ever absent from the session dict (a future refactor changing its shape, a bug elsewhere), this would silently attribute the action to a fixed, unrelated user id (6) instead of failing closed. Since `delete_theme` and `export_all_themes` now gate real deletion/export access on this exact value (#392 IDOR fix, PR #431), a fail-open default here would have undermined that fix outright.

## Fix
Added a shared `_require_user_id()` helper that extracts the value strictly and raises 401 if absent, used uniformly across all 6 routes that need it (`get_themes`, `apply_theme`, `create_theme`, `get_theme`, `delete_theme`, `export_all_themes`) — not just the two the reviewer named, since every route in the file shared the identical pattern.

Also fixed a pre-existing test bug this surfaced: `test_themes_auth.py`'s `test_export_all_themes_succeeds_for_authenticated_session` overrode `require_authentication` with a fake user dict missing `"user_id"` — which, correctly, now 401s under the new strict check. Added `user_id` to that fake dict so the test again exercises its intended case.

## Testing
Unit tests for the helper itself, plus static AST assertions that no route's source still contains the literal fail-open pattern and that all 6 routes call the new helper. Verified RED before the fix, GREEN after — 15 tests across this file and its `themes.py` siblings pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)