### PR TITLE
fix(ui): hide admin-only Spotify/Last.fm/System Health controls from non-admin users (#389)

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1247,6 +1247,21 @@
                 font-size: 1rem;
             }
         }
+
+        /* #389: admin-gated controls (Spotify/Last.fm connect/disconnect/
+           test buttons, System Health link) are marked with
+           admin-only-control across templates. A body class -- rather than
+           setting each element's inline style directly -- means this rule
+           wins regardless of DOM order against page-specific JS that also
+           toggles these same elements' visibility (e.g. lastfm.html's
+           checkLastFmStatus() flips #connectBtn/#disconnectBtn between
+           display:none and visible based on connection state; !important
+           here ensures a non-admin session stays hidden no matter which
+           runs last). See checkUserAuthentication() below for where the
+           class gets applied. */
+        body.non-admin-user .admin-only-control {
+            display: none !important;
+        }
     </style>
 
     {% block head %}{% endblock %}
@@ -1632,8 +1647,21 @@
                         if (headerUserSection) headerUserSection.style.display = 'flex';
                         if (headerUsername) headerUsername.textContent = data.user.username;
                         if (headerUserRole) headerUserRole.textContent = data.user.role;
-                    } else if (headerUserSection) {
-                        headerUserSection.style.display = 'none';
+                        // #389: hide admin-gated controls (Spotify/Last.fm
+                        // connect/disconnect/test buttons, System Health
+                        // link) for non-admin users, instead of letting
+                        // them click through to a 403. can_admin comes
+                        // from role_permissions() (src/api/fastapi/auth.py)
+                        // and is deliberately ADMIN-only, matching
+                        // auth_dependencies.require_admin's real backend
+                        // check exactly.
+                        document.body.classList.toggle('non-admin-user', !data.user.can_admin);
+                    } else {
+                        if (headerUserSection) headerUserSection.style.display = 'none';
+                        // No confirmed session -- fail closed and hide
+                        // admin-only controls too, matching an anonymous/
+                        // non-admin visitor rather than assuming admin.
+                        document.body.classList.add('non-admin-user');
                     }
                 })
                 .catch(error => {
@@ -1642,6 +1670,7 @@
                     if (headerUserSection) {
                         headerUserSection.style.display = 'none';
                     }
+                    document.body.classList.add('non-admin-user');
                 });
         }
         

--- a/frontend/templates/lastfm.html
+++ b/frontend/templates/lastfm.html
@@ -498,10 +498,10 @@
             <div id="lastfmStatus" class="status-indicator">
                 <span id="statusText">Checking...</span>
             </div>
-            <button id="connectBtn" onclick="connectToLastFm()" class="btn btn-primary" style="display: none;">
+            <button id="connectBtn" onclick="connectToLastFm()" class="btn btn-primary admin-only-control" style="display: none;">
                 Connect to Last.fm
             </button>
-            <button id="disconnectBtn" onclick="disconnectFromLastFm()" class="btn btn-danger" style="display: none;">
+            <button id="disconnectBtn" onclick="disconnectFromLastFm()" class="btn btn-danger admin-only-control" style="display: none;">
                 Disconnect
             </button>
         </div>
@@ -511,7 +511,7 @@
     <div id="authSection" class="auth-section" style="display: none;">
         <h3>Connect to Last.fm</h3>
         <p>To access your listening history and import your favorite artists, you need to connect your Last.fm account.</p>
-        <button onclick="authenticateWithLastFm()" class="btn btn-primary">
+        <button onclick="authenticateWithLastFm()" class="btn btn-primary admin-only-control">
             Authenticate with Last.fm
         </button>
     </div>

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -625,8 +625,8 @@ input:checked + .slider:before {
                 <input type="text" id="spotify_redirect_uri" name="spotify_redirect_uri" placeholder="http://localhost:5000/api/spotify/callback">
             </div>
             <div class="integration-actions">
-                <button onclick="testSpotifyIntegration()" class="btn btn-info">Test Connection</button>
-                <button onclick="authorizeSpotify()" class="btn btn-success">Authorize</button>
+                <button onclick="testSpotifyIntegration()" class="btn btn-info admin-only-control">Test Connection</button>
+                <button onclick="authorizeSpotify()" class="btn btn-success admin-only-control">Authorize</button>
                 <button onclick="importSpotifyPlaylists()" class="btn btn-secondary">Import Playlists</button>
                 <a href="/spotify" class="btn btn-primary">🎵 Spotify Manager</a>
             </div>
@@ -655,8 +655,8 @@ input:checked + .slider:before {
                 <div class="help-text">Enter your username manually or use the "Authorize" button for OAuth authentication</div>
             </div>
             <div class="integration-actions">
-                <button onclick="testLastfmIntegration()" class="btn btn-info">Test Connection</button>
-                <button onclick="authorizeLastfm()" class="btn btn-success">Authorize</button>
+                <button onclick="testLastfmIntegration()" class="btn btn-info admin-only-control">Test Connection</button>
+                <button onclick="authorizeLastfm()" class="btn btn-success admin-only-control">Authorize</button>
                 <button onclick="syncLastfmHistory()" class="btn btn-secondary">Sync Listening History</button>
                 <a href="/lastfm" class="btn btn-primary">🎵 Last.fm Manager</a>
             </div>
@@ -1622,8 +1622,9 @@ input:checked + .slider:before {
             <p class="section-description">Monitor system health, perform maintenance tasks, and view collection analytics</p>
             <div class="system-tools-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 1rem;">
 
-                <!-- System Health Tool -->
-                <div class="tool-card" style="background: var(--bg-tertiary, #333); border: 1px solid var(--border-secondary, #444); border-radius: 8px; padding: 1.5rem;">
+                <!-- System Health Tool (admin-only: /system-health and all
+                     of its backing API routes require require_admin) -->
+                <div class="tool-card admin-only-control" style="background: var(--bg-tertiary, #333); border: 1px solid var(--border-secondary, #444); border-radius: 8px; padding: 1.5rem;">
                     <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
                         <iconify-icon icon="tabler:heartbeat" style="font-size: 2rem; color: var(--text-accent, #00d4ff);"></iconify-icon>
                         <h3 style="margin: 0; font-size: 1.1rem;">System Health</h3>

--- a/frontend/templates/spotify.html
+++ b/frontend/templates/spotify.html
@@ -17,9 +17,9 @@
                 </div>
             </div>
             <div class="integration-actions">
-                <button onclick="testConnection()" class="btn btn-info">Test Connection</button>
-                <button onclick="authorize()" class="btn btn-success">Authorize Spotify</button>
-                <button onclick="disconnect()" class="btn btn-danger">Disconnect</button>
+                <button onclick="testConnection()" class="btn btn-info admin-only-control">Test Connection</button>
+                <button onclick="authorize()" class="btn btn-success admin-only-control">Authorize Spotify</button>
+                <button onclick="disconnect()" class="btn btn-danger admin-only-control">Disconnect</button>
             </div>
         </div>
 

--- a/tests/unit/test_admin_only_ui_controls.py
+++ b/tests/unit/test_admin_only_ui_controls.py
@@ -1,0 +1,175 @@
+"""Fix for #389: non-admin users got no graceful UI degradation on
+admin-gated Spotify/Last.fm/system-health buttons. Buttons like "Connect
+Spotify," "Disconnect," "Test Connection," and the System Health link were
+visible to any authenticated user, but clicking them hit a require_admin
+API endpoint and 403'd -- confusingly, since the frontend's global 401
+interceptor doesn't handle 403.
+
+Fix (frontend-hiding, per the issue's own recommendation): every control
+that maps to a require_admin-gated endpoint gets a shared
+admin-only-control class. base.html defines
+`body.non-admin-user .admin-only-control { display: none !important; }`
+and checkUserAuthentication() toggles the non-admin-user body class from
+data.user.can_admin (role_permissions()'s pre-computed, deliberately
+ADMIN-only flag -- see src/api/fastapi/auth.py -- which already matches
+auth_dependencies.require_admin's real backend check exactly, so the
+frontend doesn't duplicate that role-comparison logic itself). The
+!important body-class rule (rather than setting each element's inline
+style once) matters for lastfm.html specifically: its
+checkLastFmStatus() independently flips #connectBtn/#disconnectBtn
+between display:none and visible based on connection state, and the CSS
+rule must win regardless of which runs last.
+
+Static-content-assertion approach, matching the pattern already
+established for this app's other template regression tests (e.g.
+test_recently_found_videos_ui.py, test_oauth_settings_ui.py).
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestBaseHtmlAdminOnlyMechanism:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "base.html").read_text()
+
+    def test_css_rule_hides_admin_only_controls_for_non_admin_body_class(self):
+        assert "body.non-admin-user .admin-only-control" in self.html
+        start = self.html.index("body.non-admin-user .admin-only-control")
+        end = self.html.index("}", start)
+        rule = self.html[start:end]
+        assert "display: none !important" in rule
+
+    def test_check_user_authentication_toggles_the_body_class_from_can_admin(self):
+        start = self.html.index("function checkUserAuthentication()")
+        end = self.html.index("\n        }", start)
+        body = self.html[start:end]
+        assert "data.user.can_admin" in body
+        assert "non-admin-user" in body
+
+    def test_fails_closed_when_auth_check_itself_errors(self):
+        # A network error or non-2xx response resolving checkUserAuthentication
+        # must not leave admin-only controls visible by default.
+        start = self.html.index("function checkUserAuthentication()")
+        end = self.html.index("\n        }\n        \n", start)
+        body = self.html[start:end]
+        assert body.count("non-admin-user") >= 3  # success, failure, catch branches
+
+
+class TestSettingsHtmlAdminOnlyControls:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_spotify_test_connection_is_admin_only(self):
+        assert (
+            'onclick="testSpotifyIntegration()" class="btn btn-info admin-only-control"'
+            in self.html
+        )
+
+    def test_spotify_authorize_is_admin_only(self):
+        assert (
+            'onclick="authorizeSpotify()" class="btn btn-success admin-only-control"'
+            in self.html
+        )
+
+    def test_spotify_import_playlists_is_not_admin_only(self):
+        # /api/spotify/import-playlists is require_authentication, not
+        # require_admin -- must stay usable by any logged-in user.
+        assert (
+            'onclick="importSpotifyPlaylists()" class="btn btn-secondary">' in self.html
+        )
+        assert (
+            'onclick="importSpotifyPlaylists()" class="btn btn-secondary admin-only-control"'
+            not in self.html
+        )
+
+    def test_lastfm_test_connection_is_admin_only(self):
+        assert (
+            'onclick="testLastfmIntegration()" class="btn btn-info admin-only-control"'
+            in self.html
+        )
+
+    def test_lastfm_authorize_is_admin_only(self):
+        assert (
+            'onclick="authorizeLastfm()" class="btn btn-success admin-only-control"'
+            in self.html
+        )
+
+    def test_lastfm_sync_history_is_not_admin_only(self):
+        # /api/lastfm/sync-history is require_authentication, not
+        # require_admin -- must stay usable by any logged-in user.
+        assert 'onclick="syncLastfmHistory()" class="btn btn-secondary">' in self.html
+        assert (
+            'onclick="syncLastfmHistory()" class="btn btn-secondary admin-only-control"'
+            not in self.html
+        )
+
+    def test_system_health_tool_card_is_admin_only(self):
+        # /system-health and every one of its backing API routes require
+        # require_admin -- the whole card is gated, not just the link.
+        start = self.html.index("System Health Tool")
+        end = self.html.index("</div>", start)
+        card_open_tag = self.html[start:end]
+        assert 'class="tool-card admin-only-control"' in card_open_tag
+
+
+class TestSpotifyHtmlAdminOnlyControls:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "spotify.html").read_text()
+
+    def test_test_connection_is_admin_only(self):
+        assert (
+            'onclick="testConnection()" class="btn btn-info admin-only-control"'
+            in self.html
+        )
+
+    def test_authorize_is_admin_only(self):
+        assert (
+            'onclick="authorize()" class="btn btn-success admin-only-control"'
+            in self.html
+        )
+
+    def test_disconnect_is_admin_only(self):
+        assert (
+            'onclick="disconnect()" class="btn btn-danger admin-only-control"'
+            in self.html
+        )
+
+    def test_load_playlists_is_not_admin_only(self):
+        # /api/spotify/playlists is require_authentication, not
+        # require_admin.
+        assert 'onclick="loadPlaylists()" class="btn btn-primary">' in self.html
+
+
+class TestLastfmHtmlAdminOnlyControls:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "lastfm.html").read_text()
+
+    def test_connect_button_is_admin_only(self):
+        assert 'id="connectBtn"' in self.html
+        start = self.html.index('id="connectBtn"')
+        end = self.html.index(">", start)
+        tag = self.html[start:end]
+        assert "admin-only-control" in tag
+
+    def test_disconnect_button_is_admin_only(self):
+        assert 'id="disconnectBtn"' in self.html
+        start = self.html.index('id="disconnectBtn"')
+        end = self.html.index(">", start)
+        tag = self.html[start:end]
+        assert "admin-only-control" in tag
+
+    def test_authenticate_button_is_admin_only(self):
+        assert (
+            'onclick="authenticateWithLastFm()" class="btn btn-primary admin-only-control"'
+            in self.html
+        )
+
+    def test_refresh_top_artists_is_not_admin_only(self):
+        # Refresh/import buttons hit require_authentication endpoints,
+        # not require_admin.
+        assert (
+            'onclick="refreshTopArtists()" class="btn btn-sm btn-secondary">'
+            in self.html
+        )


### PR DESCRIPTION
## Summary
Phase 1's route-auth sweep added `require_admin` to several Spotify/Last.fm integration-management endpoints and all of `system_health.py`'s API routes. The pages surfacing these controls (`/settings`, `/spotify`, `/lastfm`) are only gated at `require_authentication` (any logged-in user), so buttons like "Connect Spotify," "Disconnect," "Test Connection," and the System Health link were visible to non-admin authenticated users — clicking them hit an admin-only endpoint and 403'd, which the frontend's global interceptor doesn't handle specially (only 401 is caught).

## Fix
Frontend-hiding, per the issue's own recommendation. Every control that maps to a `require_admin`-gated endpoint gets a shared `admin-only-control` class:
- `settings.html`: Spotify's Test Connection/Authorize buttons, Last.fm's Test Connection/Authorize buttons, the whole System Health tool-card. `Import Playlists` and `Sync Listening History` stay untouched — both hit `require_authentication` endpoints, not `require_admin`.
- `spotify.html`: Test Connection, Authorize Spotify, Disconnect.
- `lastfm.html`: `#connectBtn`, `#disconnectBtn`, the "Authenticate with Last.fm" button.

`base.html` defines `body.non-admin-user .admin-only-control { display: none !important; }` and `checkUserAuthentication()` toggles the `non-admin-user` body class from `data.user.can_admin` — `role_permissions()`'s pre-computed, deliberately ADMIN-only flag, which already matches `auth_dependencies.require_admin`'s real backend check exactly. Fails closed on a missing/failed auth check too.

The `!important` body-class approach matters specifically for `lastfm.html`: its `checkLastFmStatus()` independently flips `#connectBtn`/`#disconnectBtn` visibility based on connection state, and the CSS rule must win regardless of which runs last.

## Testing
Static-content-assertion tests reading the raw template files, matching the pattern already established for this app's other template regression tests. Verified RED by stashing the template changes and re-running, restored and GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)