### PR TITLE
fix: CSP blocked the YouTube-embed fallback for not-yet-downloaded videos

### DIFF
--- a/src/middleware/security_validation_middleware.py
+++ b/src/middleware/security_validation_middleware.py
@@ -91,7 +91,13 @@ class SecurityValidationConfig:
         "X-XSS-Protection": "1; mode=block",
         "Referrer-Policy": "strict-origin-when-cross-origin",
         "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
-        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.iconify.design https://cdn.socket.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com https:; connect-src 'self' ws: wss: https://api.iconify.design https://api.simplesvg.com https://api.unisvg.com; frame-ancestors 'none';",
+        # frame-src allows the YouTube-embed fallback in videos.html's
+        # playVideo() (for MONITORED/not-yet-downloaded videos with no
+        # local file) -- without it, frame-src falls back to default-src
+        # 'self' and browsers correctly block the embed outright.
+        # frame-ancestors stays 'none': whether THIS app can be framed by
+        # others is unrelated to whether it may frame YouTube.
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.iconify.design https://cdn.socket.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com https:; connect-src 'self' ws: wss: https://api.iconify.design https://api.simplesvg.com https://api.unisvg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none';",
     }
 
 

--- a/tests/unit/test_csp_allows_youtube_embed.py
+++ b/tests/unit/test_csp_allows_youtube_embed.py
@@ -1,0 +1,41 @@
+"""Live-reported: playing a video with no local file falls back to a
+YouTube <iframe> embed (videos.html's playVideo()), a legitimate,
+intentional preview feature for MONITORED/not-yet-downloaded videos.
+The Content-Security-Policy header had no frame-src directive, so it
+fell back to default-src 'self' -- which browsers correctly enforce
+by blocking ANY iframe embed, including YouTube's, breaking the
+feature outright with a CSP violation in the console:
+
+  Content-Security-Policy: The page's settings blocked the loading of
+  a resource (frame-src) at https://www.youtube.com/embed/<id> because
+  it violates the following directive: "default-src 'self'"
+
+Fix: SecurityValidationMiddleware.SECURITY_HEADERS' CSP now includes
+an explicit frame-src allowing only the YouTube embed origins the
+feature actually needs -- not a blanket allowance.
+"""
+
+from src.middleware.security_validation_middleware import SecurityValidationConfig
+
+
+class TestContentSecurityPolicyAllowsYoutubeEmbed:
+    def test_csp_includes_frame_src_for_youtube(self):
+        csp = SecurityValidationConfig.SECURITY_HEADERS["Content-Security-Policy"]
+        directives = {
+            d.strip().split(" ")[0]: d.strip() for d in csp.split(";") if d.strip()
+        }
+
+        assert "frame-src" in directives, (
+            "CSP has no frame-src directive -- falls back to default-src "
+            "'self', blocking the YouTube embed fallback in playVideo()"
+        )
+        frame_src = directives["frame-src"]
+        assert "https://www.youtube.com" in frame_src
+        assert "https://www.youtube-nocookie.com" in frame_src
+
+    def test_csp_still_denies_arbitrary_framing_by_default(self):
+        # The fix must be a targeted allowance, not a blanket relaxation --
+        # frame-ancestors (whether THIS app can be framed by others) is a
+        # separate, unrelated directive and must stay locked down.
+        csp = SecurityValidationConfig.SECURITY_HEADERS["Content-Security-Policy"]
+        assert "frame-ancestors 'none'" in csp


### PR DESCRIPTION
## Live-reported

Playing a video with no local file (status MONITORED, \`local_path\` null)
falls back to a YouTube \`<iframe>\` embed in \`videos.html\`'s \`playVideo()\` —
a legitimate, intentional preview feature. The CSP header had no \`frame-src\`
directive, so it fell back to \`default-src 'self'\`, and the browser
correctly blocked the embed outright:

\`\`\`
Content-Security-Policy: The page's settings blocked the loading of a
resource (frame-src) at https://www.youtube.com/embed/<id> because it
violates the following directive: "default-src 'self'"
\`\`\`

## Fix

Added an explicit \`frame-src\` directive allowing only the two YouTube embed
origins the feature actually needs (\`www.youtube.com\`,
\`www.youtube-nocookie.com\`) — a targeted allowance, not a blanket
relaxation. \`frame-ancestors\` stays \`'none'\` (whether this app can be framed
by others is a separate, unrelated directive).

## Note

\`SecurityHeaders.get_security_headers()\` in \`src/utils/security.py\` defines
a second, near-identical CSP string but is dead code — no call sites
anywhere in the FastAPI app. \`SecurityValidationMiddleware\` (fixed here) is
the one actually applied via \`app.add_middleware()\` in \`fastapi_app.py\`.
Left the dead code alone; out of scope here.

## Tests

2 new tests in \`test_csp_allows_youtube_embed.py\`: CSP includes \`frame-src\`
allowing the two YouTube embed origins; \`frame-ancestors 'none'\` still
holds (the fix must be targeted, not a blanket relaxation). \`black --check\`
/ \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)