### PR TITLE
fix(dashboard): surface Download-All-Wanted failure reasons even when zero videos succeed

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -505,42 +505,44 @@ function proceedDownloadWantedVideos() {
         if (data.success) {
             if (data.success_count > 0) {
                 showSuccess(`Successfully queued ${data.success_count} wanted videos for download!`);
-                
-                // Show detailed results if there were failures
-                if (data.failed_count > 0) {
-                    // Categorize failures for better user feedback
-                    const failures = data.results.filter(r => !r.success);
-                    const failureTypes = {};
-                    
-                    failures.forEach(failure => {
-                        const error = failure.error || 'Unknown error';
-                        if (error.includes('malformed')) {
-                            failureTypes['Malformed titles'] = (failureTypes['Malformed titles'] || 0) + 1;
-                        } else if (error.includes('age-restricted')) {
-                            failureTypes['Age-restricted content'] = (failureTypes['Age-restricted content'] || 0) + 1;
-                        } else if (error.includes('No URL available')) {
-                            failureTypes['No URLs found'] = (failureTypes['No URLs found'] || 0) + 1;
-                        } else {
-                            failureTypes['Other errors'] = (failureTypes['Other errors'] || 0) + 1;
-                        }
-                    });
-                    
-                    // Build detailed error message
-                    let errorDetails = `${data.failed_count} videos could not be downloaded:\n`;
-                    for (const [type, count] of Object.entries(failureTypes)) {
-                        errorDetails += `• ${type}: ${count}\n`;
-                    }
-                    errorDetails += '\nTip: Check video titles for cleanup, or manually search for age-restricted content.';
-                    
-                    setTimeout(() => {
-                        showError(errorDetails);
-                        console.log('Failed downloads details:', failures);
-                    }, 2000);
-                }
             } else {
                 showSuccess(data.message || 'No wanted videos found to download');
             }
-            
+
+            // Show detailed results if there were failures, regardless of
+            // whether any videos also succeeded -- otherwise a batch where
+            // every video fails (success_count === 0) never explains why.
+            if (data.failed_count > 0) {
+                // Categorize failures for better user feedback
+                const failures = data.results.filter(r => !r.success);
+                const failureTypes = {};
+
+                failures.forEach(failure => {
+                    const error = failure.error || 'Unknown error';
+                    if (error.includes('malformed')) {
+                        failureTypes['Malformed titles'] = (failureTypes['Malformed titles'] || 0) + 1;
+                    } else if (error.includes('age-restricted')) {
+                        failureTypes['Age-restricted content'] = (failureTypes['Age-restricted content'] || 0) + 1;
+                    } else if (error.includes('No URL available')) {
+                        failureTypes['No URLs found'] = (failureTypes['No URLs found'] || 0) + 1;
+                    } else {
+                        failureTypes['Other errors'] = (failureTypes['Other errors'] || 0) + 1;
+                    }
+                });
+
+                // Build detailed error message
+                let errorDetails = `${data.failed_count} videos could not be downloaded:\n`;
+                for (const [type, count] of Object.entries(failureTypes)) {
+                    errorDetails += `• ${type}: ${count}\n`;
+                }
+                errorDetails += '\nTip: Check video titles for cleanup, or manually search for age-restricted content.';
+
+                setTimeout(() => {
+                    showError(errorDetails);
+                    console.log('Failed downloads details:', failures);
+                }, 2000);
+            }
+
             // Refresh dashboard data
             loadDownloadQueue();
             loadDownloadHistory();

--- a/tests/unit/test_dashboard_download_wanted_surfaces_errors.py
+++ b/tests/unit/test_dashboard_download_wanted_surfaces_errors.py
@@ -1,0 +1,69 @@
+"""Live-reported: clicking "Download All Wanted" on the dashboard did
+nothing useful when at least one WANTED video existed but had no
+downloadable URL. Verified live: the backend
+(bulk_download_wanted_videos()) correctly identifies this and reports
+it -- success_count: 0, failed_count: 1,
+errors: ["Video 229 (Ghost - Lachryma): No URL available"] -- the
+backend was never broken.
+
+Root cause: frontend/templates/index.html's proceedDownloadWantedVideos()
+nested its entire failure-detail block (categorizing errors, showing
+"N videos could not be downloaded: ...") INSIDE
+`if (data.success_count > 0) { ... }`. When every wanted video fails
+(the exact case here: one WANTED video, zero successes), that whole
+branch is skipped, so the user only ever sees the bland
+"Queued 0 wanted videos for download" with no indication why or what
+to do about it -- indistinguishable from the button silently doing
+nothing, even though the backend response already contained the real
+reason.
+
+Fix: the failure-detail block now runs whenever failed_count > 0,
+regardless of whether success_count is also > 0 (siblings, not nested).
+"""
+
+from pathlib import Path
+
+TEMPLATE_PATH = (
+    Path(__file__).parent.parent.parent / "frontend" / "templates" / "index.html"
+)
+
+
+def _function_source() -> str:
+    text = TEMPLATE_PATH.read_text()
+    start = text.index("function proceedDownloadWantedVideos()")
+    # Next top-level `function ` declaration after this one marks the end.
+    next_fn = text.index("\nfunction ", start + 10)
+    return text[start:next_fn]
+
+
+class TestDownloadWantedSurfacesFailuresEvenWithZeroSuccesses:
+    def test_failed_count_check_is_not_nested_inside_success_count_check(self):
+        source = _function_source()
+
+        success_count_if = source.index("if (data.success_count > 0)")
+        failed_count_if = source.index("if (data.failed_count > 0)")
+
+        # Find the closing brace of the `if (data.success_count > 0) {`
+        # block by brace-matching from its opening brace.
+        open_brace = source.index("{", success_count_if)
+        depth = 0
+        close_brace = None
+        for i, ch in enumerate(source[open_brace:], start=open_brace):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    close_brace = i
+                    break
+        assert close_brace is not None, "could not find matching brace"
+
+        assert failed_count_if > close_brace, (
+            "the failed_count > 0 error-detail block must not be nested "
+            "inside success_count > 0 -- otherwise a batch where every "
+            "video fails (success_count == 0) never shows the user why"
+        )
+
+    def test_still_shows_a_message_when_there_are_zero_successes(self):
+        source = _function_source()
+        assert "data.message" in source


### PR DESCRIPTION
## Problem
Live-reported: "'Download all Wanted' button on dashboard is not picking up any videos when at least one is set to wanted."

## Root cause
Backend (`bulk_download_wanted_videos()`) was working correctly the whole time — for a WANTED video whose only URL is an IMVDb placeholder (no linked YouTube source), it correctly reports `success_count: 0`, `failed_count: 1`, with a real reason in `data.errors`/`data.results` (`"No URL available"`).

The bug was frontend-only: `proceedDownloadWantedVideos()` in `index.html` nested its entire failure-detail block (categorizing errors, building a "N videos could not be downloaded: ..." message) **inside** `if (data.success_count > 0)`. When every wanted video fails (success_count stays 0), that whole branch never runs — the user only ever sees the bland "Queued 0 wanted videos for download", indistinguishable from the button silently doing nothing.

## Fix
The `failed_count > 0` detail block is now a sibling of the `success_count > 0`/`else` check, not nested inside it, so real failure reasons surface regardless of whether any videos also succeeded.

## Testing
Added a static source-assertion test (`test_dashboard_download_wanted_surfaces_errors.py`) — embedded JS in a Jinja template can't be unit-tested directly, so it brace-matches the `success_count > 0` block and asserts `failed_count > 0` isn't nested inside it. Verified RED against the old structure, GREEN after the fix.

Requires a full `frontend/` rebuild on deploy (not bind-mounted in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)