### PR TITLE
fix(#443 follow-up): unique per-attempt cookie working copy

### DIFF
--- a/src/services/download_service_adapter.py
+++ b/src/services/download_service_adapter.py
@@ -4,6 +4,8 @@ Provides seamless integration with existing MVidarr code while using the new uni
 """
 
 import os
+import tempfile
+import time
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -109,6 +111,20 @@ class DownloadServiceAdapter:
         genuinely valid. Passing yt-dlp a disposable copy instead means
         whatever it does to that copy never propagates back to the
         database-backed master.
+
+        Follow-up fix: the first version of this method used a single
+        FIXED path (f"{cookies_path}.working") shared across every
+        dispatch. Live on mvidarr-dev this was poisoned by a stale,
+        differently-owned leftover file (created once, out-of-band, by
+        a diagnostic script run as a different user than the real app
+        process) -- every subsequent real download hit PermissionError
+        writing to it, silently fell back to the master path, and
+        reproduced the exact corruption bug this method exists to
+        prevent. A fixed shared path is also a race between concurrent
+        downloads. Each call now gets its own unique temp file, so no
+        leftover file -- however it got there -- can ever block a later
+        call again. Stale copies past the cleanup window (crashed
+        processes, killed downloads) are opportunistically removed.
         """
         try:
             from src.services.settings_service import SettingsService
@@ -124,16 +140,50 @@ class DownloadServiceAdapter:
             import base64
 
             cookie_content = base64.b64decode(cookie_content_b64)
-            working_path = f"{self.cookies_path}.working"
-            cookie_dir = os.path.dirname(working_path)
-            if cookie_dir and not os.path.exists(cookie_dir):
+            cookie_dir = os.path.dirname(self.cookies_path) or "."
+            if not os.path.exists(cookie_dir):
                 os.makedirs(cookie_dir, exist_ok=True)
-            with open(working_path, "wb") as f:
-                f.write(cookie_content)
+
+            self._cleanup_stale_working_copies(cookie_dir)
+
+            base_name = os.path.basename(self.cookies_path)
+            fd, working_path = tempfile.mkstemp(
+                prefix=f"{base_name}.", suffix=".working", dir=cookie_dir
+            )
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(cookie_content)
+            except Exception:
+                os.unlink(working_path)
+                raise
             return working_path
         except Exception as e:
             logger.error(f"Failed to prepare working cookie copy: {e}")
             return self.cookies_path if os.path.exists(self.cookies_path) else None
+
+    def _cleanup_stale_working_copies(
+        self, cookie_dir: str, max_age_seconds: int = 3600
+    ) -> None:
+        """Best-effort cleanup of leftover per-attempt working copies from
+        previous dispatches (crashed processes, killed downloads, etc.)
+        so they don't accumulate unboundedly. Never touches anything
+        younger than max_age_seconds, so a copy actively in use by a
+        concurrent in-flight download is never removed out from under
+        it."""
+        try:
+            base_name = os.path.basename(self.cookies_path)
+            now = time.time()
+            for name in os.listdir(cookie_dir):
+                if not (name.startswith(f"{base_name}.") and name.endswith(".working")):
+                    continue
+                full_path = os.path.join(cookie_dir, name)
+                try:
+                    if now - os.path.getmtime(full_path) > max_age_seconds:
+                        os.unlink(full_path)
+                except OSError:
+                    pass
+        except OSError:
+            pass
 
     def add_music_video_download(
         self,

--- a/tests/unit/test_working_cookies_copy.py
+++ b/tests/unit/test_working_cookies_copy.py
@@ -29,7 +29,9 @@ copy can no longer propagate back to the database-backed master.
 """
 
 import base64
+import os
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -108,6 +110,80 @@ class TestGetWorkingCookiesPath:
                 working_path = adapter._get_working_cookies_path()
 
             assert working_path is None
+
+
+class TestWorkingCookiesPathIsUniquePerCall:
+    """Follow-up fix: the original #443 fix used a single FIXED path
+    (f"{cookies_path}.working") shared across every dispatch. Live on
+    mvidarr-dev this was poisoned by a stale, differently-owned leftover
+    file (created once as root via an out-of-band diagnostic script,
+    while the real app process runs as an unprivileged user) --
+    every subsequent real download hit PermissionError writing to it,
+    which the broad except silently swallowed, falling back to the
+    master path and reproducing the exact cookie-corruption bug #443
+    was meant to fix. A fixed shared path is also a race: two concurrent
+    downloads would stomp on each other's copy. The fix: a unique
+    per-call temp file, so no leftover file -- however it got there --
+    can ever block a later call again."""
+
+    def test_two_calls_produce_two_independent_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cookies_path = str(Path(tmpdir) / "youtube_cookies.txt")
+            adapter = _adapter(cookies_path)
+
+            with patch(
+                "src.services.settings_service.SettingsService.get",
+                return_value=base64.b64encode(b"cookie content").decode("utf-8"),
+            ):
+                first = adapter._get_working_cookies_path()
+                second = adapter._get_working_cookies_path()
+
+            assert first != second
+            assert Path(first).exists()
+            assert Path(second).exists()
+
+    def test_a_stale_unwritable_leftover_at_the_old_fixed_path_does_not_block_a_fresh_copy(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cookies_path = str(Path(tmpdir) / "youtube_cookies.txt")
+            # Simulate the exact live failure: a leftover file at the old
+            # fixed ".working" suffix that this process cannot write to.
+            stale_path = f"{cookies_path}.working"
+            Path(stale_path).write_bytes(b"stale, unwritable leftover")
+            os.chmod(stale_path, 0o444)
+            adapter = _adapter(cookies_path)
+
+            try:
+                with patch(
+                    "src.services.settings_service.SettingsService.get",
+                    return_value=base64.b64encode(b"fresh db content").decode("utf-8"),
+                ):
+                    working_path = adapter._get_working_cookies_path()
+
+                assert working_path is not None
+                assert working_path != cookies_path
+                assert working_path != stale_path
+                assert Path(working_path).read_bytes() == b"fresh db content"
+            finally:
+                os.chmod(stale_path, 0o644)
+
+    def test_stale_working_copies_older_than_the_cleanup_window_are_removed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cookies_path = str(Path(tmpdir) / "youtube_cookies.txt")
+            old_leftover = Path(f"{cookies_path}.ancient123.working")
+            old_leftover.write_bytes(b"orphaned from a crashed process")
+            old_time = time.time() - 7200  # 2 hours ago
+            os.utime(old_leftover, (old_time, old_time))
+            adapter = _adapter(cookies_path)
+
+            with patch(
+                "src.services.settings_service.SettingsService.get",
+                return_value=base64.b64encode(b"fresh content").decode("utf-8"),
+            ):
+                adapter._get_working_cookies_path()
+
+            assert not old_leftover.exists()
 
 
 class TestAddMusicVideoDownloadUsesTheWorkingCopy:


### PR DESCRIPTION
## Root cause of the fix in #450 not resolving the live report

PR #450 introduced `_get_working_cookies_path()`, writing a disposable cookie
copy to a **fixed** path (`{cookies_path}.working`) before every dispatch so
yt-dlp's in-place `--cookies` rewrite couldn't corrupt the database-backed
master. Logically sound, and unit-tested — but the user reported the exact
same failure after retrying post-deploy.

Live investigation on mvidarr-dev (structured app logs under
`/app/data/logs/mvidarr_structured.log`, not `docker logs`) found the smoking
gun on both failed real requests:

```
ERROR mvidarr.download_adapter _get_working_cookies_path:135
Failed to prepare working cookie copy: [Errno 13] Permission denied:
'data/cookies/youtube_cookies.txt.working'
```

The fixed `.working` path had a leftover file owned by `root:root` (644) —
left behind by my own earlier `docker exec` diagnostic verification script,
which runs as root by default. The real app process runs as user `mvidarr`,
which only has read access to that file. Every real dispatch's
`open(working_path, "wb")` hit `PermissionError`, was swallowed by the
`except Exception`, and silently fell back to `self.cookies_path` — the
master file — exactly reproducing the original corruption bug.

Independent of how it got poisoned this time, a **fixed shared path** is
fragile by design: any stale ownership (crash, manual intervention, restart
under a different UID) or even two concurrent downloads racing on the same
file breaks it, with only a swallowed exception as evidence.

## Fix

`_get_working_cookies_path()` now creates a **unique temp file per call**
(`tempfile.mkstemp` in the cookies directory) instead of reusing a fixed
name. No leftover file — however it got there — can block a later call
again. Added opportunistic cleanup of working copies older than 1 hour so
they don't accumulate unboundedly.

Also manually removed the poisoned root-owned leftover file from
mvidarr-dev so the very next real attempt isn't blocked by it even before
this deploys.

## Tests

3 new tests in `test_working_cookies_copy.py` (8 total in the file, all
passing):
- two calls produce two independent, both-existing paths
- a stale, unwritable leftover at the *old* fixed path no longer blocks a
  fresh working copy
- stale working copies past the cleanup window get removed

Full adjacent suite (`test_working_cookies_copy.py`,
`test_retry_download_redispatches.py`, `test_download_queue_includes_pending.py`)
— 14/14 passing. `black --check` / `isort --check-only` clean.

Related: #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)