### PR TITLE
fix: security sweep 2026-09-03 — CORS/proxy-trust hardening + MKV notice toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,22 @@ TZ=America/New_York
 # Run 'id' command to get your user/group IDs
 PUID=1000
 PGID=1000
+
+# ========================================
+# OPTIONAL: CORS / Reverse Proxy Security
+# ========================================
+# Comma-separated list of origins allowed to make cross-origin requests.
+# Defaults to localhost/127.0.0.1 on this project's known ports (5000, 5001,
+# 5050) plus https://mvidarr.prefect42.com. Override if your deployment uses
+# a different host or port.
+# Example: CORS_ALLOWED_ORIGINS=https://videos.example.com,http://192.168.1.50:5000
+CORS_ALLOWED_ORIGINS=
+
+# Comma-separated list of proxy hosts/IPs trusted to set X-Forwarded-* headers.
+# Defaults to loopback only (127.0.0.1). If MVidarr sits behind a reverse
+# proxy (nginx, Traefik, Cloudflare Tunnel, etc.), set this to the proxy's
+# IP/hostname — otherwise HTTPS detection behind the proxy will misbehave.
+# Leaving this at "*" (trust any peer) is NOT recommended: it lets a client
+# that can reach MVidarr directly spoof its IP, bypassing rate limiting and
+# forging the source IP in login/2FA audit logs.
+TRUSTED_PROXY_HOSTS=

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -416,16 +416,30 @@ logger.info(
 )
 
 # Add CORS middleware with optimized configuration
+# Allowed origins are configurable via CORS_ALLOWED_ORIGINS (comma-separated) so
+# self-hosters running on non-default hosts/ports aren't stuck behind someone
+# else's hardcoded LAN IP (see issue #488). Defaults cover this project's own
+# documented environments (dev :5000, Docker :5001, prod :5050) plus loopback
+# and the reverse-proxy origin referenced below.
+_default_cors_origins = [
+    "http://localhost:5000",
+    "http://localhost:5001",
+    "http://localhost:5050",
+    "http://127.0.0.1:5000",
+    "http://127.0.0.1:5001",
+    "http://127.0.0.1:5050",
+    "https://mvidarr.prefect42.com",
+]
+_cors_origins_env = os.environ.get("CORS_ALLOWED_ORIGINS", "").strip()
+cors_allowed_origins = (
+    [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
+    if _cors_origins_env
+    else _default_cors_origins
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://192.168.1.145:5000",
-        "http://192.168.1.145:5010",
-        "http://localhost:5000",
-        "http://localhost:5010",
-        "http://127.0.0.1:5000",
-        "http://127.0.0.1:5010",
-    ],
+    allow_origins=cors_allowed_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
@@ -435,9 +449,16 @@ app.add_middleware(
 # Add proxy headers middleware for HTTPS reverse proxy support
 # This allows FastAPI to trust X-Forwarded-* headers from reverse proxies
 # Fixes mixed content issues when accessing via HTTPS proxy (e.g., https://mvidarr.prefect42.com)
+#
+# TRUSTED_PROXY_HOSTS defaults to loopback-only (issue #488) rather than "*" —
+# trusting X-Forwarded-For/X-Forwarded-Proto from any peer lets a client that
+# can reach FastAPI directly (no reverse proxy in front) spoof its own IP,
+# bypassing the rate limiter and forging the source IP in login/2FA audit logs.
+# Deployments that sit behind a reverse proxy (e.g. https://mvidarr.prefect42.com)
+# MUST set TRUSTED_PROXY_HOSTS explicitly to the proxy's IP/hostname.
 app.add_middleware(
     ProxyHeadersMiddleware,
-    trusted_hosts=os.environ.get("TRUSTED_PROXY_HOSTS", "*").split(","),
+    trusted_hosts=os.environ.get("TRUSTED_PROXY_HOSTS", "127.0.0.1").split(","),
 )
 logger.info("✅ Proxy headers middleware enabled for reverse proxy support")
 

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -278,6 +278,18 @@ input:checked + .slider:before {
             </div>
         </div>
 
+        <div class="settings-section" id="uiPreferencesSection">
+            <h2>🖥️ UI Preferences</h2>
+            <p class="section-description">Stored in this browser only — not synced across browsers or devices.</p>
+            <div class="form-group">
+                <label>MKV Transcoding Notice:</label>
+                <button type="button" id="mkvNoticeToggleBtn" class="btn btn-secondary" onclick="toggleMkvNoticePreference()" style="display: none;">Re-enable Notice</button>
+                <div class="form-help">
+                    <small id="mkvNoticeStatusText"></small>
+                </div>
+            </div>
+        </div>
+
         <div class="settings-section" id="userCredentialsSection" style="display: none;">
             <h2>👤 User Credentials</h2>
             <div class="form-help">
@@ -2707,6 +2719,40 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+
+// Issue #487: "UI Preferences" -- lets users undo a permanent "Don't show
+// this again" dismissal of the MKV transcoding notice (issue #485) without
+// needing DevTools. The dismissal lives entirely in localStorage (per-browser,
+// not a server-side setting), so this just reads/clears that same key.
+function getMkvNoticeHidden() {
+    try {
+        return localStorage.getItem('mvidarr_hide_mkv_warning') === 'true';
+    } catch (e) {
+        return false;
+    }
+}
+
+function refreshMkvNoticeUI() {
+    const btn = document.getElementById('mkvNoticeToggleBtn');
+    const status = document.getElementById('mkvNoticeStatusText');
+    if (!btn || !status) return;
+    const hidden = getMkvNoticeHidden();
+    btn.style.display = hidden ? '' : 'none';
+    status.textContent = hidden
+        ? 'Currently hidden -- you selected "Don\'t show this again" on a video\'s MKV transcoding notice.'
+        : 'Shown by default on video pages with MKV files that need transcoding.';
+}
+
+function toggleMkvNoticePreference() {
+    try {
+        localStorage.removeItem('mvidarr_hide_mkv_warning');
+    } catch (e) {
+        // localStorage unavailable (private browsing, etc.) -- nothing to clear
+    }
+    refreshMkvNoticeUI();
+}
+
+document.addEventListener('DOMContentLoaded', refreshMkvNoticeUI);
 
 // Handle hash changes
 window.addEventListener('hashchange', initializeTab);

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 MVidarr - Music Video Management System
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "MVidarr Team"
 __description__ = (
     "Music Video Management System with Artist Tracking and Multi-Source Search"


### PR DESCRIPTION
## Summary

Fixes #488 and #487.

### #488 — CORS allowlist hardcoded to a personal IP; TRUSTED_PROXY_HOSTS defaults to trust-all
- `allow_origins` is now configurable via `CORS_ALLOWED_ORIGINS` (comma-separated env var), defaulting to this project's actual dev (:5000), Docker (:5001), and prod (:5050) ports on localhost/127.0.0.1, plus the documented reverse-proxy origin `https://mvidarr.prefect42.com`. Previously hardcoded to a stale personal LAN IP (`192.168.1.145`) that didn't match any real deployment.
- `TRUSTED_PROXY_HOSTS` now defaults to loopback-only (`127.0.0.1`) instead of `"*"` (trust any peer). Deployments behind a reverse proxy must now set it explicitly to the proxy's IP/hostname. Previously, any client that could reach FastAPI directly (no reverse proxy in front) could spoof `X-Forwarded-For` to bypass the rate limiter and forge the source IP recorded in login/2FA audit logs.
- Both documented in `.env.example`.
- ⚠️ **Deployment note:** prod is reportedly reachable via a reverse proxy at `https://mvidarr.prefect42.com`. `TRUSTED_PROXY_HOSTS` must be set to that proxy's actual IP/hostname in prod's `.env` before/at the prod rebuild, or HTTPS/X-Forwarded-* handling will regress.

### #487 — No way to re-enable the MKV transcoding notice after "Don't show this again"
- Added a **UI Preferences** section to Settings (General tab) with a button to clear the `mvidarr_hide_mkv_warning` localStorage flag, so a misclick or change of mind no longer requires DevTools.

### Also
- Version bump 1.0.1 → 1.0.2.

## Scan results (this sweep)
- Dependabot alerts: none open
- Code scanning alerts: none open
- pip-audit (requirements.txt, requirements-fastapi.txt, requirements-dev.txt): clean, before and after fixes

## Test plan
- [x] pip-audit clean on all three requirements files (pre- and post-fix)
- [x] `black --check` / `isort --profile black --check-only` clean on `src/` + `fastapi_app.py` (matched against the isort 9.0.0 CI pin, not a stale local copy — caught and fixed an initial mismatch during this PR)
- [x] Rebuilt `mvidarr-dev` Docker container (fastapi_app.py and templates aren't bind-mounted, needed a full rebuild) — health endpoint 200, CORS preflight correctly allows the new default origins, settings page serves the new UI Preferences section, clean startup/request logs
- [x] CI `CI/CD Pipeline` green on this branch (includes `pytest tests/` — local pytest couldn't run due to missing system build headers unrelated to this change; CI is the authoritative pass here)
- [x] GitHub issues #487 and #488 will be closed after this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)