### PR TITLE
fix(ui): make MKV transcoding notice closeable (#485)

### DIFF
--- a/frontend/templates/video_detail.html
+++ b/frontend/templates/video_detail.html
@@ -934,6 +934,14 @@ function formatPersonList(data, cssClass) {
     return people.map(person => `<span class="${cssClass}">${escapeHtml(String(person))}</span>`).join(', ');
 }
 
+// Issue #485: tracks a same-view "×" dismissal of the MKV transcoding
+// notice. renderVideoDetails() re-runs on every loadVideoDetails() refresh
+// (download start, metadata enhancement, edits, quality upgrades all call
+// it) -- without this page-scoped flag, each refresh would recompute
+// hideMkvWarning from localStorage alone and silently bring the notice
+// back, undoing a dismissal the user just made.
+let mkvNoticeTemporarilyDismissed = false;
+
 function renderVideoDetails(video) {
     // Render header
     const headerHtml = `
@@ -990,7 +998,7 @@ function renderVideoDetails(video) {
     const playerHtml = `
         <div class="video-player">
             ${video.local_path ? `
-                ${needsTranscoding && !hideMkvWarning ? `
+                ${needsTranscoding && !hideMkvWarning && !mkvNoticeTemporarilyDismissed ? `
                     <div class="video-transcoding-notice" id="mkvTranscodingNotice">
                         <button type="button" class="mkv-notice-close" onclick="dismissMkvWarning(false)" aria-label="Dismiss notice">&times;</button>
                         <p><iconify-icon icon="tabler:info-circle"></iconify-icon> MKV file detected - using real-time transcoding for browser compatibility.</p>
@@ -1237,12 +1245,16 @@ function renderVideoDetails(video) {
 }
 
 // Issue #485: dismiss the MKV transcoding notice, optionally remembering the
-// choice so it doesn't reappear on future video pages.
+// choice so it doesn't reappear on future video pages. mkvNoticeTemporarilyDismissed
+// is set regardless of `permanent` so the notice also stays hidden across any
+// same-view re-render triggered by other page actions (see the flag's
+// declaration above renderVideoDetails for why that's necessary).
 function dismissMkvWarning(permanent) {
     const notice = document.getElementById('mkvTranscodingNotice');
     if (notice) {
         notice.style.display = 'none';
     }
+    mkvNoticeTemporarilyDismissed = true;
     if (permanent) {
         try {
             localStorage.setItem('mvidarr_hide_mkv_warning', 'true');
@@ -2309,7 +2321,7 @@ video::-moz-text-track-container {
     background: #fff3cd;
     border: 1px solid #ffc107;
     color: #856404;
-    padding: 1rem 2.25rem;
+    padding: 1rem 2.25rem 1rem 1rem;
     margin-bottom: 1rem;
     border-radius: 4px;
     text-align: center;
@@ -2321,7 +2333,13 @@ video::-moz-text-track-container {
     right: 0.5rem;
     background: none;
     border: none;
-    color: #856404;
+    /* inherit, not a hardcoded hex, so this stays readable if
+       .video-transcoding-notice's color ever changes -- see the
+       sibling contrast regression test/comment on .video-transcoding-notice p
+       for why an un-inherited color on this element is exactly the class of
+       bug that bit that rule before. */
+    color: inherit;
+    opacity: 0.7;
     font-size: 1.25rem;
     line-height: 1;
     cursor: pointer;
@@ -2329,7 +2347,7 @@ video::-moz-text-track-container {
 }
 
 .mkv-notice-close:hover {
-    color: #533f03;
+    opacity: 1;
 }
 
 .mkv-notice-actions {

--- a/frontend/templates/video_detail.html
+++ b/frontend/templates/video_detail.html
@@ -979,13 +979,23 @@ function renderVideoDetails(video) {
         ? `/api/videos/${video.id}/stream-transcode`
         : `/api/videos/${video.id}/stream`;
 
+    // Issue #485: let users permanently dismiss the MKV transcoding notice
+    let hideMkvWarning = false;
+    try {
+        hideMkvWarning = localStorage.getItem('mvidarr_hide_mkv_warning') === 'true';
+    } catch (e) {
+        hideMkvWarning = false;
+    }
+
     const playerHtml = `
         <div class="video-player">
             ${video.local_path ? `
-                ${needsTranscoding ? `
-                    <div class="video-transcoding-notice">
+                ${needsTranscoding && !hideMkvWarning ? `
+                    <div class="video-transcoding-notice" id="mkvTranscodingNotice">
+                        <button type="button" class="mkv-notice-close" onclick="dismissMkvWarning(false)" aria-label="Dismiss notice">&times;</button>
                         <p><iconify-icon icon="tabler:info-circle"></iconify-icon> MKV file detected - using real-time transcoding for browser compatibility.</p>
                         <p>Video is being converted on-the-fly for optimal playback.</p>
+                        <p class="mkv-notice-actions"><a href="#" onclick="dismissMkvWarning(true); return false;">Don't show this again</a></p>
                     </div>
                 ` : ''}
                 <video id="videoElement" controls class="video-element">
@@ -1224,6 +1234,22 @@ function renderVideoDetails(video) {
         </div>
     `;
     document.getElementById('videoStats').innerHTML = statsHtml;
+}
+
+// Issue #485: dismiss the MKV transcoding notice, optionally remembering the
+// choice so it doesn't reappear on future video pages.
+function dismissMkvWarning(permanent) {
+    const notice = document.getElementById('mkvTranscodingNotice');
+    if (notice) {
+        notice.style.display = 'none';
+    }
+    if (permanent) {
+        try {
+            localStorage.setItem('mvidarr_hide_mkv_warning', 'true');
+        } catch (e) {
+            console.warn('Unable to save MKV warning preference:', e);
+        }
+    }
 }
 
 function loadRelatedVideos(artistId) {
@@ -2279,13 +2305,41 @@ video::-moz-text-track-container {
 }
 
 .video-transcoding-notice {
+    position: relative;
     background: #fff3cd;
     border: 1px solid #ffc107;
     color: #856404;
-    padding: 1rem;
+    padding: 1rem 2.25rem;
     margin-bottom: 1rem;
     border-radius: 4px;
     text-align: center;
+}
+
+.mkv-notice-close {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    color: #856404;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0.25rem;
+}
+
+.mkv-notice-close:hover {
+    color: #533f03;
+}
+
+.mkv-notice-actions {
+    font-size: 0.85rem;
+}
+
+.mkv-notice-actions a {
+    color: #533f03;
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 .video-transcoding-notice iconify-icon {

--- a/tests/unit/test_mkv_warning_dismissible.py
+++ b/tests/unit/test_mkv_warning_dismissible.py
@@ -6,6 +6,17 @@ Fix: the notice now renders a close button that hides it for the current
 view, plus a "Don't show this again" link that persists the dismissal in
 localStorage (key `mvidarr_hide_mkv_warning`) so the notice stops rendering
 on future page loads.
+
+Code review on the first version of this fix caught a real bug: the close
+button's dismissal only did `notice.style.display = 'none'` on the live DOM
+node, with nothing recorded outside it. `renderVideoDetails()` re-runs on
+every `loadVideoDetails()` refresh -- which several routine same-page
+actions trigger (starting a download, enhancing metadata, saving an edit,
+a quality upgrade) -- so the notice silently reappeared on the very next
+refresh, undoing the dismissal. The fix adds a page-scoped
+`mkvNoticeTemporarilyDismissed` flag, declared outside `renderVideoDetails`
+so it survives across repeated calls within the same page view, and set
+unconditionally in `dismissMkvWarning()` regardless of the `permanent` arg.
 """
 
 from pathlib import Path
@@ -38,6 +49,35 @@ class TestMkvWarningDismissible:
         end = self.html.index("</video>", start)
         render_block = self.html[start:end]
         assert "needsTranscoding && !hideMkvWarning" in render_block
+
+    def test_render_gate_also_checks_the_same_view_dismissal_flag(self):
+        # Regression: without this, a "x" dismissal was silently undone by
+        # any same-page action that refreshes video details (download
+        # start, metadata enhancement, edits, quality upgrades all call
+        # loadVideoDetails() -> renderVideoDetails() again).
+        start = self.html.index("const playerHtml = `")
+        end = self.html.index("</video>", start)
+        render_block = self.html[start:end]
+        assert "!mkvNoticeTemporarilyDismissed" in render_block
+
+    def test_temporary_dismissal_flag_is_scoped_outside_the_render_function(self):
+        # The flag must be declared above renderVideoDetails (module/script
+        # scope), not re-initialized inside it -- otherwise it would reset
+        # to false on every call and never actually persist across
+        # same-view re-renders.
+        declare_at = self.html.index("let mkvNoticeTemporarilyDismissed = false;")
+        render_fn_at = self.html.index("function renderVideoDetails(video) {")
+        assert declare_at < render_fn_at
+
+    def test_dismiss_handler_sets_temporary_flag_unconditionally(self):
+        # Must be set regardless of `permanent` -- a plain "x" close (not
+        # "don't show again") still needs to survive same-view re-renders.
+        start = self.html.index("function dismissMkvWarning(")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        set_flag_at = body.index("mkvNoticeTemporarilyDismissed = true;")
+        if_permanent_at = body.index("if (permanent)")
+        assert set_flag_at < if_permanent_at
 
     def test_stored_preference_is_read_defensively(self):
         # localStorage access can throw (private browsing, blocked site

--- a/tests/unit/test_mkv_warning_dismissible.py
+++ b/tests/unit/test_mkv_warning_dismissible.py
@@ -1,0 +1,49 @@
+"""Regression test for issue #485: the MKV transcoding notice on the video
+detail page had no way to dismiss it, and stayed on-screen for every video
+even after a viewer had already seen it.
+
+Fix: the notice now renders a close button that hides it for the current
+view, plus a "Don't show this again" link that persists the dismissal in
+localStorage (key `mvidarr_hide_mkv_warning`) so the notice stops rendering
+on future page loads.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "frontend" / "templates"
+
+
+class TestMkvWarningDismissible:
+    def setup_method(self):
+        self.html = (TEMPLATES_DIR / "video_detail.html").read_text()
+
+    def test_notice_has_a_close_button(self):
+        assert 'id="mkvTranscodingNotice"' in self.html
+        assert 'onclick="dismissMkvWarning(false)"' in self.html
+
+    def test_notice_has_a_dont_show_again_option(self):
+        assert 'onclick="dismissMkvWarning(true); return false;"' in self.html
+
+    def test_dismiss_handler_persists_permanent_choice_in_localstorage(self):
+        start = self.html.index("function dismissMkvWarning(")
+        end = self.html.index("\n}", start)
+        body = self.html[start:end]
+        assert "localStorage.setItem('mvidarr_hide_mkv_warning', 'true')" in body
+
+    def test_render_checks_stored_preference_before_showing_notice(self):
+        # The notice's render condition must consult the stored flag, not
+        # just `needsTranscoding` alone, or a permanent dismissal would be
+        # ignored on the next page load.
+        start = self.html.index("const playerHtml = `")
+        end = self.html.index("</video>", start)
+        render_block = self.html[start:end]
+        assert "needsTranscoding && !hideMkvWarning" in render_block
+
+    def test_stored_preference_is_read_defensively(self):
+        # localStorage access can throw (private browsing, blocked site
+        # data); the read must not be able to break page rendering.
+        start = self.html.index("hideMkvWarning = false;")
+        end = self.html.index("const playerHtml", start)
+        setup_block = self.html[start:end]
+        assert "try {" in setup_block
+        assert "localStorage.getItem('mvidarr_hide_mkv_warning')" in setup_block


### PR DESCRIPTION
## Summary
Closes #485.

The "MKV file detected" notice on the video detail page had no way to dismiss it — it took up space on every MKV video's page, every time.

- Adds a close (×) button to hide the notice for the current view
- Adds a "Don't show this again" link that persists the choice via `localStorage` (key `mvidarr_hide_mkv_warning`), so it stops rendering on future page loads
- Read/write of the preference is wrapped in try/catch so a blocked or unavailable localStorage (private browsing, strict privacy settings) can't break page rendering — the notice just falls back to always showing

## Test plan
- [x] Existing regression test `tests/unit/test_transcoding_notice_contrast.py` still passes (contrast fix untouched)
- [x] New regression test `tests/unit/test_mkv_warning_dismissible.py` covers: close button present, dismiss-permanently link present, localStorage write on permanent dismiss, render gate respects stored preference, localStorage read wrapped defensively
- [x] black/isort clean on the new test file
- Scope: only `frontend/templates/video_detail.html` has the literal "MKV file detected" banner; `videos.html`'s modal player uses a different, already-minimal note and wasn't in scope for this issue