### PR TITLE
fix: IMVDb placeholder page URL was dispatched to yt-dlp, failing with a confusing error

### DIFF
--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -92,9 +92,19 @@ def _stored_video_url(video: Video, missing_value: Any = None) -> Any:
     resolve_video_url(), independently re-checks video.url first).
     Correctly parenthesized here: the youtube_id ternary only governs
     the final fallback branch.
+
+    Live-reported (#452 follow-up): video_discovery_service.py's
+    _search_imvdb_for_artist() stores an IMVDb metadata *page* URL
+    (https://imvdb.com/video/<id>) in video.url as an explicit
+    "placeholder" fallback when IMVDb has no linked YouTube source --
+    not a URL yt-dlp can ever download. Treated as valid here, it
+    reached yt-dlp and failed with a confusing "No strategy available
+    for URL" instead of the clear "No valid URL found for video" every
+    call site already raises when there's genuinely nothing to try.
     """
+    url = video.url if video.url and not _is_imvdb_placeholder(video.url) else None
     return (
-        video.url
+        url
         or video.youtube_url
         or (
             f"https://youtube.com/watch?v={video.youtube_id}"
@@ -102,6 +112,14 @@ def _stored_video_url(video: Video, missing_value: Any = None) -> Any:
             else missing_value
         )
     )
+
+
+def _is_imvdb_placeholder(url: str) -> bool:
+    """True for the specific IMVDb metadata-page pattern
+    video_discovery_service.py stores as a non-downloadable fallback
+    (https://imvdb.com/video/<id>) -- not a blanket match on the
+    imvdb.com domain, which also hosts other, unrelated page types."""
+    return "imvdb.com/video/" in url
 
 
 # ========================================================================================

--- a/tests/unit/test_stored_video_url_operator_precedence.py
+++ b/tests/unit/test_stored_video_url_operator_precedence.py
@@ -76,3 +76,53 @@ class TestStoredVideoUrl:
     def test_empty_string_youtube_id_does_not_construct_a_watch_url(self):
         video = _video(youtube_id="")
         assert _stored_video_url(video) is None
+
+
+class TestImvdbPlaceholderUrlIsNotDownloadable:
+    """Live-reported: a download attempt failed with the confusing
+    "No strategy available for URL: https://imvdb.com/video/268780274253"
+    (a yt-dlp-strategy-shaped error, not an actionable one). Root cause:
+    video_discovery_service.py's _search_imvdb_for_artist() stores an
+    IMVDb *metadata page* URL in video.url as an explicit fallback
+    ("placeholder URL", per its own comment) when IMVDb has no linked
+    YouTube source -- but nothing downstream distinguished that
+    placeholder from a genuinely downloadable URL, so it was dispatched
+    to yt-dlp anyway and failed with no matching download strategy.
+
+    Fix: _stored_video_url() no longer treats an imvdb.com/video/ page
+    as a valid URL -- it falls through to youtube_url/youtube_id, and
+    if neither exists either, to the caller's existing "No valid URL
+    found for video" ValueError guard (already in place at every call
+    site) instead of ever reaching yt-dlp.
+    """
+
+    def test_imvdb_placeholder_alone_yields_the_missing_value(self):
+        video = _video(url="https://imvdb.com/video/268780274253")
+        assert _stored_video_url(video) is None
+
+    def test_imvdb_placeholder_falls_through_to_youtube_url(self):
+        video = _video(
+            url="https://imvdb.com/video/268780274253",
+            youtube_url="https://youtube.com/watch?v=abc123",
+        )
+        assert _stored_video_url(video) == "https://youtube.com/watch?v=abc123"
+
+    def test_imvdb_placeholder_falls_through_to_constructed_watch_url(self):
+        video = _video(url="https://imvdb.com/video/268780274253", youtube_id="abc123")
+        assert _stored_video_url(video) == "https://youtube.com/watch?v=abc123"
+
+    def test_imvdb_placeholder_uses_given_missing_value(self):
+        video = _video(url="https://imvdb.com/video/268780274253")
+        assert (
+            _stored_video_url(video, missing_value="No valid URL found for video")
+            == "No valid URL found for video"
+        )
+
+    def test_a_real_imvdb_looking_domain_that_is_not_the_placeholder_path_still_wins(
+        self,
+    ):
+        # Only the specific /video/ metadata-page pattern is a
+        # known-non-downloadable placeholder -- don't over-match and
+        # discard a URL that merely mentions imvdb.com incidentally.
+        video = _video(url="https://imvdb.com/n/some-artist")
+        assert _stored_video_url(video) == "https://imvdb.com/n/some-artist"


### PR DESCRIPTION
## Live-reported

\`\`\`
No strategy available for URL: https://imvdb.com/video/268780274253
\`\`\`

## Root cause

\`video_discovery_service.py\`'s \`_search_imvdb_for_artist()\` stores an IMVDb
*metadata page* URL in \`video.url\` as an explicit fallback ("placeholder
URL", per its own comment) when IMVDb has no linked YouTube source — not
something yt-dlp can ever download. Nothing downstream distinguished that
placeholder from a genuinely downloadable URL, so \`_stored_video_url()\`
(added in #387) returned it as-is, dispatching it straight to yt-dlp and
producing a yt-dlp-strategy-shaped error instead of the clear, already-
existing \`"No valid URL found for video"\` every call site raises when
there's genuinely nothing to try.

## Fix

\`_stored_video_url()\` now recognizes the \`imvdb.com/video/<id>\` pattern
specifically (not a blanket \`imvdb.com\` domain match, which also hosts
other, unrelated page types) and treats it the same as no URL at all —
falling through to \`youtube_url\`, then a constructed watch URL from
\`youtube_id\`, then the caller's \`missing_value\`.

## Scope note

This makes the failure **clear and actionable, not successful** — a video
whose only source is an IMVDb placeholder (IMVDb genuinely has no YouTube
link for it) still has no way to download until a real URL is added,
manually or via a future auto-search fallback. Root-causing why discovery
couldn't find a YouTube source, or adding one automatically, is out of
scope here.

## Tests

5 new tests in \`test_stored_video_url_operator_precedence.py\` (12/12 in
the file passing): placeholder alone yields the missing value; falls
through to \`youtube_url\` and to a constructed watch URL when present; uses
the caller's given \`missing_value\`; a non-placeholder \`imvdb.com\` URL is
NOT discarded (only the specific \`/video/\` pattern is treated as
non-downloadable). \`black --check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)