### PR TITLE
fix: batch/auto-download's resolve_video_url() dispatched IMVDb placeholder URLs

### DIFF
--- a/src/services/video_batch_service.py
+++ b/src/services/video_batch_service.py
@@ -175,6 +175,15 @@ def get_ytdlp_path() -> str:
     return "/usr/local/bin/yt-dlp"
 
 
+def _is_imvdb_placeholder(url: str) -> bool:
+    """True for the IMVDb metadata-page pattern video_discovery_service.py
+    stores as a non-downloadable fallback (https://imvdb.com/video/<id>)
+    when it has no linked YouTube source for a video -- not a blanket
+    match on the imvdb.com domain, which also hosts other, unrelated
+    page types."""
+    return "imvdb.com/video/" in url
+
+
 def resolve_video_url(video, session, timeout: int = 30) -> Optional[str]:
     """
     Helper function to resolve video URL using yt-dlp search
@@ -188,7 +197,11 @@ def resolve_video_url(video, session, timeout: int = 30) -> Optional[str]:
     Returns:
         str: Resolved URL or None
     """
-    if video.url:
+    # #452 follow-up (live-reported): an IMVDb placeholder page URL isn't
+    # downloadable -- treat it as no stored URL at all so this falls
+    # through to youtube_url, then the live YouTube search below,
+    # instead of returning something yt-dlp will always reject.
+    if video.url and not _is_imvdb_placeholder(video.url):
         return video.url
 
     # Also check youtube_url field as fallback (but ensure it's complete)

--- a/tests/unit/test_resolve_video_url_skips_imvdb_placeholder.py
+++ b/tests/unit/test_resolve_video_url_skips_imvdb_placeholder.py
@@ -1,0 +1,87 @@
+"""Live-reported: a batch of auto-download attempts failed with
+
+    No strategy available for URL: https://imvdb.com/video/197047016632
+
+Root cause: video_discovery_service.py's _search_imvdb_for_artist()
+stores an IMVDb *metadata page* URL in video.url as an explicit
+"placeholder URL" fallback when IMVDb has no linked YouTube source --
+not something yt-dlp can ever download. resolve_video_url() (the
+Celery/batch auto-download path's URL resolver, separate from
+_stored_video_url() in videos_downloads.py, which #459 already fixed
+for the FastAPI dispatch paths) short-circuited on `if video.url:
+return video.url` -- returning the unusable placeholder immediately
+and never reaching its own, more capable fallback: a live YouTube
+search (`ytsearch1:{artist} {title}`) that could otherwise have
+resolved a genuinely downloadable URL for these videos.
+
+Fix: resolve_video_url() now treats an imvdb.com/video/<id> placeholder
+the same as no stored URL at all, letting it fall through to the
+youtube_url check and then the live YouTube search -- giving these
+videos a real chance to resolve, not just a clearer failure.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.services.video_batch_service import resolve_video_url
+
+
+class TestResolveVideoUrlSkipsImvdbPlaceholder:
+    def test_imvdb_placeholder_does_not_short_circuit(self):
+        video = MagicMock(
+            url="https://imvdb.com/video/197047016632",
+            youtube_url=None,
+            artist=MagicMock(name="Ghost"),
+            title="Rats",
+        )
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="not found"
+            )
+            resolve_video_url(video, session, timeout=5)
+
+        mock_run.assert_called_once()
+
+    def test_imvdb_placeholder_falls_through_to_a_live_youtube_search_result(self):
+        video = MagicMock(
+            url="https://imvdb.com/video/197047016632",
+            youtube_url=None,
+            youtube_id=None,
+        )
+        video.artist.name = "Ghost"
+        video.title = "Rats"
+        session = MagicMock()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='{"webpage_url": "https://www.youtube.com/watch?v=xyz789", "id": "xyz789"}',
+                stderr="",
+            )
+            result = resolve_video_url(video, session, timeout=5)
+
+        assert result == "https://www.youtube.com/watch?v=xyz789"
+        assert video.url == "https://www.youtube.com/watch?v=xyz789"
+
+    def test_imvdb_placeholder_falls_through_to_youtube_url_before_searching(self):
+        video = MagicMock(
+            url="https://imvdb.com/video/197047016632",
+            youtube_url="https://youtube.com/watch?v=already-known-good-id",
+        )
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            result = resolve_video_url(video, session, timeout=5)
+
+        assert result == "https://youtube.com/watch?v=already-known-good-id"
+        mock_run.assert_not_called()
+
+    def test_a_real_downloadable_url_still_short_circuits(self):
+        # Not a regression on the common case: a genuine URL is still
+        # returned immediately, no subprocess call.
+        video = MagicMock(url="https://youtube.com/watch?v=abc123")
+        session = MagicMock()
+        with patch("subprocess.run") as mock_run:
+            result = resolve_video_url(video, session, timeout=5)
+
+        assert result == "https://youtube.com/watch?v=abc123"
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Live-reported

A batch of 4 auto-download attempts failed at the same instant, all with:

\`\`\`
No strategy available for URL: https://imvdb.com/video/<id>
\`\`\`

#459 already fixed this for the FastAPI dispatch paths
(\`_stored_video_url()\` in \`videos_downloads.py\`), but the **Celery/batch
auto-download path uses a completely separate URL resolver** —
\`video_batch_service.py\`'s \`resolve_video_url()\` — which wasn't touched by
that fix and has its own \`if video.url: return video.url\` short-circuit.

## This one is worth fixing properly, not just clearly

\`resolve_video_url()\` has its own, more capable fallback — a **live
YouTube search** (\`ytsearch1:{artist} {title}\`) — that never got a chance
to run, because the IMVDb placeholder is truthy and returned immediately
at the top of the function. IMVDb is never itself a download source —
only ever a metadata reference IMVDb-discovered videos fall back to when
it has no linked YouTube video.

## Fix

\`resolve_video_url()\` now treats an \`imvdb.com/video/<id>\` placeholder the
same as no stored URL at all, falling through to \`youtube_url\` and then
the live YouTube search — giving these videos a real chance to resolve a
genuine, downloadable URL instead of failing outright.

## Tests

4 new tests in \`test_resolve_video_url_skips_imvdb_placeholder.py\` (19/19
passing across related files): placeholder doesn't short-circuit
(subprocess IS called); falls through to a live YouTube search result and
updates \`video.url\`; falls through to \`youtube_url\` first, without
searching, when already present; a real downloadable URL still
short-circuits as before (no regression on the common case). \`black
--check\` / \`isort --check-only\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)