### PR TITLE
fix(security): route-auth gaps in fastapi_app.py and websocket_jobs.py, found via systematic #392 re-audit

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.logging_middleware import setup_logging_middleware
 from src.api.fastapi.wizard_middleware import setup_wizard_middleware
 
@@ -725,7 +726,9 @@ async def health_check():
 
 
 @app.get("/api/discover")
-async def discover_search(q: str = Query(...)):
+async def discover_search(
+    q: str = Query(...), current_user: dict = Depends(require_authentication)
+):
     """Universal search endpoint for videos, artists, and external sources (IMVDb, YouTube)"""
     try:
         from sqlalchemy.orm import Session
@@ -1163,7 +1166,9 @@ async def retry_download(download_id: str):
 
 
 @app.delete("/api/metube/download/{download_id}")
-async def delete_download(download_id: int):
+async def delete_download(
+    download_id: int, current_user: dict = Depends(require_authentication)
+):
     """Delete a queued download"""
     try:
         from sqlalchemy.orm import Session
@@ -1278,7 +1283,9 @@ async def search_imvdb_videos(q: str = Query(...)):
 
 
 @app.post("/api/metube/process-queue")
-async def process_queued_downloads():
+async def process_queued_downloads(
+    current_user: dict = Depends(require_authentication),
+):
     """Process all queued downloads by submitting them to the job queue"""
     try:
         from sqlalchemy.orm import Session

--- a/src/api/fastapi/websocket_jobs.py
+++ b/src/api/fastapi/websocket_jobs.py
@@ -9,12 +9,11 @@ import json
 from datetime import datetime
 from typing import Any, Dict, Optional, Set
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 
+from src.api.fastapi.auth_dependencies import require_authentication
 from src.jobs.redis_manager import redis_manager
-
-# Authentication dependency removed for now - WebSocket auth handled separately
 from src.utils.logger import get_logger
 
 logger = get_logger("mvidarr.websocket.jobs")
@@ -305,42 +304,99 @@ async def get_websocket_manager():
     return websocket_manager
 
 
+async def _get_websocket_authenticated_user(
+    websocket: WebSocket,
+) -> Optional[Dict[str, Any]]:
+    """Resolve the authenticated user for a WebSocket connection.
+
+    Mirrors auth_dependencies.get_current_user_session() +
+    require_authentication(), which can't be reused directly here:
+    get_current_user_session() is typed to Request, and FastAPI's
+    WebSocket routes inject a WebSocket-typed scope, not Request, so a
+    Depends() chain built on that type won't resolve in a websocket
+    route (same constraint documented in monitoring_dashboard.py's own
+    _get_websocket_admin_user, which this mirrors). WebSocket, like
+    Request, inherits .cookies from Starlette's HTTPConnection, so the
+    same session_token lookup and SessionStore.validate_session() call
+    work unchanged.
+
+    Any authenticated role passes (unlike monitoring_dashboard.py's
+    admin-only gate) -- job/download progress is regular library
+    content, not host-system metrics.
+    """
+    try:
+        session_token = websocket.cookies.get("session_token")
+        if not session_token:
+            return None
+        from src.services.session_store import SessionStore
+
+        user_data = SessionStore.validate_session(session_token)
+        if user_data and user_data.get("authenticated"):
+            return user_data
+        return None
+    except Exception as e:
+        logger.error(f"Error resolving WebSocket session: {e}")
+        return None
+
+
+async def websocket_job_progress(websocket: WebSocket):
+    """WebSocket endpoint for real-time job progress updates.
+
+    Previously accepted every connection unauthenticated ("Authentication
+    simplified for now") -- once connected, the server's Redis subscriber
+    broadcasts real-time progress for every Celery job in the system to
+    every connected client with no further gating, so this was a
+    complete, unauthenticated exposure of live download/job activity.
+    Found via a systematic re-audit of #392's actual current status.
+    """
+    user = await _get_websocket_authenticated_user(websocket)
+    if not user:
+        await websocket.close(code=1008)
+        return
+
+    user_id = user.get("user_id")
+
+    try:
+        await websocket_manager.connect_user(websocket, user_id)
+
+        # Start Redis subscriber if not already running (fallback)
+        # Note: This should normally be started during app startup now
+        if not websocket_manager.subscription_task:
+            logger.info(
+                "🔄 Starting Redis subscriber as fallback (should have started at app startup)"
+            )
+            await websocket_manager.start_redis_subscriber()
+
+        while True:
+            # Listen for client messages
+            try:
+                data = await websocket.receive_json()
+                await handle_websocket_message(websocket, data, user_id)
+            except WebSocketDisconnect:
+                break
+
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+    finally:
+        await websocket_manager.disconnect_user(websocket)
+
+
+async def websocket_test_page(
+    current_user: dict = Depends(require_authentication),
+):
+    """Test page for WebSocket job progress"""
+    return get_websocket_test_page()
+
+
 def setup_websocket_routes(app: FastAPI):
     """Setup WebSocket routes for job progress"""
-
-    @app.websocket("/ws/jobs")
-    async def websocket_job_progress(websocket: WebSocket):
-        """WebSocket endpoint for real-time job progress updates"""
-        user_id = None  # Authentication simplified for now
-
-        try:
-            await websocket_manager.connect_user(websocket, user_id)
-
-            # Start Redis subscriber if not already running (fallback)
-            # Note: This should normally be started during app startup now
-            if not websocket_manager.subscription_task:
-                logger.info(
-                    "🔄 Starting Redis subscriber as fallback (should have started at app startup)"
-                )
-                await websocket_manager.start_redis_subscriber()
-
-            while True:
-                # Listen for client messages
-                try:
-                    data = await websocket.receive_json()
-                    await handle_websocket_message(websocket, data, user_id)
-                except WebSocketDisconnect:
-                    break
-
-        except Exception as e:
-            logger.error(f"WebSocket error: {e}")
-        finally:
-            await websocket_manager.disconnect_user(websocket)
-
-    @app.get("/ws/jobs/test", response_class=HTMLResponse)
-    async def websocket_test_page():
-        """Test page for WebSocket job progress"""
-        return get_websocket_test_page()
+    app.add_api_websocket_route("/ws/jobs", websocket_job_progress)
+    app.add_api_route(
+        "/ws/jobs/test",
+        websocket_test_page,
+        methods=["GET"],
+        response_class=HTMLResponse,
+    )
 
 
 async def handle_websocket_message(

--- a/tests/unit/test_fastapi_app_route_gaps.py
+++ b/tests/unit/test_fastapi_app_route_gaps.py
@@ -1,0 +1,77 @@
+"""Regression test for a class of route-auth gap that #392's entire file-
+by-file sweep this session structurally could not find: routes defined
+directly in fastapi_app.py itself via @app.get/@app.post/@app.delete,
+rather than in any router module under src/api/fastapi/. Found during a
+systematic audit of #392's actual current status (tracing every route
+FastAPI would really dispatch to, starting from fastapi_app.py's own
+app.include_router()/@app.<method> calls, not just grepping router
+files in isolation).
+
+Two of these duplicate paths already defined in an authenticated router
+module mounted earlier in the file (metube.py's /queue, /history,
+/clear-stuck, /download/{id}/retry, /history/clear; imvdb.py's
+/search-videos) -- FastAPI's first-registered-route-wins matching means
+those specific fastapi_app.py duplicates are dead code, live-confirmed
+via curl (401, not the stub/mock content). Left untouched here --
+removing genuinely dead code is a separate cleanup task, not a security
+fix.
+
+Three routes were NOT shadowed and are live, unauthenticated, and touch
+real data or state:
+- GET /api/discover: runs real Artist/Video DB queries, unauthenticated
+  (no colliding route exists anywhere else).
+- POST /api/metube/process-queue: state-changing (submits all queued
+  downloads to the job queue), unauthenticated -- metube.py only has a
+  same-purpose /process-pending, a different path, so no shadowing.
+- DELETE /api/metube/download/{download_id}: destructive (deletes a
+  queued download), unauthenticated -- metube.py has no plain DELETE
+  /download/{id} route (only /download/{id}/stop, POST), so no
+  shadowing.
+
+fastapi_app.py can't be imported directly in this test venv (importing
+it pulls in all 65+ mounted routers transitively, one of which imports
+netifaces -- a C extension with no build toolchain here, the same
+constraint hit earlier for mobile_access.py -- and likely others further
+down the same import chain). Static source-assertion test instead;
+behavioral correctness verified live against the deployed mvidarr-dev
+container via curl (documented in the fix's commit message).
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE_PATH = Path(__file__).resolve().parents[2] / "fastapi_app.py"
+
+NEWLY_GATED_ROUTES = {
+    "discover_search",
+    "process_queued_downloads",
+    "delete_download",
+}
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestFastapiAppDirectlyDefinedRoutesRequireAuth:
+    def test_every_newly_gated_route_requires_authentication(self):
+        for function_name in NEWLY_GATED_ROUTES:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_authentication)" in source
+            ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
+
+    def test_module_imports_require_authentication(self):
+        text = SOURCE_PATH.read_text()
+        assert (
+            "from src.api.fastapi.auth_dependencies import" in text
+            and "require_authentication" in text
+        )

--- a/tests/unit/test_websocket_jobs_auth.py
+++ b/tests/unit/test_websocket_jobs_auth.py
@@ -1,0 +1,127 @@
+"""Fix for a live, unauthenticated WebSocket found during a systematic
+re-audit of #392's actual current status: websocket_jobs.py's /ws/jobs
+endpoint accepted every connection unauthenticated ("Authentication
+simplified for now"). Once connected, the server's Redis subscriber
+broadcasts real-time progress for every Celery job in the system to every
+connected client with no further gating -- a complete, unauthenticated
+exposure of live download/job activity, the same class of bug already
+fixed for monitoring_dashboard.py's /ws in #392 Phase 2 follow-up (PR
+#419).
+
+/ws/jobs/test (a debug HTML page for the above) had the same gap.
+
+Fix: extract the connection handler and test page out of
+setup_websocket_routes()'s closures into module-level functions (needed
+for direct testability -- mirrors monitoring_dashboard.py's own
+websocket_endpoint refactor), gate /ws/jobs with a new
+_get_websocket_authenticated_user() helper (mirrors
+monitoring_dashboard.py's _get_websocket_admin_user, but accepts any
+authenticated role -- job/download progress is regular library content,
+not host-system metrics, so no admin split needed), and gate
+/ws/jobs/test with the standard Depends(require_authentication).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from src.api.fastapi.websocket_jobs import (
+    _get_websocket_authenticated_user,
+    setup_websocket_routes,
+    websocket_job_progress,
+)
+
+
+def _client():
+    app = FastAPI()
+    setup_websocket_routes(app)
+    return TestClient(app)
+
+
+class TestWebSocketJobsRejectsUnauthorizedConnections:
+    """End-to-end via TestClient.websocket_connect -- only checks
+    WebSocketDisconnect is raised, not the exact close code (a pre-accept
+    rejection has no completed handshake yet, so ASGI servers -- and
+    Starlette's TestClient -- can't transmit a real close *frame* carrying
+    a custom code; see TestWebsocketJobProgressClosesWithPolicyViolation
+    below for the precise code assertion)."""
+
+    def test_connection_with_no_session_cookie_is_rejected(self):
+        client = _client()
+        with patch(
+            "src.services.session_store.SessionStore.validate_session",
+            return_value=None,
+        ):
+            with pytest.raises(WebSocketDisconnect):
+                with client.websocket_connect("/ws/jobs"):
+                    pass
+
+    def test_connection_with_an_unauthenticated_flag_is_rejected(self):
+        client = _client()
+        with patch(
+            "src.services.session_store.SessionStore.validate_session",
+            return_value={"authenticated": False, "user_id": 1},
+        ):
+            with pytest.raises(WebSocketDisconnect):
+                with client.websocket_connect(
+                    "/ws/jobs", cookies={"session_token": "fake-token"}
+                ):
+                    pass
+
+
+class TestWebsocketJobProgressClosesWithPolicyViolation:
+    def test_closes_with_code_1008_and_never_connects_when_unauthorized(self):
+        ws = MagicMock()
+        ws.cookies = {}
+        ws.close = AsyncMock()
+
+        with patch(
+            "src.api.fastapi.websocket_jobs.websocket_manager.connect_user",
+            new_callable=AsyncMock,
+        ) as mock_connect:
+            asyncio.run(websocket_job_progress(ws))
+
+        ws.close.assert_awaited_once_with(code=1008)
+        mock_connect.assert_not_awaited()
+
+
+class TestGetWebsocketAuthenticatedUser:
+    def _fake_websocket(self, cookies):
+        ws = MagicMock()
+        ws.cookies = cookies
+        return ws
+
+    def test_returns_the_user_dict_for_any_valid_authenticated_role(self):
+        ws = self._fake_websocket({"session_token": "fake-user-token"})
+        user = {"authenticated": True, "role": "USER", "user_id": 5}
+        with patch(
+            "src.services.session_store.SessionStore.validate_session",
+            return_value=user,
+        ):
+            result = asyncio.run(_get_websocket_authenticated_user(ws))
+        assert result == user
+
+    def test_returns_none_with_no_cookie_at_all(self):
+        ws = self._fake_websocket({})
+        result = asyncio.run(_get_websocket_authenticated_user(ws))
+        assert result is None
+
+    def test_returns_none_when_validate_session_finds_nothing(self):
+        ws = self._fake_websocket({"session_token": "expired-or-bogus-token"})
+        with patch(
+            "src.services.session_store.SessionStore.validate_session",
+            return_value=None,
+        ):
+            result = asyncio.run(_get_websocket_authenticated_user(ws))
+        assert result is None
+
+
+class TestWebsocketTestPageRequiresAuth:
+    def test_401s_without_session(self):
+        client = _client()
+        response = client.get("/ws/jobs/test")
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary
Every file-by-file sweep this session (and the ones before it) checked router modules under `src/api/fastapi/` individually. That structurally could not catch two classes of live route this app also serves: routes defined directly in `fastapi_app.py` itself, and the WebSocket routes `websocket_jobs.py` registers onto the app instance outside any router's `include_router()` call. Found by tracing the actual FastAPI dispatch graph forward from `fastapi_app.py`'s own mount calls, rather than grepping router files in isolation.

## fastapi_app.py
Most of its 17 directly-defined routes turned out to be dead code, shadowed by an already-authenticated route with the same path registered earlier (FastAPI's first-registered-route-wins matching) — confirmed live via curl against `mvidarr-dev`. Three were **not** shadowed and are live, unauthenticated, and touch real data or state:
- `GET /api/discover`: real Artist/Video DB queries, unauthenticated.
- `POST /api/metube/process-queue`: state-changing, unauthenticated.
- `DELETE /api/metube/download/{download_id}`: destructive, unauthenticated.

All three now `require_authentication`.

## websocket_jobs.py
`/ws/jobs` accepted every connection unauthenticated ("Authentication simplified for now"). Once connected, the server's Redis subscriber broadcasts real-time progress for every Celery job in the system to every connected client — the same class of bug already fixed for `monitoring_dashboard.py`'s `/ws` (PR #419). `/ws/jobs/test` (a debug HTML page) had the same gap. Both fixed, mirroring `monitoring_dashboard.py`'s WebSocket auth pattern (any authenticated role, not admin-only — job progress is regular library content).

## Testing
`fastapi_app.py` can't be imported directly in this test venv (netifaces, same constraint as `mobile_access.py`) — static AST source-assertion test, with real behavior verified live via curl. `websocket_jobs.py` imports cleanly, so it gets full behavioral coverage. Verified RED before the fix, GREEN after — 17 tests pass together with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)