### PR TITLE
revert(#464): re-add auth to mobile manifest route -- was never a regression

### DIFF
--- a/src/api/fastapi/mobile_access.py
+++ b/src/api/fastapi/mobile_access.py
@@ -824,16 +824,26 @@ async def get_mobile_app_interface(
 
 
 @mobile_router.get("/manifest.json")
-async def get_mobile_app_manifest():
+async def get_mobile_app_manifest(
+    current_user: dict = Depends(require_authentication),
+):
     """Get Progressive Web App manifest.
 
-    Deliberately public (#464): a PWA manifest is conventionally fetched
-    by the browser/installer *before* any user session exists -- that's
-    the whole point of a web app manifest (enables "Add to Home Screen"
-    / installability prompts). Requiring auth here breaks that: a
-    browser can't present an install prompt for a resource it can't
-    fetch without already being logged in. Contains no sensitive data,
-    just the app's own static name/icons/theme.
+    Requires authentication (#392 Phase 2 follow-up, be3957fe): the
+    only page that links to this manifest is get_mobile_app_interface's
+    own HTML (<link rel="manifest" href="/mobile/manifest.json">), and
+    that page (GET /mobile/app) is itself already
+    require_authentication-gated. Browsers include same-origin cookies
+    for <link rel="manifest"> fetches, so gating the manifest itself
+    doesn't break anything for an already-logged-in user, and there's
+    no other, unauthenticated consumer of this specific route.
+
+    #464 previously "fixed" this back to public, mischaracterizing this
+    deliberate decision as an accidental regression -- it wasn't; it
+    was a later, considered decision that #464 simply didn't find (only
+    one of the two relevant test files was checked at the time). Every
+    other route in this file already requires authentication; this one
+    matches.
     """
     manifest = {
         "name": "MVidarr Mobile",

--- a/tests/unit/test_mobile_access_auth.py
+++ b/tests/unit/test_mobile_access_auth.py
@@ -2,11 +2,17 @@
 unauthenticated -- most handlers are inert stubs (hardcoded sample data),
 but POST /register-device is real: it calls
 network_share.set_device_access_level(...), genuinely granting network
-streaming access to the caller's IP. All non-stub AND stub routes get
+streaming access to the caller's IP. All routes in this file get
 require_authentication uniformly (cheap now, prevents a repeat of this bug
 class if a stub gets filled in later without anyone re-checking auth) --
-EXCEPT GET /manifest.json, deliberately left public (PWA manifest,
-no sensitive data, commonly fetched without credentials by browsers).
+including GET /manifest.json (added later, #392 Phase 2 follow-up,
+be3957fe): see test_mobile_access_manifest_auth.py for the reasoning
+and the more thorough reflection-based coverage of that route
+specifically. A same-session PR (#464/#465) briefly, incorrectly
+"fixed" the manifest back to public, mischaracterizing that deliberate
+decision as an accidental regression -- reverted once the conflicting
+test file (this session simply hadn't found it yet) surfaced the real
+history.
 """
 
 import ast
@@ -45,6 +51,7 @@ EXPECTED_AUTHENTICATED_ROUTES = [
     "get_mobile_playlist_videos",
     "get_mobile_app_interface",
     "register_mobile_device",
+    "get_mobile_app_manifest",
 ]
 
 
@@ -68,10 +75,6 @@ class TestMobileAccessAllRoutesAuthenticated:
                 "Depends(require_authentication)" in source
             ), f"{function_name} should use Depends(require_authentication), got:\n{source}"
 
-    def test_manifest_route_deliberately_left_unauthenticated(self):
-        source = _function_source("get_mobile_app_manifest")
-        assert "Depends(require_authentication)" not in source
-
 
 class TestMobileAccessBehavioralAuth:
     def test_register_device_401s_without_session(self):
@@ -80,13 +83,6 @@ class TestMobileAccessBehavioralAuth:
         client = TestClient(app)
         response = client.post("/mobile/register-device", json={"device_name": "x"})
         assert response.status_code == 401
-
-    def test_manifest_succeeds_without_session(self):
-        app = FastAPI()
-        app.include_router(mobile_router)
-        client = TestClient(app)
-        response = client.get("/mobile/manifest.json")
-        assert response.status_code != 401
 
     def test_register_device_succeeds_for_authenticated_session(self):
         app = FastAPI()


### PR DESCRIPTION
## I got this wrong earlier today

PR #465 ("revert accidental auth requirement on PWA manifest route") was
wrong. I found \`test_mobile_access_auth.py\`'s two failing assertions
(manifest "deliberately left unauthenticated") and concluded the auth
requirement was an accidental regression from an unrelated #392 sweep —
without searching for other tests covering the same route.

A second test file, \`tests/unit/test_mobile_access_manifest_auth.py\`, was
sitting right next to it the whole time. It was added by a **later**,
deliberate commit (\`be3957fe\`, 2026-08-23) that explicitly audited every
\`mobile_access.py\` route and added auth to the manifest with real
reasoning: the only page that links to it (\`GET /mobile/app\`) is itself
already \`require_authentication\`-gated, and browsers include same-origin
cookies for \`<link rel="manifest">\` fetches, so gating it breaks nothing
for an already-logged-in user — there's no other, unauthenticated
consumer of this specific route.

That was the correct, considered, most recent decision. PR #465 reverted
it based on incomplete investigation and shipped the actual regression.

Caught by running the full test suite after unrelated work and seeing
\`test_mobile_access_manifest_auth.py\`'s 3 tests fail against my own
change from earlier today — not caught before merging #465 because I
only ran the one test file I'd found at the time.

## Fix

Re-added \`Depends(require_authentication)\` to \`get_mobile_app_manifest()\`.
Updated \`test_mobile_access_auth.py\` to match (added
\`get_mobile_app_manifest\` to its authenticated-routes list, removed its
two now-incorrect "deliberately left public" tests and the docstring
claim) rather than leaving two test files asserting opposite things about
the same route.

## Tests

Both \`test_mobile_access_auth.py\` and \`test_mobile_access_manifest_auth.py\`
now agree — 7/7 passing. \`black\`/\`isort\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)