### PR TITLE
fix(security): MANAGER role could self-promote to ADMIN via role-change endpoint (#324)

### DIFF
--- a/src/api/fastapi/admin.py
+++ b/src/api/fastapi/admin.py
@@ -73,6 +73,30 @@ async def require_admin_access(
     return current_user
 
 
+async def require_admin_only_access(
+    current_user: UserInfo = Depends(get_current_user),
+) -> UserInfo:
+    """Stricter than require_admin_access -- ADMIN only, no MANAGER.
+
+    #324: require_admin_access's can_access_admin() check (ADMIN +
+    MANAGER) let a MANAGER session call PUT /users/{user_id}/role to set
+    its own role to ADMIN -- self-promotion past the ADMIN-only gate
+    enforced everywhere else (auth_dependencies.require_admin, and the
+    can_admin flag both OAuth and password-login sessions derive via
+    auth.py's role_permissions()). Role changes are an admin-level
+    action, not the general user management UserRole's own docstring
+    grants MANAGER ("Can manage content and users (except admins)").
+    Used only for the role-change endpoint -- every other admin.py route
+    stays on require_admin_access deliberately; re-tiering those is a
+    separate, larger decision #324 doesn't ask for.
+    """
+    if current_user.role != UserRole.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
+        )
+    return current_user
+
+
 # ====================================
 # Pydantic Models for Request/Response
 # ====================================
@@ -657,7 +681,7 @@ async def get_user_details(
 async def update_user_role(
     user_id: int,
     role_data: UserRoleUpdateRequest,
-    current_user: UserInfo = Depends(require_admin_access),
+    current_user: UserInfo = Depends(require_admin_only_access),
 ):
     """Update user role (admin only)"""
     try:

--- a/tests/unit/test_admin_role_change_manager_privilege.py
+++ b/tests/unit/test_admin_role_change_manager_privilege.py
@@ -1,0 +1,122 @@
+"""Fix for #324: MANAGER role gets inconsistent admin-equivalent
+treatment across auth checks.
+
+Three places disagreed on whether MANAGER counts as admin:
+- auth_dependencies.require_admin -- ADMIN-only.
+- admin.py's UserInfo.can_access_admin() -- ADMIN + MANAGER.
+- The OAuth callback's can_admin derivation vs. the password-login
+  endpoints' derivation in auth.py.
+
+The auth.py piece turns out to already be resolved: every can_admin
+value in that file now flows through the shared role_permissions()
+helper, whose own docstring documents the ADMIN-only decision explicitly
+("can_admin is deliberately ADMIN-only ... because the branch's actual
+admin gate (auth_dependencies.require_admin) is ADMIN-only") -- so OAuth
+and password-login already agree.
+
+The remaining, concrete piece: PUT /api/admin/users/{user_id}/role was
+gated by require_admin_access (-> can_access_admin(), ADMIN+MANAGER),
+letting a MANAGER session call it to set its own role to ADMIN --
+self-promotion past the ADMIN-only gate enforced everywhere else. Per
+UserRole's own docstring ("Can manage content and users (except
+admins)"), role changes are an admin-level action, not general user
+management -- MANAGER's "manage... users" mandate doesn't cover granting
+itself admin.
+
+Fix: PUT /users/{user_id}/role now uses a new, stricter
+require_admin_only_access dependency (ADMIN-only) instead of
+require_admin_access. Every other admin.py route (dashboard, user
+listing/creation, activate/deactivate, sessions, audit logs, system
+status/health/restart) is deliberately left on require_admin_access --
+#324 only names role-change as the concrete forcing case, and widening
+this fix to re-tier all 17 routes would be a separate, larger design
+decision (which of them MANAGER should retain per "manage content and
+users (except admins)") that #324 doesn't ask for.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.fastapi.admin import UserInfo, require_admin_only_access
+
+SOURCE_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "admin.py"
+)
+
+
+def _function_source(function_name: str) -> str:
+    text = SOURCE_PATH.read_text()
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == function_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return "".join(lines[start:end])
+    raise AssertionError(f"Could not find function {function_name!r} in {SOURCE_PATH}")
+
+
+class TestUpdateUserRoleUsesTheStricterDependency:
+    def test_update_user_role_no_longer_uses_require_admin_access(self):
+        source = _function_source("update_user_role")
+        assert "Depends(require_admin_access)" not in source
+
+    def test_update_user_role_uses_require_admin_only_access(self):
+        source = _function_source("update_user_role")
+        assert "Depends(require_admin_only_access)" in source
+
+    def test_every_other_admin_route_still_uses_require_admin_access(self):
+        # Regression guard: this fix is deliberately scoped to
+        # role-change only. Every other admin.py route should be
+        # untouched.
+        other_routes = [
+            "get_dashboard",
+            "get_system_status",
+            "restart_application",
+            "get_recent_logs",
+            "list_all_users",
+            "create_new_user",
+            "get_user_details",
+            "deactivate_user_account",
+            "activate_user_account",
+            "unlock_user_account",
+            "get_user_sessions",
+            "revoke_user_session",
+            "revoke_all_user_sessions",
+            "get_audit_logs",
+            "get_detailed_health",
+        ]
+        for function_name in other_routes:
+            source = _function_source(function_name)
+            assert (
+                "Depends(require_admin_access)" in source
+            ), f"{function_name} should still use Depends(require_admin_access)"
+
+
+class TestRequireAdminOnlyAccess:
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    def test_admin_passes(self):
+        user = UserInfo(id=1, username="root", role="ADMIN", is_active=True)
+        result = self._run(require_admin_only_access(current_user=user))
+        assert result == user
+
+    def test_manager_is_rejected(self):
+        # The exact self-promotion vector: a MANAGER previously passed
+        # can_access_admin() and could reach update_user_role.
+        user = UserInfo(id=2, username="mgr", role="MANAGER", is_active=True)
+        with pytest.raises(HTTPException) as exc_info:
+            self._run(require_admin_only_access(current_user=user))
+        assert exc_info.value.status_code == 403
+
+    def test_regular_user_is_rejected(self):
+        user = UserInfo(id=3, username="user", role="USER", is_active=True)
+        with pytest.raises(HTTPException) as exc_info:
+            self._run(require_admin_only_access(current_user=user))
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
Closes #324. Three places disagreed on whether MANAGER counts as admin. The auth.py OAuth-vs-password-login piece turns out to already be resolved (both flow through `role_permissions()`, deliberately ADMIN-only). The remaining, concrete piece: `PUT /api/admin/users/{user_id}/role` was gated by `require_admin_access` (ADMIN+MANAGER), letting a MANAGER session set its own role to ADMIN — self-promotion past the ADMIN-only gate enforced everywhere else.

## Fix
New, stricter `require_admin_only_access` dependency (ADMIN-only), used only for the role-change endpoint. Every other `admin.py` route deliberately stays on `require_admin_access` — re-tiering all 17 routes is a separate, larger decision this issue doesn't ask for.

## Testing
Static AST source assertions plus real behavioral tests of the new dependency (admin passes, MANAGER rejected — the exact self-promotion vector, regular user rejected too). Verified RED before the fix, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)