### PR TITLE
fix(ui): spotify_callback's OAuth-error redirect UX was bypassed by require_admin (#391)

### DIFF
--- a/src/api/fastapi/spotify.py
+++ b/src/api/fastapi/spotify.py
@@ -8,7 +8,12 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from src.api.fastapi.auth_dependencies import require_admin, require_authentication
+from src.api.fastapi.auth_dependencies import (
+    get_optional_user,
+    require_admin,
+    require_authentication,
+)
+from src.database.models import UserRole
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.api.spotify")
@@ -589,12 +594,35 @@ async def spotify_callback(
     request: Request,
     code: Optional[str] = Query(None, description="Authorization code from Spotify"),
     error: Optional[str] = Query(None, description="Error from Spotify OAuth"),
-    current_user: dict = Depends(require_admin),
+    current_user: Optional[dict] = Depends(get_optional_user),
 ):
     """Handle Spotify OAuth callback"""
-    try:
-        from fastapi.responses import RedirectResponse
+    from fastapi.responses import RedirectResponse
 
+    # #391: require_admin, as a Depends(), would otherwise raise during
+    # FastAPI's dependency-resolution phase -- BEFORE this function body
+    # (and its own try/except below) ever runs -- bypassing every one of
+    # this callback's friendly redirect-based error responses in favor
+    # of a raw JSON 401/403. That's a real regression right as the
+    # browser lands back on this app fresh off Spotify's own redirect
+    # (e.g. the admin's session expiring while they were on Spotify's
+    # consent screen). get_optional_user never raises -- it returns None
+    # instead -- so the exact same authenticated+ADMIN check
+    # require_admin performs is replicated here, inline, where a failure
+    # can produce the same RedirectResponse as any other failure mode in
+    # this OAuth flow instead of a bare exception.
+    if (
+        not current_user
+        or not current_user.get("authenticated")
+        or current_user.get("role") != UserRole.ADMIN.value
+    ):
+        logger.warning("Spotify callback rejected: admin session required or expired")
+        return RedirectResponse(
+            url="/settings?spotify_error=Admin session required or expired. Please log in as an admin and try again.",
+            status_code=302,
+        )
+
+    try:
         if error:
             logger.error(f"Spotify OAuth error: {error}")
             return RedirectResponse(

--- a/tests/unit/test_spotify_auth.py
+++ b/tests/unit/test_spotify_auth.py
@@ -7,6 +7,15 @@ shared instance-wide Spotify OAuth link use require_admin (mirroring
 auth.py's POST /credentials, hardened after a real dev-testing finding
 that any authenticated non-admin session could change instance-wide
 credentials); read-only routes use require_authentication.
+
+spotify_callback is deliberately excluded from EXPECTED_TIER below: #391
+found that Depends(require_admin) there bypassed the route's own
+friendly redirect-based OAuth-error UX (Depends() failures raise before
+the route body's try/except can see them). It still enforces the exact
+same authenticated+ADMIN check -- just replicated inline via
+Depends(get_optional_user) instead, so a failure can produce the same
+RedirectResponse as every other failure mode in that function. See
+test_spotify_callback_redirect_on_auth_failure.py for its real coverage.
 """
 
 import ast
@@ -37,7 +46,6 @@ EXPECTED_TIER = {
     "get_spotify_status": "auth",
     "test_spotify_integration": "admin",
     "authorize_spotify": "admin",
-    "spotify_callback": "admin",
     "disconnect_spotify": "admin",
     "import_playlist": "auth",
     "import_all_playlists": "auth",

--- a/tests/unit/test_spotify_callback_redirect_on_auth_failure.py
+++ b/tests/unit/test_spotify_callback_redirect_on_auth_failure.py
@@ -1,0 +1,150 @@
+"""Fix for #391: spotify_callback's custom OAuth-error redirect UX was
+bypassed by require_admin.
+
+spotify_callback()'s own body has careful error handling that redirects
+the browser to /settings?spotify_error=... on an OAuth failure (declined
+consent, Spotify returned an error param, token exchange failed, etc).
+But require_admin runs as a FastAPI Depends() BEFORE the route body
+executes -- Depends() failures raise during FastAPI's dependency-
+resolution phase, which the route's own try/except can never see. An
+admin-session check failure (e.g. the admin's session expired during the
+OAuth consent flow on Spotify's own site) short-circuited straight to a
+raw JSON 401/403, bypassing the friendlier redirect-based error UX
+entirely -- right as the browser lands back on this app fresh off
+Spotify's redirect.
+
+Fix: replace Depends(require_admin) with Depends(get_optional_user) (which
+never raises -- returns None instead of a session dict) and replicate
+require_admin's exact check (authenticated AND role == ADMIN) inline, as
+the first thing the route body does, so a failure there gets caught by
+the same RedirectResponse pattern as every other failure mode in this
+function. Security semantics are unchanged -- same authenticated+ADMIN
+check, just relocated so it can produce the friendly response instead of
+a bare exception.
+
+lastfm.py's handle_callback -- which #391 named as sharing "the same
+shape" -- turns out not to: unlike spotify_callback, it has NO existing
+redirect-based UX to preserve. Every branch (success and failure alike)
+already returns a plain dict or raises HTTPException; there's no
+RedirectResponse anywhere in that function for require_admin to bypass.
+Applying "the same fix" there would introduce new, inconsistent
+behavior (a redirect on exactly one failure mode, JSON on every other),
+not restore anything that used to work. Left untouched -- a genuine UX
+improvement for that endpoint (matching spotify_callback's more complete
+redirect-based flow) is a separate, larger change than what #391 asked
+for.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import RedirectResponse
+
+from src.api.fastapi.spotify import spotify_callback
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "spotify.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestSpotifyCallbackNoLongerUsesRequireAdmin:
+    def test_does_not_use_depends_require_admin(self):
+        source = _function_source("spotify_callback")
+        assert "Depends(require_admin)" not in source
+
+    def test_uses_get_optional_user_instead(self):
+        source = _function_source("spotify_callback")
+        assert "Depends(get_optional_user)" in source
+
+    def test_replicates_the_authenticated_and_admin_role_check_inline(self):
+        source = _function_source("spotify_callback")
+        assert "UserRole.ADMIN.value" in source
+
+
+class TestSpotifyCallbackBehavioralAuthFailure:
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    # NOTE: these pass a code= value (unlike the "no session" case a real
+    # unauthenticated request would have) specifically so that, against
+    # the OLD implementation, calling this function directly (bypassing
+    # FastAPI's real Depends() resolution, which direct calls always do)
+    # would fall through past the "no code" branch and into the token-
+    # exchange logic instead of coincidentally producing a same-shaped
+    # redirect for an unrelated reason. Only the NEW inline auth check
+    # can catch these before that point.
+
+    def test_redirects_to_settings_when_no_session_exists(self):
+        result = self._run(
+            spotify_callback(
+                request=None,
+                code="fake-auth-code",
+                error=None,
+                current_user=None,
+            )
+        )
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert "admin" in result.headers["location"].lower()
+
+    def test_redirects_to_settings_when_session_is_not_admin(self):
+        result = self._run(
+            spotify_callback(
+                request=None,
+                code="fake-auth-code",
+                error=None,
+                current_user={"authenticated": True, "role": "USER", "user_id": 2},
+            )
+        )
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert "admin" in result.headers["location"].lower()
+
+    def test_redirects_to_settings_when_session_is_unauthenticated_flag(self):
+        # A session that resolves but was somehow left un-flagged as
+        # authenticated (mirrors require_admin's own "not
+        # current_user.get('authenticated')" branch) must still be
+        # rejected, not silently admitted.
+        result = self._run(
+            spotify_callback(
+                request=None,
+                code="fake-auth-code",
+                error=None,
+                current_user={"authenticated": False, "role": "ADMIN", "user_id": 1},
+            )
+        )
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert "admin" in result.headers["location"].lower()
+
+    def test_does_not_redirect_early_for_a_genuine_admin_session(self):
+        # A real admin session must reach the function's own OAuth-error
+        # handling (error param present here), not get bounced by the
+        # auth check itself.
+        result = self._run(
+            spotify_callback(
+                request=None,
+                code=None,
+                error="access_denied",
+                current_user={"authenticated": True, "role": "ADMIN", "user_id": 1},
+            )
+        )
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert "spotify_error=access_denied" in result.headers["location"]


### PR DESCRIPTION
## Summary
`spotify_callback()`'s own body has careful error handling that redirects the browser to `/settings?spotify_error=...` on an OAuth failure. But `require_admin` runs as a FastAPI `Depends()` **before** the route body executes — `Depends()` failures raise during FastAPI's dependency-resolution phase, which the route's own `try/except` can never see. An admin-session check failure (e.g. the admin's session expired during the OAuth consent flow on Spotify's own site) short-circuited straight to a raw JSON 401/403, bypassing the friendlier redirect-based error UX entirely — right as the browser lands back on this app fresh off Spotify's own redirect.

## Fix
Replace `Depends(require_admin)` with `Depends(get_optional_user)` (never raises — returns `None` instead) and replicate `require_admin`'s exact check (authenticated AND role == ADMIN) inline, as the first thing the route body does, so a failure gets caught by the same `RedirectResponse` pattern as every other failure mode in this function. Security semantics are unchanged — same check, just relocated so it can produce the friendly response instead of a bare exception.

## Scope note: lastfm.py's handle_callback is deliberately NOT touched
#391 named `lastfm.py`'s `handle_callback` as sharing "the same shape" — it doesn't. Unlike `spotify_callback`, it has **no existing redirect-based UX to preserve**: every branch (success and failure alike) already returns a plain dict or raises `HTTPException`. Applying "the same fix" there would introduce new, inconsistent behavior (a redirect on exactly one failure mode, JSON on every other), not restore anything that used to work. A genuine UX improvement there (matching `spotify_callback`'s more complete flow) is a separate, larger change than what #391 asked for.

## Testing
Static AST source assertions plus real behavioral tests calling the function directly with various `current_user` shapes. Also updated `test_spotify_auth.py`'s `EXPECTED_TIER` mapping, which otherwise would have failed on this deliberate architectural change. Verified RED before the fix, GREEN after — 12 tests pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)