### PR TITLE
fix: video-URL operator-precedence bug, duplicated in 5 places (#387)

### DIFF
--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -72,6 +72,38 @@ async def resolve_video_url(
     return await asyncio.to_thread(_resolve_video_url_sync, video, session, timeout)
 
 
+def _stored_video_url(video: Video, missing_value: Any = None) -> Any:
+    """Return a video's already-stored URL, without any live resolution.
+
+    #387: the 5 call sites this replaces all computed this inline as:
+
+        video.url
+        or video.youtube_url
+        or f"https://youtube.com/watch?v={video.youtube_id}"
+        if hasattr(video, "youtube_id") and video.youtube_id
+        else None
+
+    Python's conditional expression binds looser than `or`, so that
+    parsed as `(url or youtube_url or f"...") if youtube_id else None`
+    -- the youtube_id check gated the ENTIRE or-chain, not just the
+    f-string fallback. A video with `url` set but no `youtube_id`
+    therefore evaluated to None, discarding a perfectly usable stored
+    URL (harmless in practice only because every caller's next step,
+    resolve_video_url(), independently re-checks video.url first).
+    Correctly parenthesized here: the youtube_id ternary only governs
+    the final fallback branch.
+    """
+    return (
+        video.url
+        or video.youtube_url
+        or (
+            f"https://youtube.com/watch?v={video.youtube_id}"
+            if hasattr(video, "youtube_id") and video.youtube_id
+            else missing_value
+        )
+    )
+
+
 # ========================================================================================
 # DOWNLOAD OPERATIONS
 # ========================================================================================
@@ -133,13 +165,7 @@ async def bulk_download_videos(
                     continue
 
                 # Validate and resolve video URL
-                video_url = (
-                    video.url
-                    or video.youtube_url
-                    or f"https://youtube.com/watch?v={video.youtube_id}"
-                    if hasattr(video, "youtube_id") and video.youtube_id
-                    else None
-                )
+                video_url = _stored_video_url(video)
 
                 if not video_url:
                     if url_resolution_time_used >= BULK_URL_RESOLUTION_BUDGET_SECONDS:
@@ -503,13 +529,7 @@ async def queue_video_download(
                 artist_id=video.artist_id,
                 video_id=video_id,
                 title=video.title,
-                original_url=(
-                    video.url
-                    or video.youtube_url
-                    or f"https://youtube.com/watch?v={video.youtube_id}"
-                    if hasattr(video, "youtube_id") and video.youtube_id
-                    else "Unknown URL"
-                ),
+                original_url=_stored_video_url(video, missing_value="Unknown URL"),
                 status="queued",
                 priority=priority,
                 created_at=datetime.utcnow(),
@@ -534,13 +554,7 @@ async def queue_video_download(
             subtitle_languages = settings.get("subtitle_languages", "en,en-US")
 
             # Get video URL
-            video_url = (
-                video.url
-                or video.youtube_url
-                or f"https://youtube.com/watch?v={video.youtube_id}"
-                if hasattr(video, "youtube_id") and video.youtube_id
-                else None
-            )
+            video_url = _stored_video_url(video)
 
             if not video_url:
                 raise ValueError("No valid URL found for video")
@@ -982,13 +996,7 @@ async def bulk_download_wanted_videos(
                     continue
 
                 # Check if video has a valid URL before creating download record
-                video_url = (
-                    video.url
-                    or video.youtube_url
-                    or f"https://youtube.com/watch?v={video.youtube_id}"
-                    if hasattr(video, "youtube_id") and video.youtube_id
-                    else None
-                )
+                video_url = _stored_video_url(video)
 
                 # Skip videos without URLs - don't search YouTube in bulk operations as it's too slow
                 if not video_url:
@@ -1014,13 +1022,7 @@ async def bulk_download_wanted_videos(
                     artist_id=video.artist_id,
                     video_id=video.id,
                     title=video.title,
-                    original_url=(
-                        video.url
-                        or video.youtube_url
-                        or f"https://youtube.com/watch?v={video.youtube_id}"
-                        if hasattr(video, "youtube_id") and video.youtube_id
-                        else "Unknown URL"
-                    ),
+                    original_url=_stored_video_url(video, missing_value="Unknown URL"),
                     status="queued",
                     quality="best",  # Default quality for wanted videos
                     priority=1,  # Default priority for wanted videos

--- a/tests/unit/test_stored_video_url_operator_precedence.py
+++ b/tests/unit/test_stored_video_url_operator_precedence.py
@@ -1,0 +1,78 @@
+"""Fix for #387: resolve_video_url() call condition has an
+operator-precedence bug (pre-existing).
+
+videos_downloads.py computed a video's already-stored URL via:
+
+    video.url
+    or video.youtube_url
+    or f"https://youtube.com/watch?v={video.youtube_id}"
+    if hasattr(video, "youtube_id") and video.youtube_id
+    else None
+
+Python's conditional expression (`X if C else Y`) binds looser than
+`or`, so this parses as:
+
+    (video.url or video.youtube_url or f"...watch?v={youtube_id}") if (hasattr(...) and youtube_id) else None
+
+-- the whole `or`-chain is the ternary's "true" value, and the youtube_id
+check gates ALL of it, not just the f-string fallback. A video with
+`url` set but no `youtube_id` therefore evaluates the outer condition to
+False and the whole expression to None, discarding a perfectly usable
+`video.url` -- silently falling through to an unnecessary
+resolve_video_url() call (harmless today only because that function
+independently re-checks video.url first, but wasteful, and fragile
+against future changes to that function). Confirmed identical, copy-
+pasted in 5 places across this file (not just the one #387 named):
+bulk_download_videos(), queue_video_download() (x2, one as
+original_url= for the Download record), bulk_download_wanted_videos()
+(x2, same original_url= pattern).
+
+Fix: extracted the shared logic into _stored_video_url(video,
+missing_value), which parenthesizes correctly -- the youtube_id ternary
+now only governs the final fallback branch -- and used it in all 5
+places, eliminating the duplication along with the bug.
+"""
+
+from types import SimpleNamespace
+
+from src.api.fastapi.videos_downloads import _stored_video_url
+
+
+def _video(url=None, youtube_url=None, youtube_id=None):
+    return SimpleNamespace(url=url, youtube_url=youtube_url, youtube_id=youtube_id)
+
+
+class TestStoredVideoUrl:
+    def test_url_wins_even_without_a_youtube_id(self):
+        # The exact bug: a video with url set but no youtube_id used to
+        # yield None here instead of the url.
+        video = _video(url="https://example.com/video.mp4", youtube_id=None)
+        assert _stored_video_url(video) == "https://example.com/video.mp4"
+
+    def test_url_wins_over_youtube_url_and_youtube_id(self):
+        video = _video(
+            url="https://example.com/video.mp4",
+            youtube_url="https://youtube.com/watch?v=abc123",
+            youtube_id="abc123",
+        )
+        assert _stored_video_url(video) == "https://example.com/video.mp4"
+
+    def test_falls_back_to_youtube_url_when_url_is_missing(self):
+        video = _video(youtube_url="https://youtube.com/watch?v=abc123")
+        assert _stored_video_url(video) == "https://youtube.com/watch?v=abc123"
+
+    def test_falls_back_to_a_constructed_youtube_watch_url_last(self):
+        video = _video(youtube_id="abc123")
+        assert _stored_video_url(video) == "https://youtube.com/watch?v=abc123"
+
+    def test_returns_default_missing_value_when_nothing_is_available(self):
+        video = _video()
+        assert _stored_video_url(video) is None
+
+    def test_returns_the_given_missing_value_when_nothing_is_available(self):
+        video = _video()
+        assert _stored_video_url(video, missing_value="Unknown URL") == "Unknown URL"
+
+    def test_empty_string_youtube_id_does_not_construct_a_watch_url(self):
+        video = _video(youtube_id="")
+        assert _stored_video_url(video) is None


### PR DESCRIPTION
## Summary
Closes #387. `videos_downloads.py` computed a video's already-stored URL via an inline expression where Python's conditional-expression precedence caused the `youtube_id` check to gate an entire `or`-chain instead of just its own fallback branch — a video with `url` set but no `youtube_id` evaluated to `None`, discarding a perfectly usable URL and falling through to an unnecessary resolution call. Harmless today only because the next step independently re-checks `video.url` first.

#387 named one occurrence. Grepping the file found the **identical bug, copy-pasted, in 4 more places**.

## Fix
Extracted the shared logic into `_stored_video_url(video, missing_value=None)`, correctly parenthesized, used in all 5 places — eliminating the duplication along with the bug.

## Testing
7 new unit tests exercise every branch directly. Verified RED before the fix, GREEN after. Ran the full existing `videos_downloads.py` test suite (61 tests across 9 files) to confirm no regressions from the refactor — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)