### PR TITLE
release: v1.0.0 — auth rewrite, RBAC enforcement, OAuth/2FA, security sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-# Environment variables
+# Environment variables (any .env.* variant holds real secrets - only
+# the checked-in .example/.template files should ever be tracked)
 .env
-.env.local
-.env.production
+.env.*
+!.env.example
+!.env.*.example
+!.env.*.template
 
 # Database
 data/mvidarr.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,202 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
   If this returns any rows, resolve them first (e.g. keep the oldest row per `youtube_id` and null out the others) before upgrading -- the migration's own error message includes the exact remediation SQL.
 
+## [1.0.0] - 2026-08-17
+
+First production-ready release. Gated on (per the v1.0.0 GitHub milestone): RBAC actually enforced, a working/modern login page (OAuth reachable, no dead placeholder), and auth-path test coverage — all closed. See GitHub milestone "v1.0.0" for the complete issue list.
+
+### Added
+- OAuth login (Authentik, Google, GitHub) alongside password auth, with a signup allowlist and admin-only new-account policy
+- Two-Factor Authentication (TOTP + backup codes) and a password reset flow
+- Native Discord and Apprise notification providers, wired to real download/artist activity (not just a manual test endpoint)
+- "Recently Found" videos view (#316) — one-click view on the Videos page showing all videos sorted by `date_added` desc regardless of status, via a new button plus a shareable deep-link URL (`?sort_by=date_added&sort_order=desc&status=`)
+- Live artist thumbnail sourcing (Spotify/Last.fm tried before Wikipedia)
+- Login page redesign: paired rotating background/logo art, real OAuth provider buttons, scrollable card, fixed logo panel width
+
+### Security
+- Real RBAC enforcement — role checks were previously decorative; every session was hardcoded to admin
+- Fixed a privilege-escalation bug in Authentik group-role mapping
+- Rolling security dependency updates absorbed ahead of release, matching the fixes independently released on `main` as v0.12.20–v0.12.24: aiohttp 3.14.3 (CVE-2026-69244, CVE-2026-69243, CVE-2026-59881), lxml 6.1.1 (GHSA-4jhm-jv67-739f, CVE-2025-7424, CVE-2025-11731), aiomysql (GHSA-r397-ff8c-wv2g)
+
+### Fixed
+- **Duplicate concurrent download dispatch race (#329)**: `bulk_download_wanted_videos()` (FastAPI) and `download_all_wanted_videos_internal()` (Celery) could both dispatch the same WANTED video, with the loser silently overwriting the winner's result — including overwriting a real successful download back to FAILED — and firing a false download-failed webhook. Fixed via a new atomic `claim_video_for_download()` helper (row-locked `UPDATE ... WHERE status='WANTED'`) plus a defensive already-DOWNLOADED guard (which had shipped as dead code due to an enum-vs-string `.value` comparison bug, caught and fixed in final review) that also suppresses the false webhook
+- "Stop Download" 400 error — queue ids from videos are now unambiguously tagged (`video_123`) and routed to the right table instead of always being looked up as a `Download` row
+- "Force Clear All" now also resets orphaned stuck videos with no backing `Download` row
+- Misleading "no stuck downloads found" message — backend now returns the real cleared count
+- Numerous live-testing fixes: 2FA audit logging, OAuth callback error handling, Videos-page pagination dropping active filters, webhook URL credential logging, header username display, Edit Webhook modal scroll
+
+## [0.12.19] - 2026-07-16
+
+Core fix contributed by **@Ktell123** in [#282](https://github.com/prefect421/mvidarr/pull/282) — thank you!
+
+### Fixed
+- **Anti-detection setting ignored**: `enable_aggressive_anti_detection` was read with `settings.get()`, which returns the string `'False'` — truthy in Python — forcing AGGRESSIVE anti-detection (and the Android YouTube client) on every download and capping quality at ~360p. Now uses `settings.get_bool()`.
+- **Dead YouTube URL recovery**: when a stored YouTube URL is private, unavailable, or terminated, MVidarr now searches for an official alternate upload, persists the new URL, and retries the download once.
+- **Retry file-preservation bug** (found in code review): the low-res retry logic deleted the original download's file before confirming the retry actually succeeded or was better, so a failed or worse retry could report success while pointing at a deleted file. Fixed, with 16 new unit tests covering the retry paths.
+
+### Changed
+- **Player client priority**: prefer `web,mweb,tv` YouTube clients over android-first clients that hide adaptive HD/4K formats
+- **Format selection**: yt-dlp Node JS runtime + resolution-first format sort (`-S res,br`), improved `best` format string, and an automatic MODERATE retry when an escalated (AGGRESSIVE/STEALTH) download still lands at ≤360p
+
+## [0.12.18] - 2026-07-05
+
+All clear — zero CVEs, zero Dependabot security alerts, zero code scanning alerts.
+
+### Changed
+- fastapi 0.138.1 → 0.139.0, Pillow 12.2.0 → 12.3.0, opencv-python-headless >=4.13.0.92 → >=5.0.0.93
+- click 8.1.7 → 8.4.2, tqdm 4.66.3 → 4.68.3, ruby/setup-ruby 1.314.0 → 1.315.0
+
+### Fixed
+- release.yml now tolerates pre-existing release tags (skips create if already exists)
+
+## [0.12.17] - 2026-06-27
+
+### Security
+- GHSA-4xgf-cpjx-pc3j (MEDIUM): pydantic-settings 2.14.1 → 2.14.2 — `NestedSecretsSettingsSource` symlink traversal — also fixed in requirements-fastapi.txt (pre-existing stale pin was silently downgrading httpx in Docker)
+
+### Changed
+- fastapi 0.136.3 → 0.138.1, alembic 1.18.4 → 1.18.5, httpx 0.25.2 → 0.28.1, python-slugify 8.0.1 → 8.0.4
+- mypy 1.7.1 → 2.1.0 (dev, major version — local dev tool only, not run in CI)
+- CI: actions/cache v5 → v6 (ESM migration), ruby/setup-ruby 1.313.0 → 1.314.0
+
+## [0.12.16] - 2026-06-19
+
+### Security
+- CVE-2026-53539 (HIGH, CVSS 7.5): python-multipart 0.0.27 → 0.0.32 — quadratic CPU DoS via semicolon separators
+- Dependabot #20 (MEDIUM, CVSS 6.1): bleach 6.1.0 → 6.4.0 — `formaction` URI scheme bypass
+- CVE-2026-53538/53537/45152 (LOW): python-multipart — parameter smuggling + buffer fixes
+- Dependabot #19 (LOW): bleach — Unicode >U+00A0 URI sanitization bypass
+
+### Changed
+- sentry-sdk 2.8.0 → 2.63.0 (FastAPI 0.137 compat fix), starlette floor >=1.2.1 → >=1.3.1
+- CI: actions/checkout v6 → v7 (8 active workflows; blocks unsafe fork PR checkout)
+
+## [0.12.15] - 2026-06-06
+
+### Security
+- CVE-2026-34993: aiohttp 3.13.4 → 3.14.0 — `CookieJar.load()` deserialization → arbitrary code execution (MEDIUM)
+- CVE-2026-47265: aiohttp 3.13.4 → 3.14.0 — per-request cookies leaked via cross-origin redirect (MEDIUM)
+
+### Changed
+- bcrypt 4.1.2 → 5.0.0 (breaking: passwords >72 bytes raise ValueError; guard added in auth service)
+- requests 2.33.0 → 2.34.2, alembic 1.13.1 → 1.18.4, zeroconf 0.149.7 → 0.149.16
+- CI: GitHub Actions Node 24 — docker/metadata-action@v6, upload-pages-artifact@v5, labeler@v6, label-actions@v5, lock-threads@v6
+
+## [0.12.14] - 2026-06-02
+
+### Security
+- PYSEC-2026-179/178/177/176/175: PyJWT 2.12.0 → 2.13.0 — HMAC algorithm confusion, detached JWS DoS, unbounded JWKS fetches (unauthenticated DoS), algorithm allow-list bypass via PyJWK, PyJWKClient SSRF via file://, ftp://, data://
+
+### Fixed
+- 3 stale Trivy code scanning alerts (zeroconf CVE-2026-47180/83/84) cleared via fresh scan
+
+## [0.12.13] - 2026-06-01
+
+### Fixed
+- **Video streaming 404 errors**: `find_relocated_video()` used `getattr()` returning `None`, silently ignoring `local_path`; path resolution now tries both CWD-relative and `BASE_DIR`-anchored paths for relative `local_path` values in Docker. Both `stream` and `stream-transcode` endpoints patched.
+
+## [0.12.12] - 2026-06-01
+
+### Changed
+- Python base image 3.12-slim → 3.14-slim (verified: netifaces, mysqlclient, moviepy compile cleanly)
+- aiofiles 23.2.1 → 25.1.0, starlette ≥1.2.1, python-dateutil 2.9.0.post0, werkzeug 3.1.8, PyYAML 6.0.3
+- CI: GitHub Actions upgraded to Node.js 24 — checkout@v6, login-action@v4, build-push-action@v7, github-script@v9, deploy-pages@v5
+
+## [0.12.11] - 2026-06-01
+
+### Security
+- CVE-2026-47180, CVE-2026-47183, CVE-2026-47184: zeroconf 0.132.2 → 0.149.7 — LAN-local DoS/OOM via mDNS flood
+- PYSEC-2026-161: starlette ≥1.0.1 — Host header injection / authentication bypass
+
+### Changed
+- fastapi 0.123.0 → 0.136.3 (required for starlette 1.x), pydantic 2.5.0 → 2.13.4, pydantic-settings 2.1.0 → 2.14.1
+- typing-inspection ≥0.4.2 (new fastapi 0.136.3 requirement)
+- CI: GitHub Actions v4 → Node.js 24 (checkout@v5, cache@v5, setup-python@v6, upload-artifact@v7, codecov@v6); fixed codecov `file:` → `files:` input rename
+- Incorporates Dependabot PR #213 (zeroconf) into dev branch
+
+## [0.12.10] - 2026-05-16
+
+### Security
+- CVE-2026-44432 (HIGH, CVSS 7.5): urllib3 2.6.3 → 2.7.0 — decompression-bomb bypass
+- CVE-2026-44431 (HIGH, CVSS 5.3): urllib3 2.6.3 → 2.7.0 — sensitive header forwarding
+
+### Fixed
+- pytest-asyncio 0.23.8 → 1.3.0 (0.x incompatible with pytest 9.x, broke pip-audit + test suite)
+- pytest-playwright 0.4.3 → 0.7.2 (required for pytest 9.x compatibility)
+- Dockerfile: added `--timeout 120` to pip install for reliable builds on slow connections
+
+## [0.12.9] - 2026-05-11
+
+### Changed
+- Reduced YouTube searches from 4 to 2 per artist for quota efficiency
+- Quota enforcement with file locking in YouTubeQuotaTracker
+- Per-artist `last_discovery` now committed after each artist to survive interrupted runs
+
+## [0.12.8] - 2026-05-07
+
+### Security
+- CVE-2026-41066 (HIGH): lxml 4.9.3 → 6.1.0 — XXE local file read
+- CVE-2026-42561 (MEDIUM): python-multipart 0.0.26 → 0.0.27 — DoS header parsing
+- CVE-2026-28684 (MEDIUM): python-dotenv 1.0.0 → 1.2.2 — symlink arbitrary file overwrite
+
+### Fixed
+- Broken `-r requirements-prod.txt` include in `requirements-dev.txt` → `-r requirements.txt`
+- Import ordering corrected across `src/` for CI compliance
+
+## [0.12.7] - 2026-04-16
+
+### Security
+- 5 CVEs resolved (python-multipart, Pillow, pytest)
+
+### Removed
+- sphinx from production runtime (dev-only)
+
+### Changed
+- pytest-cov 4.1.0 → 7.1.0 for pytest 9.x compatibility
+
+## [0.12.6] - 2026-04-09
+
+### Security
+- CVE-2026-25645: requests 2.32.4 → 2.33.0 — predictable temporary file creation (MEDIUM)
+- CVE-2026-22815/34513-34520: aiohttp 3.13.3 → 3.13.4 — multiple DoS and injection fixes (12 CVEs total resolved)
+
+## [0.12.5] - 2026-03-19
+
+### Security
+- CVE-2026-32597: PyJWT 2.8.0 → 2.12.0 (missing `crit` header validation)
+- CVE-2026-32274: black 24.3.0 → 26.3.1 (arbitrary cache file write) — removed black from runtime requirements (dev tool only)
+
+### Fixed
+- Docker `git_branch` always unknown — version.json now read first in health endpoint
+- Docker ERROR log spam from missing git binary on every health check
+- Installation wizard credentials now applied to login (#199)
+- Thumbnail download on video completion (#200)
+
+## [0.12.4] - 2026-02-26
+
+### Security
+- CVE-2026-27205: Flask 3.1.1→3.1.3 in docker/monitor (Vary: Cookie)
+- CVE-2026-27199: werkzeug→3.1.6 (Windows device names in safe_join)
+- CVE-2026-25990: Pillow→12.1.1 (out-of-bounds write on PSD images)
+- Replaced python-jose/ecdsa (CVE-2024-23342) with PyJWT
+
+### Fixed
+- Celery connection check no longer hangs — 2s timeout + ps fallback
+- `trigger/discovery` and `trigger/downloads` no longer 500 after 19s timeout
+- Metadata enrichment endpoints no longer block the async event loop
+- Job progress bar stuck at 0% — nested progress object now parsed correctly
+- Job completion not detected — status normalized to lowercase
+- Auto-download scheduling priority was computed but then discarded; `auto_download_max_videos` raised from 10 → 50
+- Pre-v0.10.1 artists with NULL `download_enabled` excluded from download queue
+- MONITORED videos never promoted to WANTED when artist enables auto_download
+- Plain "Artist - Song" titles classified as None type, blocked by `allowed_video_types`
+- Videos no longer set to WANTED for monitor-only artists
+- `allowed_video_types` and 20+ other artist fields now save correctly
+
+### Changed
+- Migration 004: backfill NULL Scheduler V2 fields for all existing artists
+- Default: Official Music Video pre-selected for all artists
+
 ## [0.12.3] - 2026-02-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,9 +236,12 @@ curl -X POST http://localhost:5001/api/videos/123/extract-ffmpeg-metadata
   - ✅ Numerous live-testing bug fixes: 2FA audit logging, OAuth callback error handling, Videos-page pagination dropping active filters, webhook URL credential logging, header username display, Edit Webhook modal scroll
   - ✅ Fix (#329): closed a duplicate-concurrent-download-dispatch race — `bulk_download_wanted_videos()` (FastAPI) and `download_all_wanted_videos_internal()` (Celery) could both dispatch the same WANTED video, with the loser silently overwriting the winner's result (including a real successful download getting overwritten back to FAILED) and firing a false download-failed webhook. Fixed via a new atomic `claim_video_for_download()` helper (row-locked `UPDATE ... WHERE status='WANTED'`) plus a defensive already-DOWNLOADED guard (which had shipped as dead code due to an enum-vs-string `.value` comparison bug, caught and fixed in final review) that also suppresses the false webhook
   - See GitHub milestone "v1.0.0" for the complete issue list
-- **v0.12.19** (2026-08-13): Recently Found Videos View
-  - ✅ Feature: "Recently Found" one-click view on Videos page (#316) — shows all videos sorted by date_added desc, regardless of status, via a new button + shareable deep-link URL (`?sort_by=date_added&sort_order=desc&status=`)
-  - ✅ Re-scoped from an "upcoming release calendar" after confirming no integrated data source (IMVDb, MusicBrainz, YouTube, Spotify, Last.fm) exposes reliable future release dates
+  - Note: the "Recently Found" videos view (#316, merged 2026-08-13) rolled into this release directly — it was never tagged as its own version. Re-scoped from an "upcoming release calendar" concept after confirming no integrated data source (IMVDb, MusicBrainz, YouTube, Spotify, Last.fm) exposes reliable future release dates.
+- **v0.12.19** (2026-07-16): YouTube Max-Quality Downloads & Dead-URL Recovery
+  - Core fix contributed by **@Ktell123** in [#282](https://github.com/prefect421/mvidarr/pull/282)
+  - ✅ Fixed `enable_aggressive_anti_detection` truthy-string bug forcing AGGRESSIVE anti-detection and capping quality at ~360p
+  - ✅ Player client priority, resolution-first format sort, automatic MODERATE retry on low-res escalated downloads
+  - ✅ Dead YouTube URL recovery: searches for an official alternate upload and retries once
 - **v0.12.18** (2026-07-05): Dependency Sweep (Dependabot PRs #269-274)
   - ✅ Dependency: fastapi 0.138.1 → 0.139.0, Pillow 12.2.0 → 12.3.0, opencv-python-headless >=4.13.0.92 → >=5.0.0.93
   - ✅ Dependency: click 8.1.7 → 8.4.2, tqdm 4.66.3 → 4.68.3

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 
 5. **Access the application:**
    - Open your browser to `http://localhost:5000`
-   - Default login: `admin` / `admin` (change immediately)
+   - Default login: `admin` / `mvidarr` (change immediately)
    - Complete the first-run setup wizard
 
 **Docker Images:**

--- a/README.md
+++ b/README.md
@@ -22,171 +22,18 @@
 - **🔐 User Authentication** - Role-based access control with security features
 - **🎨 Advanced Theme System** - 7 built-in themes with export/import functionality
 
-## 🚀 **LATEST: v0.12.20 - Fix Stuck Download Queue**
+## 🚀 **LATEST: v1.0.0 - First Production-Ready Release**
 
-**Released**: July 16, 2026
+**Released**: August 17, 2026
 
-> **Note**: This is a pre-production release following SemVer 0.x conventions. The software is feature-complete but undergoing testing and validation before the official v1.0.0 production release.
+- **🔐 OAuth login** (Authentik, Google, GitHub) alongside password auth, with a signup allowlist and admin-only new-account policy
+- **🔐 Real RBAC enforcement** — role checks were previously decorative; every session was hardcoded to admin
+- **🔑 Two-Factor Authentication** (TOTP + backup codes) and a password reset flow
+- **🔔 Native Discord and Apprise notification providers**, wired to real download/artist activity
+- **🎬 "Recently Found" videos view** and live artist thumbnail sourcing (Spotify/Last.fm before Wikipedia)
+- **🎨 Login page redesign**: rotating background/logo art, real OAuth provider buttons
 
-### Fixes
-- **🐛 "Stop Download" 400 error**: the queue view is built from `Video.status == DOWNLOADING`, but `stop_download` always looked the id up as a `Download` table row — so stopping a stuck video almost always 400'd with "Download not found or already completed". Queue ids from videos are now unambiguously tagged (`video_123`) and routed to the right table.
-- **🐛 "Force Clear All" reported nothing to clear**: the endpoint only reset videos reachable through a `Download` row still in `queued`/`downloading`/`pending`. A video stuck at `DOWNLOADING` with no such row (already finished, failed, or never created) was invisible to it. It now also resets orphaned stuck videos directly.
-- **🐛 Misleading "no stuck downloads found" message**: the frontend's success message depended on a `cleared_count` field the backend never sent, so it always claimed nothing was found — even when downloads were, in fact, cleared. Backend now returns the real count.
-
-> **Upgrade Note**: No database migrations required. `docker compose pull && docker compose up -d`. If you have videos currently stuck in the queue, click **Force Clear All** once — the fix operates on live database state, so it will unstick them too.
-
-## 🎯 Previous Releases
-
-### v0.12.19 - YouTube Max-Quality Downloads & Dead-URL Recovery (July 16, 2026)
-- Core fix contributed by **@Ktell123** in [#282](https://github.com/prefect421/mvidarr/pull/282) — thank you!
-- **🐛 Anti-detection setting ignored**: `enable_aggressive_anti_detection` was read with `settings.get()`, which returns the string `'False'` — truthy in Python — forcing AGGRESSIVE anti-detection (and the Android YouTube client) on every download and capping quality at ~360p. Now uses `settings.get_bool()`.
-- **🎬 Player client priority**: prefer `web,mweb,tv` YouTube clients over android-first clients that hide adaptive HD/4K formats.
-- **📈 Format selection**: yt-dlp Node JS runtime + resolution-first format sort (`-S res,br`), improved `best` format string, and an automatic MODERATE retry when an escalated (AGGRESSIVE/STEALTH) download still lands at ≤360p.
-- **🔗 Dead YouTube URL recovery**: when a stored YouTube URL is private, unavailable, or terminated, MVidarr now searches for an official alternate upload, persists the new URL, and retries the download once.
-- **🐛 Retry file-preservation bug** (found in code review): the low-res retry logic deleted the original download's file before confirming the retry actually succeeded or was better, so a failed or worse retry could report success while pointing at a deleted file. Fixed, with 16 new unit tests covering the retry paths.
-
-### v0.12.18 - Dependency Sweep (fastapi, Pillow, opencv, click, tqdm) (July 5, 2026)
-- All clear — zero CVEs, zero Dependabot security alerts, zero code scanning alerts
-- **fastapi** 0.138.1 → 0.139.0, **Pillow** 12.2.0 → 12.3.0, **opencv-python-headless** >=4.13.0.92 → >=5.0.0.93
-- **click** 8.1.7 → 8.4.2, **tqdm** 4.66.3 → 4.68.3, **ruby/setup-ruby** 1.314.0 → 1.315.0
-
-### v0.12.17 - Security Sweep (pydantic-settings CVE + dependency updates) (June 27, 2026)
-- **🔒 GHSA-4xgf-cpjx-pc3j** (MEDIUM): pydantic-settings 2.14.1 → 2.14.2 — `NestedSecretsSettingsSource` symlink traversal
-- **fastapi** 0.136.3 → 0.138.1, **alembic** 1.18.4 → 1.18.5, **httpx** 0.25.2 → 0.28.1, **python-slugify** 8.0.1 → 8.0.4
-- **mypy** 1.7.1 → 2.1.0 (dev), **actions/cache** v5 → v6, **ruby/setup-ruby** 1.313.0 → 1.314.0
-
-### v0.12.16 - Security Sweep (python-multipart, bleach) (June 19, 2026)
-- **🔒 CVE-2026-53539** (HIGH, CVSS 7.5): python-multipart 0.0.27 → 0.0.32 — quadratic CPU DoS
-- **🔒 Dependabot #20** (MEDIUM, CVSS 6.1): bleach 6.1.0 → 6.4.0 — `formaction` URI bypass
-- **🔒 CVE-2026-53538/53537/45152** (LOW): python-multipart — parameter smuggling + buffer fixes
-- **sentry-sdk** 2.8.0 → 2.63.0, **starlette** >=1.3.1, **actions/checkout** v6 → v7
-
-### v0.12.15 - Security Sweep (aiohttp CVEs) (June 6, 2026)
-- **🔒 CVE-2026-34993**: aiohttp 3.13.4 → 3.14.0 — `CookieJar.load()` deserialization → arbitrary code execution (MEDIUM)
-- **🔒 CVE-2026-47265**: aiohttp 3.13.4 → 3.14.0 — per-request cookies leaked via cross-origin redirect (MEDIUM)
-- **bcrypt** 4.1.2 → 5.0.0, **requests** 2.33.0 → 2.34.2, **alembic** 1.13.1 → 1.18.4, **zeroconf** 0.149.7 → 0.149.16
-- GitHub Actions Node 24 CI updates
-
-### v0.12.14 - Security Sweep (PyJWT CVEs) (June 2, 2026)
-- **🔒 PYSEC-2026-179/178/177/176/175**: PyJWT 2.12.0 → 2.13.0 — HMAC confusion, JWS DoS, JWKS unauthenticated DoS, algorithm bypass, SSRF
-- 3 stale Trivy code scanning alerts for zeroconf auto-closed after fresh scan
-
-### v0.12.13 - Video Streaming Fix (June 1, 2026)
-- **Fixed video streaming 404 errors** — Two bugs in the streaming endpoint caused videos to return HTTP 404 when `local_path` in the database is stored as a relative path
-- `find_relocated_video()` incorrectly used `getattr()` returning `None`; path resolution now tries both CWD-relative and `BASE_DIR`-anchored paths
-- Both `stream` and `stream-transcode` endpoints patched
-
-### v0.12.12 - Dependabot Sweep + Python 3.14 (June 1, 2026)
-- **Python 3.12-slim → 3.14-slim** — base image upgraded; netifaces, mysqlclient, moviepy verified clean
-- aiofiles 23.2.1 → 25.1.0, starlette ≥1.2.1, python-dateutil 2.9.0.post0, werkzeug 3.1.8, PyYAML 6.0.3
-- GitHub Actions upgraded to Node.js 24: checkout@v6, login-action@v4, build-push-action@v7, github-script@v9, deploy-pages@v5
-
-### v0.12.11 - Security Sweep (June 1, 2026)
-- **🔒 CVE-2026-47180, CVE-2026-47183, CVE-2026-47184**: zeroconf 0.132.2 → 0.149.7 — LAN-local DoS/OOM via mDNS flood
-- **🔒 PYSEC-2026-161**: starlette ≥1.0.1 — Host header injection / authentication bypass
-- fastapi 0.123.0 → 0.136.3, pydantic 2.5.0 → 2.13.4, pydantic-settings 2.1.0 → 2.14.1
-- GitHub Actions: setup-python@v6, upload-artifact@v7, codecov@v6 — Node.js 24 migration
-
-### v0.12.10 - Security Sweep (May 16, 2026)
-- **🔒 CVE-2026-44432** (HIGH, CVSS 7.5): urllib3 2.6.3 → 2.7.0 — decompression-bomb bypass
-- **🔒 CVE-2026-44431** (HIGH, CVSS 5.3): urllib3 2.6.3 → 2.7.0 — sensitive header forwarding
-- pytest-asyncio 0.23.8 → 1.3.0, pytest-playwright 0.4.3 → 0.7.2 for pytest 9.x compatibility
-
-### v0.12.9 - YouTube Quota & Discovery Improvements (May 11, 2026)
-- Reduced YouTube searches from 4 to 2 per artist for better API quota efficiency
-- Quota enforcement added to YouTubeQuotaTracker with file locking to prevent overruns
-- Per-artist `last_discovery` now committed after each artist completes, surviving interrupted runs
-
-### v0.12.8 - Security Patches (3 CVEs) (May 7, 2026)
-- **🔒 CVE-2026-41066** (HIGH): lxml 4.9.3 → 6.1.0 — XXE local file read
-- **🔒 CVE-2026-42561** (MEDIUM): python-multipart 0.0.26 → 0.0.27 — DoS via oversized headers
-- **🔒 CVE-2026-28684** (MEDIUM): python-dotenv 1.0.0 → 1.2.2 — symlink arbitrary file overwrite
-- Fixed broken `-r requirements-prod.txt` include in `requirements-dev.txt`
-- Import ordering corrected across `src/` for CI compliance
-
-### v0.12.7 - Dependency Cleanup & Test Infrastructure (April 16, 2026)
-- Removed sphinx from production runtime (dev-only)
-- pytest-cov 4.1.0 → 7.1.0 for pytest 9.x compatibility
-- 5 CVEs resolved (python-multipart, Pillow, pytest)
-
-### v0.12.6 - Security Dependency Updates (April 9, 2026)
-- CVE-2026-25645: requests 2.32.4 → 2.33.0 — predictable temporary file creation (MEDIUM)
-- CVE-2026-22815/34513-34520: aiohttp 3.13.3 → 3.13.4 — multiple DoS and injection fixes
-- 12 CVEs total resolved
-
-
-### v0.12.5 - Security & Bug Fixes (March 19, 2026)
-- CVE-2026-32597: PyJWT 2.8.0 → 2.12.0 (missing `crit` header validation)
-- CVE-2026-32274: black 24.3.0 → 26.3.1 (arbitrary cache file write)
-- Fixed Docker `git not found` error spam on health checks
-- Fixed installation wizard credentials being overridden by defaults (#199)
-- Fixed thumbnail download on video completion (#200)
-
-### v0.12.4 - Scheduler & Auto-Download Fixes (February 26, 2026)
-- Auto-download scheduling priority fix, auto_download_max_videos raised from 10 to 50
-- Multiple security CVEs patched (Flask, werkzeug, Pillow, PyJWT)
-- Fixed allowed_video_types and 20+ artist settings not saving correctly
-
-### v0.12.3 - Playlist Sync & Logging (February 16, 2026)
-- VEVO/Official channel name cleanup during playlist sync
-- Celery worker logging fix, authentication added to 36 API endpoints
-
-### v0.12.2 - Authentication & Stability (February 14, 2026)
-- **🔐 API Security**: Added authentication to 36 unprotected API endpoints across 6 files
-- **🔐 Global 401 Interceptor**: Unauthenticated users redirected to login instead of seeing error counts
-- **🎬 Discovery Fix**: Videos no longer set to WANTED when artist `auto_download` is disabled
-- **🗑️ Artist Deletion**: Fixed 500 error from orphaned playlist/download foreign key references
-- **📺 Playlist Auto-Sync**: YouTube monitored playlists now auto-sync every 6 hours via Celery scheduled task
-- **🧹 Cleanup**: Removed obsolete po-token-provider process causing FATAL crashes on startup
-
-### v0.12.1 - Security Hardening Stabilization (February 12, 2026)
-- **🛡️ WAF Fixes**: Resolved false positives blocking URLs, cookies, and Range headers
-- **📺 Video Streaming**: Range header no longer blocked by security middleware
-- **🔐 Auth Bridge**: Fixed Flask-to-FastAPI session bridge for consistent authentication
-- **📺 Playlist Sync**: Fixed not detecting new videos in YouTube playlists
-- **⚡ Rate Limiting**: Set to 300/min with static files exempt
-- **🔧 CI/CD**: 28 files reformatted with black 24.3.0
-
-### v0.12.0 - Security Hardening Sprint (February 11, 2026)
-- **🔐 Auth Consolidation**: Unified SimpleAuth + SessionStore authentication system
-- **🚫 Backdoors Removed**: Eliminated `/test-login` and credential reset endpoints
-- **🔒 Bcrypt Passwords**: Upgraded from SHA-256 to bcrypt with lazy migration on login
-- **🛡️ SSRF Protection**: Safe tar extraction, upload sanitization, restricted proxy hosts
-- **🔑 Redis Auth**: Redis authentication enabled, secure cookies enforced
-- **🐛 49 Vulnerabilities Fixed**: 8 critical, 12 high, 16 medium, 13 low
-
-### v0.11.9 - Security Updates & Video Quality (February 5, 2026)
-- 11 CVEs fixed via dependency updates
-- Video downloads now respect user quality settings (was defaulting to 360p)
-- YouTube discovery API key caching bug fixed
-
-### v0.11.8 - Thumbnail System Overhaul (February 4, 2026)
-- Complete fix of artist thumbnail system (0% → 87% bulk scan success)
-- Manual thumbnail setting fixed, Google Images priority, Wikimedia compatibility
-- Redis configuration environment variables (REDIS_HOST, REDIS_PORT)
-
-### v0.11.7 - Video Filtering, Extended Discovery & Blacklist Fix (February 2, 2026)
-- Per-artist video type filtering for autodownload (Issue #191)
-- Extended YouTube discovery (live performances, concerts, acoustic versions)
-- Increased max_videos_per_discovery from 5 to 50
-- Fixed blacklist not saving info (Issue #190)
-
-### v0.11.6 - Blacklist POST Hotfix (January 2, 2026)
-- Fixed non-existent fields from blacklist POST endpoint
-- Blacklist API/model mismatch fixes
-- Pagination fixes
-
-### v0.11.0 - Scheduler V2 Release
-- Database-driven scheduling with web UI management
-- Code cleanup & optimization (71.4% size reduction)
-- Security hardening (30 issues fixed)
-- Docker architecture simplification (3-container deployment)
-
-### v0.9.8 - Subtitle System & User Testing Fixes
-- Complete subtitle implementation (WebVTT, SRT, ASS, SSA, SUB)
-- Smart YouTube language resolution
-- User testing fixes (8/8 critical issues resolved)
-- 100% Flask to FastAPI migration complete
+📜 **[View the full changelog](CHANGELOG.md)** for v1.0.0's complete notes and every earlier release.
 
 ## 🚀 Quick Start
 
@@ -233,7 +80,7 @@
 
 **Docker Images:**
 - **Latest:** `ghcr.io/prefect421/mvidarr:latest`
-- **Specific version:** `ghcr.io/prefect421/mvidarr:v0.12.20`
+- **Specific version:** `ghcr.io/prefect421/mvidarr:v1.0.0`
 
 **What's Running:**
 - All background jobs (Celery) run automatically inside the main container
@@ -374,7 +221,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **yt-dlp** - Video download and processing
 - **IMVDb** - Music video metadata database
 - **YouTube API** - Video discovery and streaming
-- **Flask** - Web framework
+- **FastAPI** - Web framework
 - **MariaDB** - Database engine
 
 ## 📞 Support
@@ -385,4 +232,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**MVidarr v0.12.20** - Built with ❤️ for music video enthusiasts
+**MVidarr v1.0.0** - Built with ❤️ for music video enthusiasts

--- a/docs/_tabs/installation.md
+++ b/docs/_tabs/installation.md
@@ -69,7 +69,7 @@ docker-compose up -d
 
 **5. Access the application:**
 - Open your browser to `http://localhost:5000`
-- Default login: `admin` / `admin` (⚠️ **Change immediately**)
+- Default login: `admin` / `mvidarr` (⚠️ **Change immediately**)
 - Complete the first-run setup wizard
 
 ### Production Docker Image
@@ -233,7 +233,7 @@ celery -A src.celery_app beat --loglevel=info
 
 **8. Access the application:**
 - Open your browser to `http://localhost:5000`
-- Default login: `admin` / `admin`
+- Default login: `admin` / `mvidarr`
 
 ### Production Service (systemd)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ docker pull ghcr.io/prefect421/mvidarr:latest
 
 **Access the application:**
 - Open your browser to `http://localhost:5000`
-- Default login: `admin` / `admin` (change immediately)
+- Default login: `admin` / `mvidarr` (change immediately)
 - Complete the first-run setup wizard
 
 ## 🏗️ Architecture

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ docker-compose up -d
 
 **5. Access the application:**
 - Open your browser to `http://localhost:5000`
-- Default login: `admin` / `admin` (⚠️ **Change immediately**)
+- Default login: `admin` / `mvidarr` (⚠️ **Change immediately**)
 - Complete the first-run setup wizard
 
 ### Production Docker Image
@@ -317,7 +317,7 @@ celery -A src.celery_app beat --loglevel=info
 
 **8. Access the application:**
 - Open your browser to `http://localhost:5000`
-- Default login: `admin` / `admin`
+- Default login: `admin` / `mvidarr`
 
 ### Production Service (systemd)
 

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -48,7 +48,10 @@ async function apiRequest(url, options = {}) {
         const data = await response.json();
         
         if (!response.ok) {
-            throw new Error(data.error || `HTTP error! status: ${response.status}`);
+            // FastAPI's HTTPException returns {"detail": "..."}; some
+            // legacy endpoints return {"error": "..."} instead. Check
+            // both before falling back to the generic status message.
+            throw new Error(data.detail || data.error || `HTTP error! status: ${response.status}`);
         }
         
         return data;
@@ -723,8 +726,8 @@ async function updateCredentials() {
         return;
     }
     
-    if (password.length < 6) {
-        showError('Password must be at least 6 characters long');
+    if (password.length < 8) {
+        showError('Password must be at least 8 characters long');
         return;
     }
     

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1437,6 +1437,55 @@
     <div class="app-layout">
         <main class="main-content" id="mainContent" role="main" aria-label="Main content">
             <a href="#mainContent" class="skip-link">Skip to main content</a>
+            {% if is_authenticated and default_password_active %}
+            <div class="default-password-warning" id="defaultPasswordWarning" role="alert">
+                <iconify-icon icon="tabler:alert-triangle"></iconify-icon>
+                <span>You're still using the default login password. <a href="/settings#userCredentialsSection">Change it now</a>.</span>
+                <button type="button" class="default-password-warning-dismiss" onclick="dismissDefaultPasswordWarning()" aria-label="Dismiss">✕</button>
+            </div>
+            <style>
+                .default-password-warning {
+                    display: flex;
+                    align-items: center;
+                    gap: 0.6rem;
+                    background: #f59e0b;
+                    color: #1a1a1a;
+                    padding: 0.75rem 1rem;
+                    margin-bottom: 1rem;
+                    border-radius: 6px;
+                    font-size: 0.95rem;
+                }
+                .default-password-warning a {
+                    color: #1a1a1a;
+                    font-weight: 600;
+                    text-decoration: underline;
+                }
+                .default-password-warning-dismiss {
+                    margin-left: auto;
+                    background: none;
+                    border: none;
+                    cursor: pointer;
+                    color: #1a1a1a;
+                    font-size: 1rem;
+                    line-height: 1;
+                }
+            </style>
+            <script>
+                (function() {
+                    try {
+                        if (sessionStorage.getItem('defaultPasswordWarningDismissed') === '1') {
+                            document.getElementById('defaultPasswordWarning').style.display = 'none';
+                        }
+                    } catch (e) { /* sessionStorage unavailable; leave the warning visible */ }
+                })();
+                function dismissDefaultPasswordWarning() {
+                    document.getElementById('defaultPasswordWarning').style.display = 'none';
+                    try {
+                        sessionStorage.setItem('defaultPasswordWarningDismissed', '1');
+                    } catch (e) { /* best-effort only */ }
+                }
+            </script>
+            {% endif %}
             {% block content %}{% endblock %}
         </main>
     </div>

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -292,14 +292,14 @@ input:checked + .slider:before {
             </div>
             <div class="form-group">
                 <label for="auth_password">Password:</label>
-                <input type="password" id="auth_password" name="auth_password" placeholder="Enter new password" minlength="6">
+                <input type="password" id="auth_password" name="auth_password" placeholder="Enter new password" minlength="8">
                 <div class="form-help">
-                    <small>Password must be at least 6 characters long</small>
+                    <small>Password must be at least 8 characters long</small>
                 </div>
             </div>
             <div class="form-group">
                 <label for="auth_password_confirm">Confirm Password:</label>
-                <input type="password" id="auth_password_confirm" name="auth_password_confirm" placeholder="Confirm new password" minlength="6">
+                <input type="password" id="auth_password_confirm" name="auth_password_confirm" placeholder="Confirm new password" minlength="8">
                 <div class="form-help">
                     <small>Re-enter the password to confirm</small>
                 </div>

--- a/src/api/fastapi/template_system.py
+++ b/src/api/fastapi/template_system.py
@@ -313,7 +313,21 @@ class AsyncTemplateSystem:
             "user_role": None,
             "session": {},
             "auth_enabled": True,  # Default to enabled
+            "default_password_active": False,
         }
+
+        try:
+            # Warn a logged-in admin who never changed the bootstrap
+            # credential. Cheap (one settings read + bcrypt compare) so
+            # it's fine to compute unconditionally; visibility itself is
+            # gated on is_authenticated in the template.
+            from src.services.simple_auth_service import SimpleAuthService
+
+            auth_context["default_password_active"] = (
+                SimpleAuthService.is_default_password()
+            )
+        except Exception as e:
+            logger.warning(f"Default password check error: {e}")
 
         try:
             # Check if authentication middleware is enabled

--- a/src/services/simple_auth_service.py
+++ b/src/services/simple_auth_service.py
@@ -150,8 +150,12 @@ class SimpleAuthService:
         return username, has_credentials
 
     @staticmethod
-    def _is_default_password() -> bool:
-        """Check if current password is still the default 'mvidarr'."""
+    def is_default_password() -> bool:
+        """Check if current password is still the default 'mvidarr'.
+
+        Used to warn a logged-in admin that they never changed the
+        bootstrap credential (see frontend base template).
+        """
         try:
             stored_password_hash = SettingsService.get("simple_auth_password")
             if not stored_password_hash:

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -94,8 +94,8 @@ class UserService:
     def change_password(self, user_id: int, new_password: str) -> bool:
         """Change user password"""
         try:
-            if len(new_password) < 6:
-                raise ValueError("Password must be at least 6 characters long")
+            if len(new_password) < 8:
+                raise ValueError("Password must be at least 8 characters long")
 
             password_hash = self.hash_password(new_password)
 

--- a/tests/unit/test_credentials_endpoint.py
+++ b/tests/unit/test_credentials_endpoint.py
@@ -71,3 +71,46 @@ class TestUpdateCredentialsRoleGating:
             "/api/auth/credentials", json={"username": "", "password": ""}
         )
         assert response.status_code in (400, 422)
+
+
+class TestPasswordLengthMismatchBetweenFrontendAndBackend:
+    """Regression for a real bug reported in dev testing: the frontend's
+    updateCredentials() accepted any password >= 6 characters, but
+    SimpleAuthService.set_credentials() (the actual backend enforcement)
+    requires >= 8. A 6-7 char password -- including "mvidarr", the
+    bootstrap default -- passed client-side validation and reached this
+    route, only to be rejected here with a 400 whose real message
+    ("Password must be at least 8 characters long") main.js's apiRequest()
+    then discarded in favor of a generic "HTTP error! status: 400"
+    (apiRequest checked data.error; FastAPI's HTTPException returns
+    data.detail). Both the frontend length check and the error-message
+    extraction were fixed in frontend/static/main.js; this test exercises
+    the backend half of the contract those fixes now actually match,
+    using the real (unmocked) set_credentials -- the 7-char password is
+    rejected before any DB access happens.
+    """
+
+    def test_seven_char_password_is_rejected_with_the_real_length_message(self):
+        client = _make_client({"role": "ADMIN", "user_id": 1})
+        response = client.post(
+            "/api/auth/credentials",
+            json={"username": "admin", "password": "mvidarr"},
+        )
+        assert response.status_code == 400
+        assert "8 characters" in response.json()["detail"]
+
+    def test_eight_char_password_reaches_set_credentials_unmodified(self):
+        # The route itself does no length check of its own -- that lives
+        # entirely in set_credentials. Confirms the route doesn't add a
+        # second, possibly-different length gate in front of it.
+        client = _make_client({"role": "ADMIN", "user_id": 1})
+        with patch(
+            "src.services.simple_auth_service.SimpleAuthService.set_credentials",
+            return_value=(True, "Credentials updated"),
+        ) as mock_set:
+            response = client.post(
+                "/api/auth/credentials",
+                json={"username": "admin", "password": "8charpw!"},
+            )
+        assert response.status_code == 200
+        mock_set.assert_called_once_with("admin", "8charpw!")

--- a/tests/unit/test_default_password_warning_context.py
+++ b/tests/unit/test_default_password_warning_context.py
@@ -1,0 +1,62 @@
+"""Tests wiring SimpleAuthService.is_default_password() into the template
+context AsyncTemplateSystem._get_auth_context builds for every page render
+-- this is what drives the default-password warning banner in base.html.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from starlette.requests import Request
+
+from src.api.fastapi.template_system import AsyncTemplateSystem
+
+IS_DEFAULT_PASSWORD = (
+    "src.services.simple_auth_service.SimpleAuthService.is_default_password"
+)
+
+
+def _make_request(path="/"):
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [(b"host", b"localhost")],
+        "query_string": b"",
+        "server": ("localhost", 5000),
+        "client": ("127.0.0.1", 12345),
+        "scheme": "http",
+        "app": None,
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def template_system():
+    return AsyncTemplateSystem()
+
+
+class TestDefaultPasswordActiveInAuthContext:
+    @pytest.mark.asyncio
+    async def test_flag_is_true_when_default_password_still_set(self, template_system):
+        request = _make_request()
+        with patch(IS_DEFAULT_PASSWORD, return_value=True):
+            context = await template_system._get_auth_context(request)
+        assert context["default_password_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_flag_is_false_once_password_changed(self, template_system):
+        request = _make_request()
+        with patch(IS_DEFAULT_PASSWORD, return_value=False):
+            context = await template_system._get_auth_context(request)
+        assert context["default_password_active"] is False
+
+    @pytest.mark.asyncio
+    async def test_lookup_error_does_not_break_page_rendering(self, template_system):
+        # _get_auth_context must never raise -- every authenticated page
+        # renders through this method. A broken settings lookup should
+        # degrade to "no warning shown", not a 500 on every page.
+        request = _make_request()
+        with patch(IS_DEFAULT_PASSWORD, side_effect=RuntimeError("db down")):
+            context = await template_system._get_auth_context(request)
+        assert context["default_password_active"] is False
+        assert "current_user" in context

--- a/tests/unit/test_simple_auth_is_default_password.py
+++ b/tests/unit/test_simple_auth_is_default_password.py
@@ -1,0 +1,52 @@
+"""Tests for SimpleAuthService.is_default_password() -- promoted from a
+dead private helper (_is_default_password, never called anywhere) to a
+public check wired into the dashboard's default-password warning banner.
+"""
+
+import hashlib
+from unittest.mock import patch
+
+import bcrypt
+
+from src.services.settings_service import SettingsService
+from src.services.simple_auth_service import SimpleAuthService
+
+
+class TestIsDefaultPasswordBcrypt:
+    def test_default_bcrypt_password_is_detected(self):
+        stored_hash = bcrypt.hashpw(b"mvidarr", bcrypt.gensalt()).decode()
+        with patch.object(SettingsService, "get", return_value=stored_hash):
+            assert SimpleAuthService.is_default_password() is True
+
+    def test_changed_bcrypt_password_is_not_flagged(self):
+        stored_hash = bcrypt.hashpw(b"a-real-password", bcrypt.gensalt()).decode()
+        with patch.object(SettingsService, "get", return_value=stored_hash):
+            assert SimpleAuthService.is_default_password() is False
+
+
+class TestIsDefaultPasswordSha256Legacy:
+    def test_default_sha256_password_is_detected(self):
+        stored_hash = hashlib.sha256(b"mvidarr").hexdigest()
+        with patch.object(SettingsService, "get", return_value=stored_hash):
+            assert SimpleAuthService.is_default_password() is True
+
+    def test_changed_sha256_password_is_not_flagged(self):
+        stored_hash = hashlib.sha256(b"a-real-password").hexdigest()
+        with patch.object(SettingsService, "get", return_value=stored_hash):
+            assert SimpleAuthService.is_default_password() is False
+
+
+class TestIsDefaultPasswordFailSafe:
+    def test_no_stored_credential_is_treated_as_default(self):
+        # Fresh install, credentials not yet initialized -- treat as
+        # default rather than silently assuming it's safe.
+        with patch.object(SettingsService, "get", return_value=None):
+            assert SimpleAuthService.is_default_password() is True
+
+    def test_lookup_error_fails_safe_to_default(self):
+        with patch.object(SettingsService, "get", side_effect=RuntimeError("db down")):
+            assert SimpleAuthService.is_default_password() is True
+
+    def test_unrecognized_hash_format_fails_safe_to_default(self):
+        with patch.object(SettingsService, "get", return_value="not-a-real-hash"):
+            assert SimpleAuthService.is_default_password() is True

--- a/tests/unit/test_update_credentials_password_length.py
+++ b/tests/unit/test_update_credentials_password_length.py
@@ -1,0 +1,44 @@
+"""Static-content regression test for the frontend/backend password-length
+mismatch reported in dev testing: updateCredentials() in main.js accepted
+any password >= 6 characters and forwarded it to POST /api/auth/credentials,
+but SimpleAuthService.set_credentials() (see test_credentials_endpoint.py)
+requires >= 8 -- a 6-7 char password, including "mvidarr" (the bootstrap
+default), passed the frontend check only to be rejected by the backend
+with a message the frontend's apiRequest() then discarded (it read
+data.error; FastAPI's HTTPException returns data.detail), surfacing as a
+bare "HTTP error! status: 400".
+
+Matches the static-content-assertion approach already established this
+session for template/script changes (e.g. test_login_page_redesign_ui.py):
+reads the raw source, no browser/render step.
+"""
+
+from pathlib import Path
+
+STATIC_DIR = Path(__file__).resolve().parents[2] / "frontend" / "static"
+
+
+class TestUpdateCredentialsLengthMatchesBackend:
+    def setup_method(self):
+        self.js = (STATIC_DIR / "main.js").read_text()
+
+    def test_frontend_minimum_is_eight_not_six(self):
+        assert "password.length < 8" in self.js
+        assert "password.length < 6" not in self.js
+
+    def test_frontend_message_matches_the_enforced_minimum(self):
+        assert "Password must be at least 8 characters long" in self.js
+        assert "Password must be at least 6 characters long" not in self.js
+
+
+class TestApiRequestSurfacesFastApiErrorDetail:
+    def setup_method(self):
+        self.js = (STATIC_DIR / "main.js").read_text()
+
+    def test_api_request_checks_detail_before_falling_back_to_generic_message(self):
+        # FastAPI's HTTPException responses are {"detail": "..."}, not
+        # {"error": "..."} -- apiRequest must check data.detail (in
+        # addition to the legacy data.error some endpoints still use)
+        # or every FastAPI validation message gets silently replaced
+        # with "HTTP error! status: <code>".
+        assert "data.detail || data.error" in self.js

--- a/tests/unit/test_update_credentials_password_length.py
+++ b/tests/unit/test_update_credentials_password_length.py
@@ -8,6 +8,13 @@ with a message the frontend's apiRequest() then discarded (it read
 data.error; FastAPI's HTTPException returns data.detail), surfacing as a
 bare "HTTP error! status: 400".
 
+The Settings page itself (settings.html's userCredentialsSection) had its
+own separate copies of the stale 6-char rule -- a <small> hint and, worse,
+HTML minlength="6" attributes on both the password and confirm-password
+inputs, which enforce browser-native validation independently of the JS
+check above. Found by the user reading the actual rendered page after the
+main.js fix, since that fix alone didn't touch this template.
+
 Matches the static-content-assertion approach already established this
 session for template/script changes (e.g. test_login_page_redesign_ui.py):
 reads the raw source, no browser/render step.
@@ -16,6 +23,7 @@ reads the raw source, no browser/render step.
 from pathlib import Path
 
 STATIC_DIR = Path(__file__).resolve().parents[2] / "frontend" / "static"
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
 
 
 class TestUpdateCredentialsLengthMatchesBackend:
@@ -29,6 +37,24 @@ class TestUpdateCredentialsLengthMatchesBackend:
     def test_frontend_message_matches_the_enforced_minimum(self):
         assert "Password must be at least 8 characters long" in self.js
         assert "Password must be at least 6 characters long" not in self.js
+
+
+class TestSettingsPageCredentialsFormMatchesBackend:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "settings.html").read_text()
+
+    def test_password_field_hint_matches_the_enforced_minimum(self):
+        assert "Password must be at least 8 characters long" in self.html
+        assert "Password must be at least 6 characters long" not in self.html
+
+    def test_password_and_confirm_fields_use_minlength_eight(self):
+        assert 'id="auth_password" name="auth_password"' in self.html
+        assert 'id="auth_password_confirm"' in self.html
+        assert 'minlength="6"' not in self.html
+        # Both the password and its confirm field carry minlength="8" --
+        # count rather than a single substring check so a regression in
+        # either one is still caught.
+        assert self.html.count('minlength="8"') >= 2
 
 
 class TestApiRequestSurfacesFastApiErrorDetail:

--- a/tests/unit/test_user_service_change_password_length.py
+++ b/tests/unit/test_user_service_change_password_length.py
@@ -1,0 +1,40 @@
+"""Consistency fix: UserService.change_password() carried its own copy of
+the stale 6-character password minimum (found while fixing the same rule
+elsewhere -- see test_update_credentials_password_length.py and
+test_credentials_endpoint.py). This method has no callers anywhere in the
+codebase today, so the bug wasn't user-reachable, but the constant should
+still agree with SimpleAuthService.set_credentials()'s real 8-character
+minimum rather than drift further out of sync if it's ever wired up.
+"""
+
+import pytest
+
+from src.services.user_service import UserService
+
+
+@pytest.fixture
+def service():
+    # change_password's length check raises before any DB access, so a
+    # None database_manager is fine for this test.
+    return UserService(database_manager=None)
+
+
+class TestChangePasswordMinimumLength:
+    # change_password catches its own length ValueError in a blanket
+    # except Exception and returns False rather than letting it
+    # propagate -- so the boundary itself shows up as a False return,
+    # and the corrected message text (8, not 6) is only observable via
+    # the log line it emits on that path.
+
+    def test_seven_char_password_is_rejected(self, service, caplog):
+        assert service.change_password(1, "mvidarr") is False
+        assert "8 characters" in caplog.text
+
+    def test_six_char_password_is_no_longer_the_enforced_boundary(
+        self, service, caplog
+    ):
+        # Regression pin: this used to be the exact boundary that passed
+        # (and, before that, the message said 6 even for a call this
+        # short would never have reached in the first place).
+        assert service.change_password(1, "six6ch") is False
+        assert "8 characters" in caplog.text


### PR DESCRIPTION
## v1.0.0 — First Production-Ready Release

`main` has been at v0.12.24 (2026-08-09) while `dev` accumulated 200+ commits, including the
full v1.0.0 backlog. `version.json`/`CLAUDE.md` already claim v1.0.0 was "released" — this PR
is what makes that true.

### Highlights
- **RBAC actually enforced** — was previously decorative; every session was hardcoded to admin
- **OAuth login** (Authentik, Google, GitHub) with a signup allowlist and admin-only new-account policy
- **Two-Factor Authentication** (TOTP + backup codes) and a password reset flow
- **Login page redesign** — rotating background/logo art, real OAuth provider buttons
- **Native Discord and Apprise notification providers**, wired to real download/artist activity
- **#392 security sweep** — authentication added to ~150 previously-open FastAPI routes
- **"Recently Found" videos view** and live artist thumbnail sourcing (Spotify/Last.fm before Wikipedia)
- Fixed a duplicate-concurrent-download-dispatch race (#329)
- Repo hygiene: removed ~3,900 files of historical bloat (`.git-rewrite/`, `venv_temp/`, stray logs) that had been tracked since the initial commit
- Various fixes found in this session's testing: default-password warning banner, frontend/backend password-length policy mismatch (6 vs 8 chars), a `.gitignore` gap that could have let a real `.env.*` file slip into a commit, wrong `admin`/`admin` default-credential docs

See CLAUDE.md's Version History and CHANGELOG.md for the complete list.

### Validation
- `black --check src/` — clean
- `isort --profile black --check-only src/` — clean
- `pytest tests/unit` — full suite passes (verified locally in an isolated venv against this exact merge commit)
- `dev`'s tip CI (build, test 3.11/3.12, security) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
