### PR TITLE
fix(dashboard): don't show a false success toast when every wanted video fails

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -505,7 +505,11 @@ function proceedDownloadWantedVideos() {
         if (data.success) {
             if (data.success_count > 0) {
                 showSuccess(`Successfully queued ${data.success_count} wanted videos for download!`);
-            } else {
+            } else if (data.failed_count === 0) {
+                // Only show this as a success toast when there were no
+                // failures either -- an all-failed batch (success_count
+                // === 0, failed_count > 0) must not get a false "success"
+                // notification; the error toast below is its only signal.
                 showSuccess(data.message || 'No wanted videos found to download');
             }
 

--- a/tests/unit/test_dashboard_download_wanted_no_false_success_toast.py
+++ b/tests/unit/test_dashboard_download_wanted_no_false_success_toast.py
@@ -1,0 +1,64 @@
+"""Follow-up to PR #476 (test_dashboard_download_wanted_surfaces_errors.py),
+found by code review of that fix.
+
+That PR made the failure-detail block run regardless of success_count, so
+the real failure reason ("No URL available") does surface -- but as a
+second, delayed (2s) error toast. Before it appears, the code still
+unconditionally calls showSuccess() when success_count is 0: it falls into
+the `else { showSuccess(data.message || ...) }` branch, showing a green
+"success"-styled toast for a batch that was 100% failures. The user's
+first signal for an all-failed batch was a false "success" notification --
+the same misleading-UX class the earlier fix was written to close, just not
+fully closed.
+
+Fix: only show the "no wanted videos" success toast when there were no
+failures either (success_count === 0 AND failed_count === 0). When
+success_count === 0 but failed_count > 0, skip the success toast entirely --
+the error toast (with the real reason) is the only signal the user gets.
+"""
+
+from pathlib import Path
+
+TEMPLATE_PATH = (
+    Path(__file__).parent.parent.parent / "frontend" / "templates" / "index.html"
+)
+
+
+def _function_source() -> str:
+    text = TEMPLATE_PATH.read_text()
+    start = text.index("function proceedDownloadWantedVideos()")
+    next_fn = text.index("\nfunction ", start + 10)
+    return text[start:next_fn]
+
+
+class TestNoFalseSuccessToastWhenBatchEntirelyFails:
+    def test_the_zero_successes_message_branch_is_guarded_by_failed_count(self):
+        source = _function_source()
+
+        # The "no wanted videos" success toast must not fire unconditionally
+        # whenever success_count is 0 -- it must also check that there were
+        # no failures, otherwise an all-failed batch shows a false "success"
+        # toast before the real error appears 2s later.
+        message_call = source.index("showSuccess(data.message")
+
+        # Walk backwards from the showSuccess(data.message call to its
+        # nearest guarding `if`/`else if` condition and confirm it checks
+        # failed_count, not just success_count.
+        preceding = source[:message_call]
+        last_else_if = preceding.rfind("else if")
+        last_bare_else = preceding.rfind("else {")
+
+        assert last_else_if != -1 and last_else_if > last_bare_else, (
+            "showSuccess(data.message...) must be reached through an "
+            "`else if` that also checks data.failed_count, not a bare "
+            "`else` that fires whenever success_count is 0 regardless of "
+            "failures"
+        )
+
+        guard = source[last_else_if : message_call + 1]
+        assert "failed_count" in guard, (
+            "the guard reaching showSuccess(data.message...) must "
+            "reference data.failed_count, so an all-failed batch "
+            "(success_count == 0, failed_count > 0) does not get a false "
+            "success toast"
+        )


### PR DESCRIPTION
## Problem
Follow-up to PR #476, found by the automated code review of that fix.

PR #476 made the failure-detail block run regardless of `success_count`, so the real failure reason ("No URL available") does surface — but only as a second, delayed (2s) error toast. Before it appears, the code still unconditionally called `showSuccess()` whenever `success_count` was 0, via a bare `else { showSuccess(data.message || ...) }`. For an all-failed batch (`success_count: 0`, `failed_count: 1+`), that message is "Queued 0 wanted videos for download" — a truthy string routed through a green "success"-styled toast. The user's first signal for a 100%-failed batch was a **false success notification**, the same misleading-UX class the earlier fix was written to close, just not fully closed.

## Fix
Only show the "no wanted videos" success toast when there were also no failures (`success_count === 0 && failed_count === 0`). When `success_count === 0` but `failed_count > 0`, skip the success toast entirely — the error toast with the real reason is the only signal.

## Testing
Added a static source-assertion test (`test_dashboard_download_wanted_no_false_success_toast.py`) confirming the `showSuccess(data.message...)` call is reached through a guard that checks `failed_count`, not an unconditional `else`. Verified RED against the pre-fix structure, GREEN after.

Requires a full `frontend/` rebuild on deploy (not bind-mounted in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)