### PR TITLE
fix(security): wizard.py's post-completion endpoints stayed open indefinitely (#405)

### DIFF
--- a/src/api/fastapi/wizard.py
+++ b/src/api/fastapi/wizard.py
@@ -11,11 +11,22 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
-from src.api.fastapi.auth_dependencies import require_authentication
+from src.api.fastapi.auth_dependencies import (
+    get_current_user_session,
+    require_authentication,
+)
 from src.database.connection import get_db_session
 from src.database.models import WizardState, WizardStatus, WizardStep
 from src.services.imvdb_service import imvdb_service
@@ -33,6 +44,65 @@ router = APIRouter(
         422: {"description": "Validation error"},
     },
 )
+
+
+# ========================================================================================
+# POST-COMPLETION ACCESS CONTROL (#405)
+# ========================================================================================
+#
+# The wizard is only genuinely "public by design" -- no auth required --
+# while it's still running, pre-setup, before any admin account exists.
+# Only create_admin_user() originally enforced that; validate_directory,
+# test_api, start_video_import, upload_videos, and
+# start_custom_directory_import stayed callable by anyone, indefinitely,
+# after setup completed.
+#
+# Two different fixes are needed, not one uniform gate: validate_directory
+# and test_api have no legitimate caller once setup is done, so they're
+# simply closed off. start_video_import, upload_videos, and
+# start_custom_directory_import are ALSO used by settings.html's
+# "Settings > System" video import feature -- a normal, ongoing,
+# post-setup feature that happens to share this router's Celery task
+# logic. Closing all five off outright would have 403'd that Settings
+# feature on every real deployment (the wizard is COMPLETED by then).
+
+
+async def require_wizard_incomplete(
+    session: Session = Depends(get_db_session),
+) -> None:
+    """For endpoints with no legitimate caller once setup is done
+    (validate_directory, test_api). Matches create_admin_user's existing
+    WizardStatus.COMPLETED check.
+    """
+    wizard_state = session.query(WizardState).first()
+    if wizard_state and wizard_state.status == WizardStatus.COMPLETED:
+        raise HTTPException(
+            status_code=403,
+            detail="This wizard endpoint is no longer available: setup has already completed",
+        )
+
+
+async def require_wizard_incomplete_or_authenticated(
+    request: Request,
+    session: Session = Depends(get_db_session),
+) -> Optional[Dict[str, Any]]:
+    """For start_video_import (/import/start), which is genuinely
+    dual-purpose: called by wizard.js pre-setup (no session exists yet)
+    AND by settings.html's Settings > System import feature post-setup
+    (an already-authenticated caller). Passes through untouched while
+    the wizard is still incomplete; once it's completed, falls back to
+    requiring a real authenticated session, exactly like every other
+    post-setup API route in this app.
+    """
+    wizard_state = session.query(WizardState).first()
+    if not wizard_state or wizard_state.status != WizardStatus.COMPLETED:
+        return None
+
+    user = await get_current_user_session(request)
+    if not user or not user.get("authenticated"):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
+
 
 # ========================================================================================
 # PYDANTIC MODELS FOR REQUEST/RESPONSE VALIDATION
@@ -528,6 +598,7 @@ async def skip_wizard(
 async def validate_directory(
     request: DirectoryValidationRequest,
     session: Session = Depends(get_db_session),
+    _wizard_gate: None = Depends(require_wizard_incomplete),
 ):
     """
     Validate a directory path for use as music videos directory.
@@ -604,6 +675,7 @@ async def validate_directory(
 async def test_api(
     request: APITestRequest,
     session: Session = Depends(get_db_session),
+    _wizard_gate: None = Depends(require_wizard_incomplete),
 ):
     """
     Test API keys/credentials before saving.
@@ -684,6 +756,9 @@ async def test_api(
 async def start_video_import(
     request: ImportStartRequest,
     session: Session = Depends(get_db_session),
+    _auth_or_wizard: Optional[Dict[str, Any]] = Depends(
+        require_wizard_incomplete_or_authenticated
+    ),
 ):
     """
     Start video import as part of wizard using Celery.
@@ -775,6 +850,7 @@ async def start_video_import(
 async def start_custom_directory_import(
     request: ImportStartRequest,
     session: Session = Depends(get_db_session),
+    current_user: dict = Depends(require_authentication),
 ):
     """
     Start custom directory import (Settings > System feature).
@@ -870,6 +946,7 @@ class UploadResponse(BaseModel):
 async def upload_videos(
     files: List[UploadFile] = File(...),
     session: Session = Depends(get_db_session),
+    current_user: dict = Depends(require_authentication),
 ):
     """
     Upload video files from user's PC to a temporary directory on the server.

--- a/tests/unit/test_wizard_post_completion_auth.py
+++ b/tests/unit/test_wizard_post_completion_auth.py
@@ -1,0 +1,225 @@
+"""Fix for issue #405: wizard.py is only partially self-disabling after
+setup completes. Only create_admin_user() checked WizardStatus.COMPLETED;
+the other 5 endpoints named in the issue stayed callable by anyone,
+indefinitely, post-setup:
+
+  - POST /validate-directory
+  - POST /test-api
+  - POST /import/start
+  - POST /upload-videos
+  - POST /import/custom-directory/start
+
+The issue's suggested fix ("extend the same WizardStatus.COMPLETED guard
+... to the other five endpoints") turns out to be wrong for 3 of the 5:
+grepping the frontend showed /import/start, /upload-videos, and
+/import/custom-directory/start are ALSO called by settings.html's
+"Settings > System" video import feature (startVideoImport(), the
+upload-then-import flow) -- a normal, ongoing, POST-setup feature, not
+just a wizard step. wizard.js (the actual wizard frontend) only calls
+/status, /steps/{step}/complete, /create-admin, /validate-directory,
+/test-api, /import/start, and /skip -- notably NOT /upload-videos or
+/import/custom-directory/start.
+
+Blindly gating all 5 behind "wizard not completed" would have 403'd
+Settings > System's import feature on every real, post-setup deployment
+(every wizard is COMPLETED by then). The actual fix:
+
+  - validate_directory, test_api: wizard-only, no other caller -> gated
+    with require_wizard_incomplete (403 once WizardStatus.COMPLETED,
+    matching create_admin_user's existing precedent).
+  - upload_videos, start_custom_directory_import: Settings-only, never
+    called pre-setup -> gated with the standard require_authentication
+    (same tier as every other authenticated API route in this app).
+  - start_video_import (/import/start): genuinely dual-purpose (called
+    by both wizard.js pre-setup and settings.html post-setup) -> gated
+    with require_wizard_incomplete_or_authenticated, which passes
+    through untouched while the wizard is incomplete (pre-setup, no
+    session exists yet) and otherwise requires a real authenticated
+    session (post-setup Settings caller).
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from starlette.requests import Request
+
+from src.api.fastapi.wizard import (
+    require_wizard_incomplete,
+    require_wizard_incomplete_or_authenticated,
+    router,
+)
+from src.database.connection import Base, get_db_session
+from src.database.models import WizardState, WizardStatus
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "wizard.py"
+)
+
+WIZARD_ONLY_ROUTES = {"validate_directory", "test_api"}
+SETTINGS_ONLY_ROUTES = {"upload_videos", "start_custom_directory_import"}
+DUAL_PURPOSE_ROUTES = {"start_video_import"}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestRouteWiring:
+    def test_wizard_only_routes_use_require_wizard_incomplete(self):
+        for function_name in WIZARD_ONLY_ROUTES:
+            source = _function_source(function_name)
+            assert "Depends(require_wizard_incomplete)" in source
+
+    def test_settings_only_routes_use_require_authentication(self):
+        for function_name in SETTINGS_ONLY_ROUTES:
+            source = _function_source(function_name)
+            assert "Depends(require_authentication)" in source
+
+    def test_dual_purpose_route_uses_the_either_or_dependency(self):
+        for function_name in DUAL_PURPOSE_ROUTES:
+            source = _function_source(function_name)
+            # Depends(...) is line-wrapped by black for this long name --
+            # check the pieces are both present rather than exact spacing.
+            assert "Depends(" in source
+            assert "require_wizard_incomplete_or_authenticated" in source
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[WizardState.__table__])
+    return sessionmaker(bind=engine)
+
+
+def _seed_wizard(session_factory, status):
+    session = session_factory()
+    session.add(WizardState(status=status))
+    session.commit()
+    session.close()
+
+
+def _make_request(cookies=None):
+    headers = []
+    if cookies:
+        cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        headers.append((b"cookie", cookie_header.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/wizard/import/start",
+        "headers": headers,
+        "query_string": b"",
+        "server": ("localhost", 5000),
+        "client": ("127.0.0.1", 12345),
+        "scheme": "http",
+        "app": None,
+    }
+    return Request(scope)
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+class TestRequireWizardIncomplete:
+    def test_passes_when_no_wizard_row_exists(self, session_factory):
+        session = session_factory()
+        result = _run(require_wizard_incomplete(session=session))
+        assert result is None
+
+    def test_passes_while_wizard_is_in_progress(self, session_factory):
+        _seed_wizard(session_factory, WizardStatus.IN_PROGRESS)
+        session = session_factory()
+        result = _run(require_wizard_incomplete(session=session))
+        assert result is None
+
+    def test_rejects_once_wizard_has_completed(self, session_factory):
+        _seed_wizard(session_factory, WizardStatus.COMPLETED)
+        session = session_factory()
+        with pytest.raises(HTTPException) as exc_info:
+            _run(require_wizard_incomplete(session=session))
+        assert exc_info.value.status_code in (400, 403)
+
+
+class TestRequireWizardIncompleteOrAuthenticated:
+    def test_passes_while_wizard_is_incomplete_even_with_no_session(
+        self, session_factory
+    ):
+        session = session_factory()
+        request = _make_request(cookies=None)
+        result = _run(
+            require_wizard_incomplete_or_authenticated(request=request, session=session)
+        )
+        assert result is None
+
+    def test_rejects_completed_wizard_with_no_session(self, session_factory):
+        _seed_wizard(session_factory, WizardStatus.COMPLETED)
+        session = session_factory()
+        request = _make_request(cookies=None)
+        with pytest.raises(HTTPException) as exc_info:
+            _run(
+                require_wizard_incomplete_or_authenticated(
+                    request=request, session=session
+                )
+            )
+        assert exc_info.value.status_code == 401
+
+    def test_accepts_completed_wizard_with_a_valid_session(
+        self, session_factory, monkeypatch
+    ):
+        _seed_wizard(session_factory, WizardStatus.COMPLETED)
+        session = session_factory()
+        request = _make_request(cookies={"session_token": "fake-valid-token"})
+
+        async def _fake_get_current_user_session(req):
+            return {"authenticated": True, "user_id": 1, "role": "USER"}
+
+        monkeypatch.setattr(
+            "src.api.fastapi.wizard.get_current_user_session",
+            _fake_get_current_user_session,
+        )
+
+        result = _run(
+            require_wizard_incomplete_or_authenticated(request=request, session=session)
+        )
+        assert result == {"authenticated": True, "user_id": 1, "role": "USER"}
+
+
+class TestSettingsOnlyRoutesBehavioralAuth:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_db_session] = lambda: iter([MagicMock()])
+        return TestClient(app)
+
+    def test_upload_videos_401s_without_session(self):
+        client = self._client()
+        response = client.post(
+            "/api/wizard/upload-videos",
+            files={"files": ("test.mp4", b"fake video data", "video/mp4")},
+        )
+        assert response.status_code == 401
+
+    def test_custom_directory_import_401s_without_session(self):
+        client = self._client()
+        response = client.post(
+            "/api/wizard/import/custom-directory/start",
+            json={"directory": "/tmp"},
+        )
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary
Closes #405. Only `create_admin_user()` checked `WizardStatus.COMPLETED`. The other 5 endpoints named in the issue stayed callable by anyone, indefinitely, post-setup: `POST /validate-directory`, `/test-api`, `/import/start`, `/upload-videos`, `/import/custom-directory/start`.

**#405's own suggested fix turns out to be wrong for 3 of the 5.** Grepping the frontend showed `/import/start`, `/upload-videos`, and `/import/custom-directory/start` are ALSO called by `settings.html`'s "Settings > System" video import feature (`startVideoImport()`, the upload-then-import flow) — a normal, ongoing, post-setup feature, not just a wizard step. `wizard.js` (the actual wizard frontend) only calls `/status`, `/steps/{step}/complete`, `/create-admin`, `/validate-directory`, `/test-api`, `/import/start`, and `/skip` — notably **not** `/upload-videos` or `/import/custom-directory/start`.

Blindly gating all 5 behind "wizard not completed" would have 403'd Settings > System's import feature on every real, post-setup deployment (every wizard is `COMPLETED` by then).

## The actual fix
- `validate_directory`, `test_api`: wizard-only, no other caller → new `require_wizard_incomplete` dependency (403 once `WizardStatus.COMPLETED`, matching `create_admin_user`'s existing precedent).
- `upload_videos`, `start_custom_directory_import`: Settings-only, never called pre-setup → standard `require_authentication`.
- `start_video_import` (`/import/start`): genuinely dual-purpose → new `require_wizard_incomplete_or_authenticated` dependency, which passes through untouched while the wizard is incomplete and otherwise requires a real authenticated session.

## Testing
Static AST source assertions for all 5 routes' wiring, plus real behavioral tests — both new dependency functions tested directly against an in-memory SQLite-backed `WizardState` table, plus `TestClient`-based 401-without-session tests for the two `require_authentication`-only routes. Verified RED before the fix, GREEN after — 14 tests pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)