### PR TITLE
infra(#457): add py-spy for live stack-trace diagnosis of process hangs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,14 @@ COPY requirements.txt requirements-fastapi.txt ./
 # Install Python dependencies (both Flask/core and FastAPI)
 RUN pip install --no-cache-dir --timeout 120 -r requirements.txt -r requirements-fastapi.txt
 
+# py-spy (#457): a live process got fully unresponsive with no stack
+# trace to diagnose why -- this lets a running container's process be
+# sampled in place (`py-spy dump --pid <pid>`) without killing it.
+# Needs SYS_PTRACE (see docker-compose.dev.yml's cap_add) to attach to
+# another process in the same container. Small, inert unless invoked --
+# left in unconditionally rather than split into a dev-only image.
+RUN pip install --no-cache-dir py-spy
+
 # Copy application code
 COPY . .
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,6 +65,13 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    # #457: SYS_PTRACE lets py-spy attach to the fastapi/celery processes
+    # in this same container to sample a live stack trace
+    # (`py-spy dump --pid <pid>`) when something hangs, without killing
+    # it. Dev-only diagnostic capability -- not added to the prod compose
+    # file.
+    cap_add:
+      - SYS_PTRACE
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
       interval: 30s


### PR DESCRIPTION
## Why

Last time the FastAPI process froze completely (#457), there was no way to
see what it was actually blocked on — had to restart to restore service,
destroying the only chance to diagnose it, and file the issue on
correlation and guesswork alone.

## What

\`py-spy\` lets a running container's process be sampled in place
(\`py-spy dump --pid <pid>\`) without killing it, showing every thread's real
Python stack. Needs \`SYS_PTRACE\` to attach to another process in the same
container — added to \`docker-compose.dev.yml\` only (dev-only diagnostic
capability, not added to the prod compose file).

## Verified live

\`py-spy dump --pid <fastapi_pid>\` correctly shows the event loop thread
(idle, blocked on the Redis pubsub read for the WebSocket job-progress
system) and threadpool worker threads — confirms the tool and capability
are wired correctly.

Step 1 of the #457 investigation plan. Next: deliberately try to reproduce
the freeze with this armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)