### PR TITLE
fix(#452): android fallback must never pass cookies

### DIFF
--- a/src/services/unified_download_service.py
+++ b/src/services/unified_download_service.py
@@ -480,8 +480,13 @@ class YouTubeDownloadStrategy(DownloadStrategy):
             cmd.extend(
                 ["--extractor-args", f"youtube:player_client={force_player_client}"]
             )
-            if context.cookies_path and os.path.exists(context.cookies_path):
-                cmd.extend(["--cookies", context.cookies_path])
+            # Deliberately no --cookies here: yt-dlp 2026.08.19 skips the
+            # android client entirely ("Skipping client "android" since
+            # it does not support cookies") when cookies are supplied --
+            # confirmed live on mvidarr-dev. android is only useful for
+            # non-age-restricted PO-token/SABR-gated videos; age-
+            # restricted videos still need the real PO-token provider
+            # (#452), not this fallback.
         else:
             # Anti-detection arguments
             cmd.extend(self.anti_detection.get_anti_detection_args(level, context))

--- a/tests/unit/test_unified_download_service.py
+++ b/tests/unit/test_unified_download_service.py
@@ -282,7 +282,12 @@ class TestAttemptDownloadForcePlayerClient:
         assert cmd[idx + 1] == "youtube:player_client=android"
         strategy.anti_detection.get_anti_detection_args.assert_not_called()
 
-    def test_includes_cookies_when_present(self, tmp_path):
+    def test_omits_cookies_even_when_present(self, tmp_path):
+        # yt-dlp 2026.08.19 actively refuses to use the android client at
+        # all when cookies are supplied ("Skipping client "android" since
+        # it does not support cookies" -- confirmed live on mvidarr-dev),
+        # so the fallback must never pass --cookies regardless of whether
+        # context.cookies_path is set.
         strategy = _make_strategy()
         cookie_file = tmp_path / "cookies.txt"
         cookie_file.write_text("# Netscape HTTP Cookie File\n")
@@ -304,8 +309,8 @@ class TestAttemptDownloadForcePlayerClient:
             )
 
         cmd = mock_popen.call_args[0][0]
-        assert "--cookies" in cmd
-        assert str(cookie_file) in cmd
+        assert "--cookies" not in cmd
+        assert str(cookie_file) not in cmd
 
 
 class TestIsDeadYoutubeError:


### PR DESCRIPTION
## Bug in my own #453 stopgap

Live-reported: the android-client fallback from #453 still failed on video
174 with the identical "Requested format is not available" error. Structured
logs showed the fallback attempt DID run, but yt-dlp silently skipped it:

\`\`\`
WARNING: [youtube] Skipping client "android" since it does not support cookies
\`\`\`

yt-dlp 2026.08.19 refuses to combine the android client with cookies at all.
\`_attempt_download\`'s \`force_player_client\` branch was passing \`--cookies\`
whenever \`context.cookies_path\` existed — which defeats the fallback on
every real call, since cookies are always configured on a working system.

## Fix

Never pass \`--cookies\` for the forced-client fallback. Confirmed via direct
yt-dlp CLI reproduction (with and without cookies) that this is exactly the
mechanism. Also confirmed a real limit worth being upfront about: android
*without* cookies still can't rescue an age-restricted video on its own
(hits \`LOGIN_REQUIRED\` regardless) — that combination genuinely needs both
cookie-based auth and a working PO-token provider, which is #452's real,
not-yet-shipped fix. This stopgap now correctly helps PO-token/SABR-gated
videos that *aren't* also age-restricted; video 174 specifically still needs
the real PO-token server.

## Tests

\`test_includes_cookies_when_present\` → \`test_omits_cookies_even_when_present\`,
asserting the corrected behavior. 22/22 passing in the file. \`black --check\`
/ \`isort --check-only\` clean.

Related: #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)