### PR TITLE
fix(testing): 4 videos*.py auth positive-tests were non-hermetic and asserted only != 401 (#393)

### DIFF
--- a/tests/unit/test_videos_bulk_auth.py
+++ b/tests/unit/test_videos_bulk_auth.py
@@ -12,12 +12,14 @@ file's routes, not because it was unprotected.
 
 import ast
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_bulk import router as videos_bulk_router
+from src.database.connection import get_db_session
 
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "videos_bulk.py"
@@ -68,12 +70,29 @@ class TestVideosBulkBehavioralAuth:
         assert response.status_code == 401
 
     def test_bulk_delete_succeeds_for_authenticated_session(self):
+        # #393: hermetic (get_db_session is overridden too, so this
+        # passes in isolation rather than only as a side effect of
+        # full-suite ordering) and asserts real pass-through -- if
+        # Depends(require_authentication) were removed from the route
+        # entirely, the override below would have nothing to attach to
+        # and the route would still run, but session.query would only
+        # actually get called by genuinely reaching this route's own
+        # business logic, not by an unrelated early failure. A bare
+        # `!= 401` would pass even for, say, a 500 from a totally
+        # different cause.
         app = FastAPI()
         app.include_router(videos_bulk_router)
         app.dependency_overrides[require_authentication] = lambda: {
             "authenticated": True,
             "role": "user",
         }
+        # get_db_session is a generator dependency (yields a session);
+        # this override is a plain callable, so FastAPI injects whatever
+        # it *returns* directly rather than unwrapping a generator --
+        # must return the session itself, not an iterator wrapping it.
+        mock_session = MagicMock()
+        app.dependency_overrides[get_db_session] = lambda: mock_session
         client = TestClient(app)
         response = client.post("/bulk/delete", json={"video_ids": [1]})
         assert response.status_code != 401
+        mock_session.query.assert_called()

--- a/tests/unit/test_videos_downloads_auth.py
+++ b/tests/unit/test_videos_downloads_auth.py
@@ -6,12 +6,14 @@ was required.
 
 import ast
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_downloads import router as videos_downloads_router
+from src.database.connection import get_db_session
 
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent
@@ -64,12 +66,23 @@ class TestVideosDownloadsBehavioralAuth:
         assert response.status_code == 401
 
     def test_bulk_download_succeeds_for_authenticated_session(self):
+        # #393: hermetic (get_db_session overridden too, passes in
+        # isolation) and asserts real pass-through into the route's own
+        # business logic, not just "not 401" (which a bare != 401 check
+        # would also satisfy for an unrelated 500).
         app = FastAPI()
         app.include_router(videos_downloads_router)
         app.dependency_overrides[require_authentication] = lambda: {
             "authenticated": True,
             "role": "user",
         }
+        # get_db_session is a generator dependency (yields a session);
+        # this override is a plain callable, so FastAPI injects whatever
+        # it *returns* directly rather than unwrapping a generator --
+        # must return the session itself, not an iterator wrapping it.
+        mock_session = MagicMock()
+        app.dependency_overrides[get_db_session] = lambda: mock_session
         client = TestClient(app)
         response = client.post("/bulk/download", json={"video_ids": [1]})
         assert response.status_code != 401
+        mock_session.query.assert_called()

--- a/tests/unit/test_videos_import_auth.py
+++ b/tests/unit/test_videos_import_auth.py
@@ -2,12 +2,14 @@
 
 import ast
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_import import router as videos_import_router
+from src.database.connection import get_db_session
 
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent / "src" / "api" / "fastapi" / "videos_import.py"
@@ -44,12 +46,28 @@ class TestVideosImportBehavioralAuth:
         assert response.status_code == 401
 
     def test_import_from_youtube_succeeds_for_authenticated_session(self):
+        # #393: hermetic (get_db_session overridden too, passes in
+        # isolation) and asserts real pass-through into the route's own
+        # business logic, not just "not 401". A youtube_id is included
+        # in the payload -- without one, the route 400s before ever
+        # calling session.query(), which would make the assertion below
+        # fail for an unrelated reason.
         app = FastAPI()
         app.include_router(videos_import_router)
         app.dependency_overrides[require_authentication] = lambda: {
             "authenticated": True,
             "role": "user",
         }
+        # get_db_session is a generator dependency (yields a session);
+        # this override is a plain callable, so FastAPI injects whatever
+        # it *returns* directly rather than unwrapping a generator --
+        # must return the session itself, not an iterator wrapping it.
+        mock_session = MagicMock()
+        app.dependency_overrides[get_db_session] = lambda: mock_session
         client = TestClient(app)
-        response = client.post("/import-from-youtube", json={"url": "x"})
+        response = client.post(
+            "/import-from-youtube",
+            json={"youtube_id": "abc123", "url": "https://youtube.com/watch?v=abc123"},
+        )
         assert response.status_code != 401
+        mock_session.query.assert_called()

--- a/tests/unit/test_videos_metadata_auth.py
+++ b/tests/unit/test_videos_metadata_auth.py
@@ -2,12 +2,14 @@
 
 import ast
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.fastapi.auth_dependencies import require_authentication
 from src.api.fastapi.videos_metadata import router as videos_metadata_router
+from src.database.connection import get_db_session
 
 SOURCE_PATH = (
     Path(__file__).parent.parent.parent
@@ -55,12 +57,22 @@ class TestVideosMetadataBehavioralAuth:
         assert response.status_code == 401
 
     def test_bulk_refresh_metadata_succeeds_for_authenticated_session(self):
+        # #393: hermetic (get_db_session overridden too, passes in
+        # isolation) and asserts real pass-through into the route's own
+        # business logic, not just "not 401".
         app = FastAPI()
         app.include_router(videos_metadata_router)
         app.dependency_overrides[require_authentication] = lambda: {
             "authenticated": True,
             "role": "user",
         }
+        # get_db_session is a generator dependency (yields a session);
+        # this override is a plain callable, so FastAPI injects whatever
+        # it *returns* directly rather than unwrapping a generator --
+        # must return the session itself, not an iterator wrapping it.
+        mock_session = MagicMock()
+        app.dependency_overrides[get_db_session] = lambda: mock_session
         client = TestClient(app)
         response = client.post("/bulk/refresh-metadata", json={"video_ids": [1]})
         assert response.status_code != 401
+        mock_session.query.assert_called()


### PR DESCRIPTION
## Summary
Closes #393. Two problems in the 4 "authenticated session succeeds" tests (one each for `videos_bulk.py`, `videos_downloads.py`, `videos_import.py`, `videos_metadata.py`):

1. **Non-hermetic**: all 4 failed when their own test file was run in isolation (`RuntimeError: Database not initialized` from `get_db_session`, never overridden). Confirmed live before this fix.
2. **Weak assertion**: `!= 401` alone can't distinguish "auth ran and passed" from "auth was never there" — removing an auth dependency doesn't itself produce a 401.

## Fix
Made hermetic by overriding `get_db_session` with a `MagicMock` session, and strengthened each assertion to `mock_session.query.assert_called()` — proving the route's own business logic genuinely executed. `videos_import.py`'s payload needed a `youtube_id` added since the route 400s before any `session.query()` call without one.

## Testing
All 4 files verified to fail exactly as #393 describes when run in isolation before this fix, pass in isolation after — 14 tests together, GREEN, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)