### PR TITLE
fix(#452): deploy PO-token provider server + bump Node to 22 (real fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,34 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js from official binaries (required for yt-dlp JavaScript runtime)
-RUN curl -fsSL https://nodejs.org/dist/v20.18.1/node-v20.18.1-linux-x64.tar.xz -o /tmp/node.tar.xz \
+# Install Node.js from official binaries. Node >=22 is REQUIRED (not just
+# recommended): yt-dlp's own JS challenge solver (NodeJsRuntime) hardcodes
+# MIN_SUPPORTED_VERSION = (22, 0, 0) and refuses older runtimes outright,
+# and the bgutil-ytdlp-pot-provider server below (package.json "engines")
+# requires the same floor -- confirmed live on 2026-08-25 that v20.18.1
+# is rejected by both ("node (unavailable)" / ERR_REQUIRE_ESM crash),
+# while v22.23.2 (LTS "Jod") resolves full-quality formats end-to-end.
+RUN curl -fsSL https://nodejs.org/dist/v22.23.2/node-v22.23.2-linux-x64.tar.xz -o /tmp/node.tar.xz \
     && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
     && rm /tmp/node.tar.xz \
     && node --version && npm --version
+
+# Build the bgutil-ytdlp-pot-provider PO token server (#452): generates the
+# Proof-of-Origin tokens yt-dlp needs to bypass YouTube's SABR/bot-detection
+# gating on age-restricted and otherwise-protected videos. The Python
+# client plugin (bgutil-ytdlp-pot-provider) is already installed via
+# requirements.txt -- it was the client half only; this is its companion
+# HTTP server. Run by supervisord below, reachable at the plugin's default
+# http://127.0.0.1:4416 with zero yt-dlp invocation changes needed. Pinned
+# to the same 1.3.2 release as the installed Python plugin.
+RUN mkdir -p /app/vendor/bgutil-ytdlp-pot-provider \
+    && curl -fsSL https://github.com/Brainicism/bgutil-ytdlp-pot-provider/archive/refs/tags/1.3.2.tar.gz -o /tmp/pot-provider.tar.gz \
+    && tar -xzf /tmp/pot-provider.tar.gz -C /app/vendor/bgutil-ytdlp-pot-provider --strip-components=1 \
+    && rm /tmp/pot-provider.tar.gz \
+    && cd /app/vendor/bgutil-ytdlp-pot-provider/server \
+    && npm ci --no-audit --no-fund \
+    && npx tsc \
+    && npm prune --omit=dev
 
 # Set working directory
 WORKDIR /app

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,6 +4,21 @@ logfile=/app/data/logs/supervisord.log
 pidfile=/var/run/supervisord.pid
 user=root
 
+[program:pot-provider]
+; bgutil-ytdlp-pot-provider server (#452): generates the PO tokens yt-dlp
+; needs to bypass YouTube's SABR/bot-detection gating. Started before
+; fastapi/celery (lower priority number = earlier start) so downloads
+; never race an unready server on a cold container start; yt-dlp falls
+; back gracefully (with a logged warning) if it's briefly unreachable.
+command=node /app/vendor/bgutil-ytdlp-pot-provider/server/build/main.js
+directory=/app/vendor/bgutil-ytdlp-pot-provider/server
+user=mvidarr
+autostart=true
+autorestart=true
+stdout_logfile=/app/data/logs/pot-provider.log
+stderr_logfile=/app/data/logs/pot-provider_error.log
+priority=900
+
 [program:fastapi]
 command=python3 /app/fastapi_app.py
 directory=/app


### PR DESCRIPTION
## The real fix, not the stopgap

#453/#454 added an android-client fallback that trades quality for reliability.
This is the actual infrastructure fix, verified end-to-end on mvidarr-dev
before this PR.

## Two hard requirements were missing

1. **No PO-token provider server running.** The Python client plugin
   (`bgutil-ytdlp-pot-provider`) has been pinned in `requirements.txt` and
   installed all along — only its companion HTTP server (the actual
   PO-token generator) was never deployed. The plugin defaults to expecting
   it at `http://127.0.0.1:4416`.
2. **Node 20.18.1 is hard-rejected by yt-dlp's own JS challenge solver.**
   `NodeJsRuntime.MIN_SUPPORTED_VERSION = (22, 0, 0)` in yt-dlp itself —
   confirmed via source read, not guesswork. The pot-provider server's own
   `package.json` (`"engines": {"node": ">=22"}`) requires the same floor,
   and genuinely **crashes at runtime** on Node 20 (`ERR_REQUIRE_ESM` in a
   transitive dependency), not just a version-check warning.

## Verified live, step by step, before this commit

- `npm ci` + `tsc` succeed on both Node 20 and 22, but the built server only
  actually **runs** on Node ≥22 — reproduced the `ERR_REQUIRE_ESM` crash on
  20.18.1 directly, then confirmed clean startup + `/ping` response on 22.23.2
- With Node 22 + the PO-token server running, a direct yt-dlp CLI
  reproduction against video 174 (BE3kJeBr9QI, the video from #443/#452)
  went from `Only images are available for download` to successfully
  resolving `Downloading 1 format(s): 401+251`
- After rebuilding the image with these Dockerfile changes, ran the exact
  production code path (`DownloadServiceAdapter.retry_download()` on the
  real, previously-failing `Download` row) end to end: **completed
  successfully, 562MB file, 3840×2026 VP9 (4K), video status DOWNLOADED**

## Changes

- `Dockerfile`: Node v20.18.1 → v22.23.2 (LTS "Jod")
- `Dockerfile`: build `bgutil-ytdlp-pot-provider` 1.3.2 (matching the
  already-installed Python plugin's version) into
  `/app/vendor/bgutil-ytdlp-pot-provider/server/build` via `npm ci` +
  `npx tsc` + `npm prune --omit=dev`; the native `canvas` dependency
  installs cleanly from prebuilt binaries, no extra system libs needed
- `supervisord.conf`: new `[program:pot-provider]` entry running
  `node build/main.js` as user `mvidarr`, started before fastapi/celery
  (`priority=900`) so downloads don't race an unready server on a cold
  start; falls back gracefully (logged warning) if briefly unreachable
  regardless

No Python/application code changes — purely Docker image and process
supervision. The #453/#454 android-client fallback stays in place as
defense-in-depth.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)