### PR TITLE
fix(security): jobs.py's deprecated GET /{job_id} had no gating at all (#392 Phase 2 follow-up)

### DIFF
--- a/src/api/fastapi/jobs.py
+++ b/src/api/fastapi/jobs.py
@@ -4,9 +4,12 @@ Background jobs are now handled by Celery + Redis system.
 This module provides compatibility endpoints and redirects to the new system.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
 
+from src.api.fastapi.wizard import require_wizard_incomplete_or_authenticated
+from src.database.connection import get_db_session
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.fastapi.jobs")
@@ -63,12 +66,23 @@ async def create_job():
 
 
 @router.get("/{job_id}")
-async def get_job(job_id: str):
+async def get_job(
+    job_id: str,
+    session: Session = Depends(get_db_session),
+    _auth_or_wizard=Depends(require_wizard_incomplete_or_authenticated),
+):
     """
-    Get status of a Celery job (wizard-compatible, no auth required)
+    Get status of a Celery job (wizard-compatible pre-setup, authenticated
+    post-setup)
 
-    This endpoint queries Celery directly and is compatible with the wizard
-    which uses its own middleware for access control.
+    This endpoint queries Celery directly. It's genuinely dual-purpose:
+    wizard.js polls it pre-setup (no session exists yet), and
+    settings.html's "Settings > System" import feature polls the exact
+    same endpoint post-setup for jobs started via /api/wizard/import/start
+    -- the same split #405 fixed for that endpoint. Gated with the shared
+    require_wizard_incomplete_or_authenticated dependency: passes through
+    while the wizard is still incomplete, requires a real authenticated
+    session once it's completed.
     """
     # Handle expired/invalid job IDs
     if not job_id or job_id == "undefined":

--- a/tests/unit/test_jobs_deprecated_get_job_auth.py
+++ b/tests/unit/test_jobs_deprecated_get_job_auth.py
@@ -1,0 +1,123 @@
+"""Regression test for a gap in jobs.py's deprecated GET /{job_id}
+(get_job), found while reviewing #405's wizard.py fix. get_job() had no
+gating at all -- not even the wizard-completion awareness wizard.py's
+other dual-purpose endpoints got.
+
+Its own docstring says "wizard-compatible, no auth required", and
+wizard.js does poll it pre-setup (`fetch(`/api/jobs/${wizardState.
+importJobId}`)`) -- but grepping the frontend shows settings.html's
+"Settings > System" import feature ALSO polls this exact same endpoint
+post-setup (pollVideoImportProgress() -> fetch(`/api/jobs/${importJobId}`)),
+to track progress of jobs started by /api/wizard/import/start -- the
+identical dual-purpose situation #405 fixed for that endpoint. Without
+any gate, any unauthenticated caller could poll the status/progress/
+result of ANY Celery job_id in the system, indefinitely, post-setup.
+
+Fix: reuse wizard.py's require_wizard_incomplete_or_authenticated
+dependency (already covers exactly this pre-setup/post-setup split) --
+passes through untouched while the wizard is still incomplete, and
+requires a real authenticated session once it's completed.
+
+cancel_job (DELETE /{job_id}) and the other jobs.py endpoints are
+untouched here: cancel_job is a redirect-only 301 to
+/api/metadata-enrichment/job/{job_id}/cancel, which is already
+require_authentication-gated at the real destination; health/status/
+list_jobs/create_job return only static deprecation messages or generic
+migration info, no per-job or system data.
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.fastapi.jobs import router
+from src.database.connection import Base, get_db_session
+from src.database.models import WizardState, WizardStatus
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "jobs.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestGetJobUsesTheDualPurposeGate:
+    def test_get_job_wires_the_wizard_or_authenticated_dependency(self):
+        source = _function_source("get_job")
+        assert "Depends(" in source
+        assert "require_wizard_incomplete_or_authenticated" in source
+
+    def test_cancel_job_stays_untouched_pure_redirect(self):
+        # Regression guard: cancel_job must stay a bare redirect (its
+        # security already comes from the destination route), not
+        # accidentally pick up its own auth dependency that could break
+        # the redirect-only contract.
+        source = _function_source("cancel_job")
+        assert "RedirectResponse" in source
+        assert "Depends(" not in source
+
+
+@pytest.fixture
+def session_factory():
+    # TestClient runs the ASGI app in its own background thread.
+    # check_same_thread=False permits cross-thread use of the connection;
+    # StaticPool keeps it to the single connection actually holding the
+    # schema (SQLAlchemy's default SingletonThreadPool for sqlite:///:memory:
+    # hands the *other* thread a brand new, empty in-memory database
+    # instead of reusing this one).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[WizardState.__table__])
+    return sessionmaker(bind=engine)
+
+
+class TestGetJobBehavioralAuth:
+    def _client(self, session_factory):
+        app = FastAPI()
+        app.include_router(router)
+        # get_db_session is a generator dependency (yields a session);
+        # this override is a plain callable, so FastAPI injects
+        # whatever it *returns* directly rather than unwrapping a
+        # generator -- must return the session itself, not an iterator
+        # wrapping it, or session.query(...) fails on the wrapper object.
+        app.dependency_overrides[get_db_session] = lambda: session_factory()
+        return TestClient(app)
+
+    def test_401s_for_a_completed_wizard_with_no_session(self, session_factory):
+        session = session_factory()
+        session.add(WizardState(status=WizardStatus.COMPLETED))
+        session.commit()
+        session.close()
+
+        client = self._client(session_factory)
+        response = client.get("/api/jobs/some-job-id")
+        assert response.status_code == 401
+
+    def test_passes_through_while_wizard_is_incomplete(self, session_factory):
+        # No WizardState row seeded -- matches a fresh install where the
+        # wizard hasn't started yet.
+        client = self._client(session_factory)
+        response = client.get("/api/jobs/some-job-id")
+        # Reaches the route body (may itself fail against a fake/missing
+        # Celery backend, but must not be rejected by the auth gate).
+        assert response.status_code != 401


### PR DESCRIPTION
## Summary
Found while reviewing #405's `wizard.py` fix (PR #434). `get_job()` had no gating at all — not even the wizard-completion awareness `wizard.py`'s other dual-purpose endpoints got.

Its own docstring said "wizard-compatible, no auth required", and `wizard.js` does poll it pre-setup — but grepping the frontend shows `settings.html`'s "Settings > System" import feature ALSO polls this exact same endpoint post-setup (`pollVideoImportProgress()`), to track progress of jobs started by `/api/wizard/import/start` — the identical dual-purpose situation #405 just fixed for that endpoint. Without any gate, any unauthenticated caller could poll the status/progress/result of **any** Celery `job_id` in the system, indefinitely, post-setup.

## Fix
Reuse `wizard.py`'s `require_wizard_incomplete_or_authenticated` dependency instead of duplicating similar logic — passes through untouched while the wizard is still incomplete, requires a real authenticated session once it's completed.

`cancel_job` (`DELETE /{job_id}`) and the other `jobs.py` endpoints are untouched: `cancel_job` is a redirect-only 301 to `/api/metadata-enrichment/job/{job_id}/cancel`, already `require_authentication`-gated at the real destination; the rest return only static deprecation messages.

## Testing
Static AST source assertions plus real behavioral tests via FastAPI's `TestClient` against an in-memory SQLite-backed `WizardState` table. Two test-environment wrinkles surfaced and fixed along the way (documented in the commit message). Verified RED before the fix, GREEN after — 25 tests pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)