### PR TITLE
fix(#452 stopgap): android-client fallback when PO-token clients fail

### DIFF
--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -399,6 +399,34 @@ class YouTubeDownloadStrategy(DownloadStrategy):
                     current_level = AntiDetectionLevel.AGGRESSIVE
                     time.sleep(2**attempt)
 
+        # Normal anti-detection ladder exhausted. #452: mvidarr's yt-dlp
+        # setup currently has no working PO-token provider, which
+        # strips every real video/audio format from the web/mweb/tv
+        # clients on PO-token-gated videos ("Requested format is not
+        # available" / "Only images are available"), even with valid
+        # cookies. Last resort: force yt-dlp's android client, which
+        # historically doesn't require PO-token verification or JS
+        # signature/nsig challenge solving -- trading resolution for a
+        # completed download instead of an outright failure.
+        try:
+            fallback_result = self._attempt_download(
+                context, current_level, force_player_client="android"
+            )
+        except Exception as e:
+            logger.error(f"Fallback download attempt exception: {e}")
+            fallback_result = None
+
+        if fallback_result and fallback_result.success:
+            logger.warning(
+                f"{context.title}: primary clients failed (see #452 -- no "
+                "PO token provider deployed); succeeded via fallback "
+                "android client, likely at reduced quality"
+            )
+            fallback_result.duration = time.time() - start_time
+            return fallback_result
+        if fallback_result and fallback_result.error_message:
+            last_error = fallback_result.error_message
+
         detail = last_error or "unknown error"
         return DownloadResult(
             success=False,
@@ -415,9 +443,21 @@ class YouTubeDownloadStrategy(DownloadStrategy):
             pass
 
     def _attempt_download(
-        self, context: DownloadContext, level: AntiDetectionLevel
+        self,
+        context: DownloadContext,
+        level: AntiDetectionLevel,
+        force_player_client: Optional[str] = None,
     ) -> DownloadResult:
-        """Attempt single download with specified anti-detection level"""
+        """Attempt single download with specified anti-detection level.
+
+        force_player_client (#452 fallback): when set, skips the normal
+        anti-detection client selection entirely -- which requires a
+        working PO-token provider / JS signature challenge solver,
+        neither of which is currently deployed -- in favor of a
+        minimal command using only the named client (e.g. "android")
+        plus cookies. See YouTubeDownloadStrategy.download()'s
+        last-resort fallback call.
+        """
 
         # Build command with anti-detection arguments
         cmd = [self.ytdlp_manager.current_executable]
@@ -436,13 +476,23 @@ class YouTubeDownloadStrategy(DownloadStrategy):
         # Metadata options
         cmd.extend(["--write-info-json", "--embed-metadata", "--add-metadata"])
 
-        # Anti-detection arguments
-        cmd.extend(self.anti_detection.get_anti_detection_args(level, context))
+        if force_player_client:
+            cmd.extend(
+                ["--extractor-args", f"youtube:player_client={force_player_client}"]
+            )
+            if context.cookies_path and os.path.exists(context.cookies_path):
+                cmd.extend(["--cookies", context.cookies_path])
+        else:
+            # Anti-detection arguments
+            cmd.extend(self.anti_detection.get_anti_detection_args(level, context))
 
         # URL
         cmd.append(context.url)
 
-        logger.info(f"Executing download: {context.title} with {level} anti-detection")
+        logger.info(
+            f"Executing download: {context.title} with "
+            f"{f'forced client={force_player_client}' if force_player_client else level}"
+        )
 
         try:
             process = subprocess.Popen(

--- a/tests/unit/test_unified_download_service.py
+++ b/tests/unit/test_unified_download_service.py
@@ -162,6 +162,152 @@ class TestFindDownloadedFile:
         )
 
 
+class TestFallbackClientDownload:
+    """#452: no PO token provider is deployed, so YouTube's SABR-only
+    rollout strips every real video/audio format from the web/mweb/tv
+    clients on PO-token-gated videos ("Requested format is not
+    available" / "Only images are available"), even with valid
+    cookies. Stopgap: after the normal 3-attempt anti-detection ladder
+    is exhausted, try once more forcing yt-dlp's android client, which
+    historically doesn't require PO-token verification or JS
+    signature/nsig challenge solving -- trading resolution for a
+    completed download instead of an outright failure.
+    """
+
+    def test_tries_android_fallback_after_all_attempts_fail(self):
+        strategy = _make_strategy()
+        failing = DownloadResult(
+            success=False, error_message="Requested format is not available"
+        )
+        fallback_success = DownloadResult(
+            success=True, file_path="/tmp/video.mp4", file_size=123
+        )
+
+        with patch.object(
+            strategy,
+            "_attempt_download",
+            side_effect=[failing, failing, failing, fallback_success],
+        ) as mock_attempt:
+            result = strategy.download(_make_context())
+
+        assert result.success is True
+        assert result.file_path == "/tmp/video.mp4"
+        # 3 normal attempts + 1 fallback attempt
+        assert mock_attempt.call_count == 4
+        last_call_kwargs = mock_attempt.call_args
+        assert last_call_kwargs.kwargs.get("force_player_client") == "android"
+
+    def test_does_not_try_fallback_when_first_attempt_succeeds(self):
+        strategy = _make_strategy()
+        success = DownloadResult(success=True, file_path="/tmp/video.mp4")
+
+        with patch.object(
+            strategy, "_attempt_download", return_value=success
+        ) as mock_attempt, patch.object(
+            strategy, "_probe_video_height", return_value=1080
+        ):
+            result = strategy.download(_make_context())
+
+        assert result.success is True
+        assert mock_attempt.call_count == 1
+
+    def test_returns_final_failure_when_fallback_also_fails(self):
+        strategy = _make_strategy()
+        failing = DownloadResult(
+            success=False, error_message="Requested format is not available"
+        )
+        fallback_failing = DownloadResult(
+            success=False, error_message="fallback also failed: no formats"
+        )
+
+        with patch.object(
+            strategy,
+            "_attempt_download",
+            side_effect=[failing, failing, failing, fallback_failing],
+        ):
+            result = strategy.download(_make_context())
+
+        assert result.success is False
+        assert "fallback also failed" in result.error_message
+
+    def test_fallback_exception_does_not_crash_download(self):
+        strategy = _make_strategy()
+        failing = DownloadResult(
+            success=False, error_message="Requested format is not available"
+        )
+
+        def _side_effect(*args, **kwargs):
+            if kwargs.get("force_player_client"):
+                raise RuntimeError("fallback subprocess exploded")
+            return failing
+
+        with patch.object(strategy, "_attempt_download", side_effect=_side_effect):
+            result = strategy.download(_make_context())
+
+        assert result.success is False
+        assert "Requested format is not available" in result.error_message
+
+
+class TestAttemptDownloadForcePlayerClient:
+    """Covers _attempt_download's force_player_client override used by the
+    #452 fallback: it must skip the anti-detection manager's normal
+    (PO-token/JS-dependent) client selection entirely, using only a
+    minimal, explicit client + cookies."""
+
+    def test_builds_minimal_command_bypassing_anti_detection_args(self, tmp_path):
+        strategy = _make_strategy()
+        strategy.anti_detection.get_anti_detection_args = MagicMock(
+            side_effect=AssertionError(
+                "force_player_client must bypass anti_detection.get_anti_detection_args"
+            )
+        )
+        context = _make_context(output_path=str(tmp_path))
+
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [""]
+        mock_process.returncode = 1
+        mock_process.wait.return_value = None
+
+        with patch(
+            "src.services.unified_download_service.subprocess.Popen",
+            return_value=mock_process,
+        ) as mock_popen:
+            strategy._attempt_download(
+                context, AntiDetectionLevel.MODERATE, force_player_client="android"
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--extractor-args" in cmd
+        idx = cmd.index("--extractor-args")
+        assert cmd[idx + 1] == "youtube:player_client=android"
+        strategy.anti_detection.get_anti_detection_args.assert_not_called()
+
+    def test_includes_cookies_when_present(self, tmp_path):
+        strategy = _make_strategy()
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        context = _make_context(
+            output_path=str(tmp_path), cookies_path=str(cookie_file)
+        )
+
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [""]
+        mock_process.returncode = 1
+        mock_process.wait.return_value = None
+
+        with patch(
+            "src.services.unified_download_service.subprocess.Popen",
+            return_value=mock_process,
+        ) as mock_popen:
+            strategy._attempt_download(
+                context, AntiDetectionLevel.MODERATE, force_player_client="android"
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--cookies" in cmd
+        assert str(cookie_file) in cmd
+
+
 class TestIsDeadYoutubeError:
     def _check(self, message):
         service = UnifiedDownloadService.__new__(UnifiedDownloadService)


### PR DESCRIPTION
## Stopgap for #452, not the real fix

mvidarr's yt-dlp setup has no working PO token provider deployed — the Python
client plugin (`bgutil-ytdlp-pot-provider`, pinned in `requirements.txt`) is
installed, but its companion server (the actual PO-token-generating HTTP
service) was never stood up. Separately, yt-dlp reports the container's Node
runtime as "unsupported" for its own JS signature/nsig challenge solver.

Together, on PO-token-gated videos this strips every real video/audio format
from the web/mweb/tv clients, leaving only images:

\`\`\`
WARNING: [youtube] ...: Signature solving failed: Some formats may be missing.
WARNING: [youtube] ...: n challenge solving failed: Some formats may be missing.
WARNING: Only images are available for download. use --list-formats to see them
ERROR: [youtube] ...: Requested format is not available.
\`\`\`

## Fix (stopgap)

After the normal 3-attempt anti-detection ladder is exhausted,
\`YouTubeDownloadStrategy.download()\` now tries once more forcing yt-dlp's
\`android\` client via a new \`_attempt_download(..., force_player_client=...)\`
parameter that skips the anti-detection manager's normal (PO-token/JS-
dependent) client selection entirely — just cookies + quality + the forced
client. The android client has historically not required PO-token
verification or JS challenge solving, at the cost of a lower resolution cap.
Trades quality for a completed download instead of an outright failure while
the real fix (deploying the PO-token provider server, tracked in #452) gets
built.

## Tests

6 new tests in \`test_unified_download_service.py\` (28/28 in the file
passing): fallback only triggers after all 3 primary attempts fail; never
triggers when an early attempt succeeds; a failing fallback still surfaces a
real error; a fallback exception doesn't crash the download; the forced-
client command bypasses \`anti_detection.get_anti_detection_args()\` entirely;
cookies are still included when present. `black --check` / `isort
--check-only` clean.

Related: #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)