### PR TITLE
fix: retry_download() never actually re-dispatched anything (#444)

### DIFF
--- a/src/api/fastapi/metube.py
+++ b/src/api/fastapi/metube.py
@@ -222,14 +222,21 @@ async def get_download_queue(
 
             from ...database.models import Artist, Download
 
-            # Get recent downloads that are still in queue/downloading status
+            # Get recent downloads that are still in queue/downloading/
+            # pending status. "pending" included defensively (#444): it's
+            # the Download model's own default status, and any download
+            # genuinely left there for any reason -- not just the retry
+            # bug this queue-item-vanishing report was root-caused to --
+            # would otherwise be invisible here (and in get_download_
+            # history()'s completed/failed/cancelled filter) with no
+            # indication anything was ever attempted.
             recent_cutoff = datetime.utcnow() - timedelta(hours=2)  # Last 2 hours
 
             recent_downloads = (
                 session.query(Download, Artist.name)
                 .join(Artist, Download.artist_id == Artist.id)
                 .filter(
-                    Download.status.in_(["queued", "downloading"]),
+                    Download.status.in_(["queued", "downloading", "pending"]),
                     Download.created_at >= recent_cutoff,
                 )
                 .order_by(Download.created_at.desc())

--- a/src/services/download_service_adapter.py
+++ b/src/services/download_service_adapter.py
@@ -492,10 +492,43 @@ class DownloadServiceAdapter:
             }
 
     def retry_download(self, download_id: int) -> Dict[str, Any]:
-        """Retry a failed/stopped download (API compatibility method)"""
+        """Retry a failed/stopped download (API compatibility method).
+
+        Live-reported (#444): clicking Retry made the download vanish
+        from both the queue and history widgets, then it silently
+        appeared as downloaded a couple minutes later with no trace of
+        the retry anywhere. Two compounding bugs:
+
+        1. This method never actually re-dispatched anything -- it just
+           set status="pending" and returned success, on the apparent
+           assumption something else would notice and process it. Nothing
+           did: process_queued_downloads() (the only code that queries
+           for "pending" downloads) is only reachable via a manual
+           POST /api/metube/process-queue call, never triggered
+           automatically. The eventual "appeared as downloaded" was an
+           unrelated coincidence (most likely the separate auto-download
+           scheduler independently redownloading the same still-WANTED
+           video through its own normal path), not this retry succeeding.
+        2. Even setting that aside, "pending" isn't a status either the
+           queue view (get_download_queue: queued/downloading) or the
+           history view (get_download_history: completed/failed/
+           cancelled) recognizes -- so a download genuinely left at
+           "pending" for any reason is invisible in both places, exactly
+           matching the reported symptom.
+
+        Fix: actually claim the video and dispatch the download here,
+        mirroring the claim-then-dispatch-then-revert-on-failure pattern
+        already used by videos_downloads.py's queue_video_download() /
+        queue_download_video() / bulk_download_videos(). On success the
+        download settles at "queued" -- a status the queue view already
+        recognizes. On failure it reverts to "failed" with a real error
+        message, exactly where it started, instead of a silent "pending"
+        that only vanishes.
+        """
         try:
             from src.database.connection import get_db
-            from src.database.models import Download, Video
+            from src.database.models import Download, Video, VideoStatus
+            from src.services.video_batch_service import claim_video_for_redownload
 
             with get_db() as session:
                 download = (
@@ -518,14 +551,89 @@ class DownloadServiceAdapter:
                         "error": f"Invalid status: {download.status}",
                     }
 
-                # Reset download status to pending for retry
-                download.status = "pending"
+                if not download.video_id:
+                    return {
+                        "success": False,
+                        "message": "Download has no associated video and cannot be re-dispatched",
+                        "download_id": download_id,
+                        "error": "Missing video_id",
+                    }
+
+                video = (
+                    session.query(Video).filter(Video.id == download.video_id).first()
+                )
+                if not video:
+                    return {
+                        "success": False,
+                        "message": "Associated video not found",
+                        "download_id": download_id,
+                        "error": "Video not found",
+                    }
+
+                original_status = video.status
+
+                if not claim_video_for_redownload(download.video_id):
+                    return {
+                        "success": False,
+                        "message": "Video is currently downloading and cannot be retried right now",
+                        "download_id": download_id,
+                        "error": "Failed to claim video for retry",
+                    }
+
+                # claim_video_for_redownload() commits DOWNLOADING via its
+                # own, separate engine connection (deliberately, so it's
+                # immune to whatever state this session already holds --
+                # see its docstring). This session's own `video` object
+                # was loaded before that claim and has no idea the row
+                # changed underneath it, so SQLAlchemy's dirty-checking
+                # would otherwise compare a later `video.status =
+                # original_status` revert against its own stale, cached
+                # belief (still whatever it loaded originally) and see no
+                # real change -- silently skipping the UPDATE and leaving
+                # the video stuck at DOWNLOADING forever on a dispatch
+                # failure. Refreshing here makes this session's copy
+                # agree with the real DB value first.
+                session.refresh(video, attribute_names=["status"])
+
+                download.status = "queued"
                 download.progress = 0
                 download.error_message = None
                 download.updated_at = datetime.utcnow()
                 session.commit()
 
-                logger.info(f"Download {download_id} queued for retry")
+                try:
+                    result = self.add_music_video_download(
+                        artist=video.artist.name if video.artist else "Unknown Artist",
+                        title=video.title,
+                        url=download.original_url,
+                        quality=download.quality or "best",
+                        video_id=download.video_id,
+                        download_id=download.id,
+                    )
+                except Exception as dispatch_error:
+                    result = {"success": False, "error": str(dispatch_error)}
+
+                if not (result and result.get("success")):
+                    dispatch_error_message = (
+                        result.get("error", "Unknown dispatch error")
+                        if result
+                        else "Unknown dispatch error"
+                    )
+                    logger.error(
+                        f"Retry dispatch failed for download {download_id}: {dispatch_error_message}"
+                    )
+                    video.status = original_status
+                    download.status = "failed"
+                    download.error_message = dispatch_error_message
+                    session.commit()
+                    return {
+                        "success": False,
+                        "message": f"Failed to retry download: {dispatch_error_message}",
+                        "download_id": download_id,
+                        "error": dispatch_error_message,
+                    }
+
+                logger.info(f"Download {download_id} re-dispatched for retry")
 
                 return {
                     "success": True,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,7 +24,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import src.database.connection as connection
-from src.database.models import Artist, Video
+from src.database.models import Artist, Download, Video
 
 # Test modules that want a real (unpatched) get_db() backed by a real DB.
 _REAL_DB_MODULES = {
@@ -34,6 +34,8 @@ _REAL_DB_MODULES = {
     "test_import_duplicate_video_race.py",
     "test_discovery_dedup_global_youtube_id.py",
     "test_discovery_savepoint_preserves_earlier_inserts.py",
+    "test_retry_download_redispatches.py",
+    "test_download_queue_includes_pending.py",
 }
 
 
@@ -47,7 +49,7 @@ def _wire_real_sqlite_db(request, monkeypatch):
     os.close(db_fd)
     engine = create_engine(f"sqlite:///{db_path}")
     connection.Base.metadata.create_all(
-        engine, tables=[Artist.__table__, Video.__table__]
+        engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
     )
     # expire_on_commit=False: the wanted_video fixture in
     # test_claim_video_for_download.py reads `artist.id` in its teardown

--- a/tests/unit/test_download_queue_includes_pending.py
+++ b/tests/unit/test_download_queue_includes_pending.py
@@ -1,0 +1,76 @@
+"""Defense-in-depth fix for #444: get_download_queue()'s DB-backed filter
+only recognized "queued"/"downloading" status, not "pending" -- the
+Download model's own default status. A download genuinely left at
+"pending" for any reason (not just the retry_download() bug this report
+was root-caused to -- see test_retry_download_redispatches.py) was
+invisible here, and also invisible in get_download_history()'s
+completed/failed/cancelled filter, with no indication anything was ever
+attempted. Now included alongside "queued"/"downloading".
+
+Uses conftest.py's _wire_real_sqlite_db fixture (real SQLite behind
+get_db(), the same real, unpatched database access this endpoint and
+unified_download_service.get_download_queue() both use).
+"""
+
+import asyncio
+
+import pytest
+
+from src.api.fastapi.metube import get_download_queue
+from src.database.connection import get_db
+from src.database.models import Artist, Download, Video, VideoStatus
+
+
+@pytest.fixture
+def seeded_pending_download():
+    with get_db() as session:
+        artist = Artist(name="Test Artist")
+        session.add(artist)
+        session.flush()
+
+        video = Video(
+            artist_id=artist.id,
+            title="Test Song",
+            status=VideoStatus.WANTED,
+            url="https://youtube.com/watch?v=abc123",
+            youtube_id="abc123",
+        )
+        session.add(video)
+        session.flush()
+
+        download = Download(
+            artist_id=artist.id,
+            video_id=video.id,
+            title="Test Song",
+            original_url="https://youtube.com/watch?v=abc123",
+            status="pending",
+        )
+        session.add(download)
+        session.flush()
+        download_id = download.id
+
+    return download_id
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestDownloadQueueIncludesPendingDownloads:
+    def test_a_pending_download_appears_in_the_queue(self, seeded_pending_download):
+        download_id = seeded_pending_download
+
+        with get_db() as session:
+            result = _run(
+                get_download_queue(
+                    current_user={"user_id": 1, "username": "test"},
+                    session=session,
+                )
+            )
+
+        db_download_ids = {
+            item.get("db_download_id")
+            for item in result.queue
+            if item.get("db_download_id") is not None
+        }
+        assert download_id in db_download_ids

--- a/tests/unit/test_retry_download_redispatches.py
+++ b/tests/unit/test_retry_download_redispatches.py
@@ -1,0 +1,193 @@
+"""Fix for #444 (live-reported): clicking Retry on a failed download made
+it vanish from both the download queue and history widgets. A couple
+minutes later it silently appeared as downloaded, with no trace of the
+retry ever having happened.
+
+Two compounding bugs, both in DownloadServiceAdapter.retry_download():
+
+1. It never actually re-dispatched anything -- it just set
+   status="pending" and returned success, on the apparent assumption
+   something else would notice and process it. Nothing does:
+   process_queued_downloads() (the only code that queries for "pending"
+   downloads) is only reachable via a manual POST /api/metube/
+   process-queue call, never triggered automatically. The eventual
+   "appeared as downloaded" was an unrelated coincidence -- most likely
+   the separate auto-download scheduler independently redownloading the
+   same still-eligible video through its own normal path -- not this
+   retry succeeding.
+2. "pending" isn't a status either the queue view
+   (get_download_queue: queued/downloading) or the history view
+   (get_download_history: completed/failed/cancelled) recognizes, so a
+   download genuinely left at "pending" for any reason is invisible in
+   both places -- exactly matching the reported symptom.
+
+Fix: retry_download() now actually claims the video
+(claim_video_for_redownload(), the same helper videos_downloads.py's
+functions already use) and dispatches through
+add_music_video_download(), mirroring the claim-then-dispatch-then-
+revert-on-failure pattern established there. On success the download
+settles at "queued" (a status the queue view recognizes); on failure it
+reverts to "failed" with a real error message and the video's real
+pre-claim status, exactly where it started.
+
+Uses tests/unit/conftest.py's _wire_real_sqlite_db fixture (real SQLite
+behind get_db(), the same real, unpatched database access
+retry_download() and claim_video_for_redownload() actually use) rather
+than mocking session objects -- this file needed Download.__table__
+added to that fixture's schema creation, which it didn't have before
+(only Artist/Video).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.database.connection import get_db
+from src.database.models import Artist, Download, Video, VideoStatus
+from src.services.download_service_adapter import DownloadServiceAdapter
+
+
+@pytest.fixture
+def seeded_failed_download():
+    """A video + a failed Download row pointing at it, ready to retry."""
+    with get_db() as session:
+        artist = Artist(name="Test Artist")
+        session.add(artist)
+        session.flush()
+
+        video = Video(
+            artist_id=artist.id,
+            title="Test Song",
+            status=VideoStatus.FAILED,
+            url="https://youtube.com/watch?v=abc123",
+            youtube_id="abc123",
+        )
+        session.add(video)
+        session.flush()
+
+        download = Download(
+            artist_id=artist.id,
+            video_id=video.id,
+            title="Test Song",
+            original_url="https://youtube.com/watch?v=abc123",
+            status="failed",
+            error_message="yt-dlp exploded",
+        )
+        session.add(download)
+        session.flush()
+
+        video_id = video.id
+        download_id = download.id
+
+    return video_id, download_id
+
+
+def _adapter():
+    """DownloadServiceAdapter.__init__() does real filesystem/settings
+    work (_load_settings(), _restore_cookies_from_database()) that isn't
+    relevant here -- bypass it via __new__, matching the established
+    pattern for constructor-heavy classes elsewhere in this test suite
+    (e.g. test_youtube_download_engine_pure_helpers.py)."""
+    return DownloadServiceAdapter.__new__(DownloadServiceAdapter)
+
+
+class TestRetryDownloadActuallyRedispatches:
+    def test_successful_retry_settles_at_queued_not_pending(
+        self, seeded_failed_download
+    ):
+        video_id, download_id = seeded_failed_download
+        adapter = _adapter()
+
+        with patch.object(
+            DownloadServiceAdapter,
+            "add_music_video_download",
+            return_value={"success": True, "id": "job-1"},
+        ) as mock_dispatch:
+            result = adapter.retry_download(download_id)
+
+        assert result["success"] is True
+        mock_dispatch.assert_called_once()
+
+        with get_db() as session:
+            download = (
+                session.query(Download).filter(Download.id == download_id).first()
+            )
+            # The exact bug: this used to be "pending" -- a status
+            # neither the queue nor the history view recognizes, so the
+            # download vanished from both.
+            assert download.status == "queued"
+            video = session.query(Video).filter(Video.id == video_id).first()
+            assert video.status == VideoStatus.DOWNLOADING
+
+    def test_dispatch_failure_reverts_to_failed_with_a_real_error(
+        self, seeded_failed_download
+    ):
+        video_id, download_id = seeded_failed_download
+        adapter = _adapter()
+
+        with patch.object(
+            DownloadServiceAdapter,
+            "add_music_video_download",
+            return_value={"success": False, "error": "disk full"},
+        ):
+            result = adapter.retry_download(download_id)
+
+        assert result["success"] is False
+        assert "disk full" in result["error"]
+
+        with get_db() as session:
+            download = (
+                session.query(Download).filter(Download.id == download_id).first()
+            )
+            assert download.status == "failed"
+            assert "disk full" in download.error_message
+            video = session.query(Video).filter(Video.id == video_id).first()
+            # Reverted to the real pre-claim status (FAILED), not left
+            # stuck at DOWNLOADING and not reset to some hardcoded value.
+            assert video.status == VideoStatus.FAILED
+
+    def test_dispatch_exception_reverts_to_failed(self, seeded_failed_download):
+        video_id, download_id = seeded_failed_download
+        adapter = _adapter()
+
+        with patch.object(
+            DownloadServiceAdapter,
+            "add_music_video_download",
+            side_effect=RuntimeError("connection reset"),
+        ):
+            result = adapter.retry_download(download_id)
+
+        assert result["success"] is False
+
+        with get_db() as session:
+            download = (
+                session.query(Download).filter(Download.id == download_id).first()
+            )
+            assert download.status == "failed"
+            video = session.query(Video).filter(Video.id == video_id).first()
+            assert video.status == VideoStatus.FAILED
+
+    def test_download_not_found_reports_a_clear_error(self):
+        adapter = _adapter()
+        result = adapter.retry_download(999999)
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_refuses_to_retry_a_download_that_is_not_retriable(
+        self, seeded_failed_download
+    ):
+        video_id, download_id = seeded_failed_download
+        with get_db() as session:
+            download = (
+                session.query(Download).filter(Download.id == download_id).first()
+            )
+            download.status = "queued"  # already active, not retriable
+
+        adapter = _adapter()
+        with patch.object(
+            DownloadServiceAdapter, "add_music_video_download"
+        ) as mock_dispatch:
+            result = adapter.retry_download(download_id)
+
+        assert result["success"] is False
+        mock_dispatch.assert_not_called()


### PR DESCRIPTION
## Summary
Closes #444. Clicking Retry on a failed download made it vanish from both the download queue and history widgets, then it silently appeared as downloaded a couple minutes later with no trace of the retry.

Two compounding bugs in `DownloadServiceAdapter.retry_download()`:
1. It never actually re-dispatched anything — it just set `status="pending"` and returned success. Nothing automatically processes "pending" downloads (the only code that does, `process_queued_downloads()`, is manual-trigger-only). The eventual completion was an unrelated coincidence.
2. `"pending"` isn't a status either the queue view or history view recognizes, so it vanished from both.

## Fix
`retry_download()` now actually claims the video and dispatches, mirroring the claim-then-dispatch-then-revert pattern already used elsewhere in this codebase. Also added `"pending"` to `get_download_queue()`'s filter defensively.

## Testing
Real behavioral tests against a real SQLite-backed `get_db()`. Verified RED by temporarily swapping back the original implementation. Caught and fixed a second, subtler bug during the same TDD cycle: the video revert was silently a no-op due to SQLAlchemy dirty-checking against a stale in-memory object — fixed with an explicit `session.refresh()`. Full existing suite sharing the extended test fixture (26 tests) re-run to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)