### PR TITLE
fix(#464): revert accidental auth requirement on PWA manifest route

### DIFF
--- a/src/api/fastapi/mobile_access.py
+++ b/src/api/fastapi/mobile_access.py
@@ -824,10 +824,17 @@ async def get_mobile_app_interface(
 
 
 @mobile_router.get("/manifest.json")
-async def get_mobile_app_manifest(
-    current_user: dict = Depends(require_authentication),
-):
-    """Get Progressive Web App manifest"""
+async def get_mobile_app_manifest():
+    """Get Progressive Web App manifest.
+
+    Deliberately public (#464): a PWA manifest is conventionally fetched
+    by the browser/installer *before* any user session exists -- that's
+    the whole point of a web app manifest (enables "Add to Home Screen"
+    / installability prompts). Requiring auth here breaks that: a
+    browser can't present an install prompt for a resource it can't
+    fetch without already being logged in. Contains no sensitive data,
+    just the app's own static name/icons/theme.
+    """
     manifest = {
         "name": "MVidarr Mobile",
         "short_name": "MVidarr",


### PR DESCRIPTION
## Bug

\`get_mobile_app_manifest()\` (\`/mobile/manifest.json\`) required
\`Depends(require_authentication)\`, returning 401 for an unauthenticated
request. Introduced by an earlier commit (\`be3957fe\`, #392 Phase 2
follow-up) auditing for routes leaking data without auth — but a static
manifest describing the app's own name/icons/theme isn't sensitive, and
gating it breaks a real feature.

## Why this matters

A PWA manifest is conventionally fetched by the browser/installer
**before** any user session exists — that's the whole point, it enables
"Add to Home Screen" / installability prompts. A browser can't present an
install prompt for a resource it can't fetch without already being
logged in.

## Fix

Removed the auth dependency from this one route.
\`test_mobile_access_auth.py\` already documented and asserted the correct,
intended behavior (manifest deliberately public, every other route
authenticated) — the earlier commit broke it without those tests being
run/noticed. No test changes needed, just the route fix.

## Tests

All 5 tests in \`test_mobile_access_auth.py\` pass. \`black --check\` /
\`isort --check-only\` clean.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)