### PR TITLE
fix(#457): offload blocking claim/dispatch calls off the shared event loop

### DIFF
--- a/src/api/fastapi/metube.py
+++ b/src/api/fastapi/metube.py
@@ -3,6 +3,7 @@ FastAPI MeTube/yt-dlp Integration Router
 Migrated from Flask src/api/metube.py - yt-dlp CLI API endpoints for video downloading
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -452,10 +453,17 @@ async def retry_download(
             f"Retrying {kind} {actual_id} for user {current_user.get('username')}"
         )
 
+        # #457: both of these are fully synchronous and can block on an
+        # InnoDB row lock inside claim_video_for_redownload() -- run on
+        # a worker thread, not the shared event loop, so a lock wait
+        # here degrades to a slow request instead of freezing the
+        # entire application (every route, including unrelated ones).
         if kind == "video":
-            result = ytdlp_service.retry_video_download(actual_id)
+            result = await asyncio.to_thread(
+                ytdlp_service.retry_video_download, actual_id
+            )
         else:
-            result = ytdlp_service.retry_download(actual_id)
+            result = await asyncio.to_thread(ytdlp_service.retry_download, actual_id)
 
         if not result.get("success"):
             raise HTTPException(status_code=400, detail=result)

--- a/src/api/fastapi/videos_downloads.py
+++ b/src/api/fastapi/videos_downloads.py
@@ -224,7 +224,11 @@ async def bulk_download_videos(
                 # DOWNLOADED too (#377).
                 original_status = video.status
 
-                if not claim_video_for_redownload(video_id):
+                # #457: synchronous, can block on an InnoDB row lock --
+                # run on a worker thread, not the shared event loop, so
+                # a lock wait degrades to a slow request instead of
+                # freezing the entire application.
+                if not await asyncio.to_thread(claim_video_for_redownload, video_id):
                     skipped_count += 1
                     continue
                 claimed = True
@@ -504,7 +508,11 @@ async def queue_video_download(
 
         from src.services.video_batch_service import claim_video_for_redownload
 
-        if not claim_video_for_redownload(video_id):
+        # #457: synchronous, can block on an InnoDB row lock -- run on a
+        # worker thread, not the shared event loop, so a lock wait
+        # degrades to a slow request instead of freezing the entire
+        # application.
+        if not await asyncio.to_thread(claim_video_for_redownload, video_id):
             # claim_video_for_redownload() returns False both when the
             # video genuinely lost a race to a concurrent claim AND when
             # the claim attempt itself errored (live-observed: a
@@ -805,7 +813,11 @@ async def queue_download_video(
 
         from src.services.video_batch_service import claim_video_for_redownload
 
-        if not claim_video_for_redownload(video_id):
+        # #457: synchronous, can block on an InnoDB row lock -- run on a
+        # worker thread, not the shared event loop, so a lock wait
+        # degrades to a slow request instead of freezing the entire
+        # application.
+        if not await asyncio.to_thread(claim_video_for_redownload, video_id):
             # See queue_video_download()'s identical comment above:
             # claim_video_for_redownload() returning False doesn't by
             # itself distinguish a genuine race loss from an unrelated
@@ -1031,7 +1043,11 @@ async def bulk_download_wanted_videos(
                 # select the same WANTED video; only one of them may win.
                 # A failed claim means another process already has it --
                 # a normal, healthy skip, not an error.
-                if not claim_video_for_download(video.id):
+                # #457: synchronous, can block on an InnoDB row lock --
+                # run on a worker thread, not the shared event loop, so
+                # a lock wait degrades to a slow request instead of
+                # freezing the entire application.
+                if not await asyncio.to_thread(claim_video_for_download, video.id):
                     skipped_count += 1
                     continue
 

--- a/tests/unit/test_bulk_download_by_ids_claims_before_dispatch.py
+++ b/tests/unit/test_bulk_download_by_ids_claims_before_dispatch.py
@@ -36,11 +36,14 @@ def _function_source(function_name: str) -> str:
 class TestBulkDownloadByIdsClaimsBeforeDispatch:
     def test_calls_claim_video_for_redownload(self):
         source = _function_source("bulk_download_videos")
-        assert "claim_video_for_redownload(" in source
+        assert "claim_video_for_redownload" in source
 
     def test_claim_is_called_before_dispatch(self):
         source = _function_source("bulk_download_videos")
-        claim_pos = source.index("claim_video_for_redownload(")
+        # Anchor on the actual call site (asyncio.to_thread(...)), not
+        # the earlier local `from ... import claim_video_for_redownload`
+        # statement, which also contains this substring.
+        claim_pos = source.index("asyncio.to_thread(claim_video_for_redownload")
         dispatch_pos = source.index("ytdlp_service.add_music_video_download(")
         assert claim_pos < dispatch_pos
 
@@ -54,7 +57,10 @@ class TestBulkDownloadByIdsClaimsBeforeDispatch:
         text, and before the Download row is constructed."""
         source = _function_source("bulk_download_videos")
         url_resolution_pos = source.index("resolved_url = await resolve_video_url(")
-        claim_pos = source.index("claim_video_for_redownload(")
+        # Anchor on the actual call site (asyncio.to_thread(...)), not
+        # the earlier local `from ... import claim_video_for_redownload`
+        # statement, which also contains this substring.
+        claim_pos = source.index("asyncio.to_thread(claim_video_for_redownload")
         download_row_pos = source.index("download = Download(")
         assert url_resolution_pos < claim_pos < download_row_pos
 
@@ -63,7 +69,10 @@ class TestBulkDownloadByIdsClaimsBeforeDispatch:
         # The claim-failure branch must `continue` rather than falling
         # through to dispatch -- assert the claim call is immediately
         # followed (within a small window) by a continue statement.
-        claim_pos = source.index("claim_video_for_redownload(")
+        # Anchor on the actual call site (asyncio.to_thread(...)), not
+        # the earlier local `from ... import claim_video_for_redownload`
+        # statement, which also contains this substring.
+        claim_pos = source.index("asyncio.to_thread(claim_video_for_redownload")
         window = source[claim_pos : claim_pos + 200]
         assert "continue" in window
 
@@ -97,7 +106,10 @@ class TestBulkDownloadRevertPath:
         of a hardcoded WANTED."""
         source = _function_source("bulk_download_videos")
         original_status_pos = source.index("original_status = video.status")
-        claim_pos = source.index("claim_video_for_redownload(")
+        # Anchor on the actual call site (asyncio.to_thread(...)), not
+        # the earlier local `from ... import claim_video_for_redownload`
+        # statement, which also contains this substring.
+        claim_pos = source.index("asyncio.to_thread(claim_video_for_redownload")
         assert original_status_pos < claim_pos
 
     def test_terminal_commit_moved_inside_loop_right_after_flush(self):
@@ -150,6 +162,8 @@ class TestBulkDownloadRevertPath:
         fails before ever attempting its own claim."""
         source = _function_source("bulk_download_videos")
         for_pos = source.index("for video in videos:")
-        claim_success_pos = source.index("claim_video_for_redownload(video_id):")
+        claim_success_pos = source.index(
+            "await asyncio.to_thread(claim_video_for_redownload, video_id):"
+        )
         between = source[for_pos:claim_success_pos]
         assert "claimed = False" in between

--- a/tests/unit/test_bulk_download_claims_before_dispatch.py
+++ b/tests/unit/test_bulk_download_claims_before_dispatch.py
@@ -31,13 +31,17 @@ class TestBulkDownloadClaimsBeforeDispatch:
 
     def test_claim_happens_before_the_dispatch_call(self):
         body = self._function_body("bulk_download_wanted_videos")
-        claim_index = body.index("claim_video_for_download(")
+        # Anchor on the actual call site (asyncio.to_thread(...), #457),
+        # not a later comment that also mentions this function by name.
+        claim_index = body.index("asyncio.to_thread(claim_video_for_download")
         dispatch_index = body.index("ytdlp_service.add_music_video_download(")
         assert claim_index < dispatch_index
 
     def test_a_failed_claim_increments_skipped_not_errors(self):
         body = self._function_body("bulk_download_wanted_videos")
-        claim_index = body.index("claim_video_for_download(")
+        # Anchor on the actual call site (asyncio.to_thread(...), #457),
+        # not a later comment that also mentions this function by name.
+        claim_index = body.index("asyncio.to_thread(claim_video_for_download")
         # The nearest "if not <claim result>:" branch after the claim call
         # should touch skipped_count, not errors.append, within a small
         # window (the immediate handling of a failed claim).

--- a/tests/unit/test_bulk_download_response_includes_success_key.py
+++ b/tests/unit/test_bulk_download_response_includes_success_key.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from src.api.fastapi.videos_downloads import bulk_download_videos
 from src.api.fastapi.videos_models import BulkDownloadRequest
@@ -71,7 +72,16 @@ class TestBulkDownloadVideosResponseHasSuccessKey:
 
 @pytest.fixture
 def session_factory():
-    engine = create_engine("sqlite:///:memory:")
+    # #457: claim_video_for_redownload() now runs via asyncio.to_thread()
+    # -- a real, different OS thread. StaticPool + check_same_thread=False
+    # keeps the in-memory SQLite database visible across that thread hop
+    # (see test_download_dispatch_claim_and_revert_behavioral.py for the
+    # full explanation).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(
         engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
     )

--- a/tests/unit/test_download_dispatch_claim_and_revert_behavioral.py
+++ b/tests/unit/test_download_dispatch_claim_and_revert_behavioral.py
@@ -33,6 +33,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from src.api.fastapi.videos_downloads import (
     bulk_download_videos,
@@ -46,7 +47,20 @@ from src.database.models import Artist, Download, Video, VideoStatus
 
 @pytest.fixture
 def session_factory():
-    engine = create_engine("sqlite:///:memory:")
+    # #457: claim_video_for_redownload()/claim_video_for_download() now
+    # run via asyncio.to_thread() -- a real, different OS thread. Plain
+    # `sqlite:///:memory:` uses SQLAlchemy's SingletonThreadPool, which
+    # hands a *different*, empty in-memory database to any thread other
+    # than the one that created the engine. StaticPool forces every
+    # connection (any thread) to share the single underlying DBAPI
+    # connection, and check_same_thread=False lifts SQLite's own same-
+    # thread guard (safe here: this fixture's usage is never truly
+    # concurrent, just cross-thread).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(
         engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
     )

--- a/tests/unit/test_queue_download_claims_before_staging_download_row.py
+++ b/tests/unit/test_queue_download_claims_before_staging_download_row.py
@@ -64,7 +64,9 @@ class TestQueueDownloadVideoClaimsBeforeStagingDownloadRow:
 
     def test_claims_the_video_before_adding_the_download_row(self):
         source = _function_source(self.FUNCTION_NAME)
-        claim_pos = source.index("claim_video_for_redownload(video_id)")
+        claim_pos = source.index(
+            "asyncio.to_thread(claim_video_for_redownload, video_id)"
+        )
         add_pos = source.index("session.add(download)")
         assert claim_pos < add_pos, (
             "session.add(download) must not run before "
@@ -87,7 +89,9 @@ class TestQueueVideoDownloadClaimsBeforeStagingDownloadRow:
 
     def test_claims_the_video_before_adding_the_download_row(self):
         source = _function_source(self.FUNCTION_NAME)
-        claim_pos = source.index("claim_video_for_redownload(video_id)")
+        claim_pos = source.index(
+            "asyncio.to_thread(claim_video_for_redownload, video_id)"
+        )
         add_pos = source.index("session.add(download)")
         assert claim_pos < add_pos, (
             "session.add(download) must not run before "

--- a/tests/unit/test_retry_download_route_offloads_to_thread.py
+++ b/tests/unit/test_retry_download_route_offloads_to_thread.py
@@ -1,0 +1,65 @@
+"""#457: the FastAPI process froze completely (all routes, including
+totally unrelated ones and the health check) after two overlapping
+download requests for the same video. Root cause, found via code
+audit: metube.py's `async def retry_download()` called the fully
+synchronous `ytdlp_service.retry_download()`/`retry_video_download()`
+directly, with no `await`/threadpool offload. Those methods open a DB
+session and call `claim_video_for_redownload()`, which runs a row-
+locking `UPDATE ... WHERE status='WANTED'` on its own raw connection.
+If that has to wait on an InnoDB row lock (any two requests touching
+the same video's row close together), the wait runs synchronously on
+the single asyncio event loop thread -- freezing the *entire
+application*, not just the one request, for up to
+innodb_lock_wait_timeout (~50s default). Multiple overlapping requests
+stack this into a multi-minute outage.
+
+Fix: the route now awaits `asyncio.to_thread(...)`, moving the
+blocking call onto a worker thread. A lock wait there still slows that
+one request, but no longer blocks every other request in the
+application.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from src.api.fastapi.metube import retry_download
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestRetryDownloadOffloadsToAThread:
+    def test_video_kind_offloads_retry_video_download_to_a_thread(self):
+        with patch("src.api.fastapi.metube.ytdlp_service") as mock_service, patch(
+            "src.api.fastapi.metube.asyncio.to_thread"
+        ) as mock_to_thread:
+            mock_to_thread.return_value = {"success": True}
+
+            _run(
+                retry_download(
+                    "video_5",
+                    current_user={"user_id": 1, "username": "mike"},
+                    session=MagicMock(),
+                )
+            )
+
+        mock_to_thread.assert_called_once_with(mock_service.retry_video_download, 5)
+        mock_service.retry_video_download.assert_not_called()
+
+    def test_download_kind_offloads_retry_download_to_a_thread(self):
+        with patch("src.api.fastapi.metube.ytdlp_service") as mock_service, patch(
+            "src.api.fastapi.metube.asyncio.to_thread"
+        ) as mock_to_thread:
+            mock_to_thread.return_value = {"success": True}
+
+            _run(
+                retry_download(
+                    "42",
+                    current_user={"user_id": 1, "username": "mike"},
+                    session=MagicMock(),
+                )
+            )
+
+        mock_to_thread.assert_called_once_with(mock_service.retry_download, 42)
+        mock_service.retry_download.assert_not_called()

--- a/tests/unit/test_single_video_download_reverts_on_falsy_result.py
+++ b/tests/unit/test_single_video_download_reverts_on_falsy_result.py
@@ -29,6 +29,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from src.api.fastapi.videos_downloads import (
     queue_download_video,
@@ -40,7 +41,16 @@ from src.database.models import Artist, Download, Video, VideoStatus
 
 @pytest.fixture
 def session_factory():
-    engine = create_engine("sqlite:///:memory:")
+    # #457: claim_video_for_redownload() now runs via asyncio.to_thread()
+    # -- a real, different OS thread. StaticPool + check_same_thread=False
+    # keeps the in-memory SQLite database visible across that thread hop
+    # (see test_download_dispatch_claim_and_revert_behavioral.py for the
+    # full explanation).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(
         engine, tables=[Artist.__table__, Video.__table__, Download.__table__]
     )


### PR DESCRIPTION
## Root cause (#457), found via code audit

Every download-dispatch route in \`metube.py\` and \`videos_downloads.py\` is
declared \`async def\` but called the fully synchronous
\`claim_video_for_redownload()\` / \`claim_video_for_download()\` /
\`ytdlp_service.retry_download()\` / \`retry_video_download()\` directly, with
no \`await\`/threadpool offload. Those functions open their own raw DB
connection and run a row-locking \`UPDATE ... WHERE status='WANTED'\`.

If that \`UPDATE\` ever has to wait on an InnoDB row lock — which happens
naturally when two requests touch the same video's row close together —
the wait runs synchronously on the **single** asyncio event loop thread
that serves the **entire application**. One blocked call freezes every
other request, the health check, and WebSocket connections, not just the
request that triggered it. Multiple overlapping requests stack this into
an outage lasting minutes, matching what was observed in #457.

(One of the existing static-assertion test files' docstrings already
documents an earlier capture of this exact incident class hitting a
reverse proxy's 504 gateway timeout before the DB's own 50s lock timeout
could even return — this bug class has bitten this codebase before.)

## Fix

Wrap each blocking claim call in \`await asyncio.to_thread(...)\`.
\`claim_video_for_redownload()\`/\`claim_video_for_download()\` both use their
own separate raw connection already (not the request's session), so this
is safe — no cross-thread session sharing. A lock wait now blocks one
worker thread instead of the shared event loop, degrading to a single
slow request instead of freezing the whole application.

**Call sites fixed:**
- \`metube.py\`: \`retry_download()\` (both branches) — the exact function in the original incident
- \`videos_downloads.py\`: \`bulk_download_videos()\`, \`queue_video_download()\`, \`queue_download_video()\`, \`bulk_download_wanted_videos()\`

## Tests

New: \`test_retry_download_route_offloads_to_thread.py\` proves the route
offloads via \`asyncio.to_thread\` rather than calling the service methods
directly.

Updated existing tests to match:
- 4 static source-assertion files anchored on \`"claim_video_for_redownload("\`
  to locate the call site — now anchor on \`"asyncio.to_thread(claim_video_for_redownload"\`
  (trailing paren no longer follows the name; the bare name alone also
  matches an earlier \`from ... import\` line)
- 3 behavioral test files using a real SQLite \`:memory:\` engine: added
  \`poolclass=StaticPool\` + \`connect_args={"check_same_thread": False}\`.
  Plain \`sqlite:///:memory:\` uses SQLAlchemy's \`SingletonThreadPool\`, which
  hands a *different*, empty in-memory database to any thread other than
  the one that created the engine — exactly the thread \`asyncio.to_thread\`
  now introduces. \`StaticPool\` shares the single underlying DBAPI
  connection across threads instead.

All 43 tests across the 9 touched/added files pass; full \`tests/unit/\`
suite: 735 passed (2 pre-existing failures in \`test_mobile_access_auth.py\`,
confirmed via \`git log\` to predate this change entirely and be unrelated).

Related: #457 (py-spy infra from #462 also part of this investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)